### PR TITLE
Exclude current user's items in search load function

### DIFF
--- a/src/routes/search/+page.server.ts
+++ b/src/routes/search/+page.server.ts
@@ -4,6 +4,7 @@ import { PB_URL } from '../../hooks.server';
 export async function load ({ locals }) {
 
     const items = await locals.pb.collection('items').getFullList({
+        filter: `field != "${locals.user.id}"`, // do not load items of the current user
         expand: 'field'
     });
 

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -41,11 +41,6 @@
 			);
 		}
 
-		// Filter out own items
-		if (data.userId) {
-			filteredResults = filteredResults.filter((item) => item.expand.field.id !== data.userId);
-		}
-
 		return filteredResults;
 	});
 </script>


### PR DESCRIPTION
Excluding the items directly from the DB request is (1) more performant (I think) and (2) automatically prevents the filter function from including current user's items in building its categories.