### PR TITLE
Add client-side image compression to fix upload error

### DIFF
--- a/src/routes/user/items/ItemModal.svelte
+++ b/src/routes/user/items/ItemModal.svelte
@@ -56,6 +56,50 @@
 		}
 	}
 
+	async function compressImage(file: File): Promise<Blob> {
+		const MAX_DIMENSION = 1920;
+		const QUALITY = 0.8;
+
+		return new Promise((resolve, reject) => {
+			const img = new Image();
+			const url = URL.createObjectURL(file);
+
+			img.onload = () => {
+				URL.revokeObjectURL(url);
+				let w = img.naturalWidth;
+				let h = img.naturalHeight;
+
+				if (w > MAX_DIMENSION || h > MAX_DIMENSION) {
+					if (w >= h) {
+						h = Math.round((h / w) * MAX_DIMENSION);
+						w = MAX_DIMENSION;
+					} else {
+						w = Math.round((w / h) * MAX_DIMENSION);
+						h = MAX_DIMENSION;
+					}
+				}
+
+				const canvas = document.createElement('canvas');
+				canvas.width = w;
+				canvas.height = h;
+				canvas.getContext('2d')!.drawImage(img, 0, 0, w, h);
+
+				canvas.toBlob(
+					(blob) => (blob ? resolve(blob) : reject(new Error('Compression failed'))),
+					'image/jpeg',
+					QUALITY
+				);
+			};
+
+			img.onerror = () => {
+				URL.revokeObjectURL(url);
+				reject(new Error('Failed to load image'));
+			};
+
+			img.src = url;
+		});
+	}
+
 	$effect(() => {
 		if (isVisible) {
 			if (!previewUrl && !imgUrl) {
@@ -91,7 +135,12 @@
 		action="?/{type === 'edit' ? 'update' : 'create'}"
 		method="POST"
 		enctype="multipart/form-data"
-		use:enhance={() => {
+		use:enhance={async ({ formData }) => {
+			const file = formData.get('itemImage');
+			if (file instanceof File && file.size > 0 && file.type !== 'image/svg+xml') {
+				const compressed = await compressImage(file);
+				formData.set('itemImage', compressed, file.name);
+			}
 			return async ({ result, update }) => {
 				if (result.type === 'success') {
 					isVisible = false;


### PR DESCRIPTION
Implement client-side image compression to resolve issues with image uploads, ensuring that images are resized and compressed before being sent to the server.