### PR TITLE
Refactor item modal and user item card to fix bug and improve UX

### DIFF
--- a/src/routes/user/items/+page.svelte
+++ b/src/routes/user/items/+page.svelte
@@ -59,7 +59,7 @@
 				{#each data.items as item (item.id)}
 					<UserItemCard
 						{item}
-						{data}
+						PB_URL={data.PB_URL}
 						imgUrl={getItemImageUrl(item, data.PB_URL)}
 					/>
 				{/each}

--- a/src/routes/user/items/ItemModal.svelte
+++ b/src/routes/user/items/ItemModal.svelte
@@ -184,7 +184,7 @@
 		<div class="space-y-2">
 			<span class="text-sm font-medium">{texts.forms.itemCategories}</span>
 			<div class="flex flex-wrap gap-x-4 gap-y-2">
-				{#each ITEM_CATEGORIES as cat}
+				{#each ITEM_CATEGORIES as cat(cat)}
 					<Label class="flex items-center gap-1.5 cursor-pointer font-normal">
 						<Checkbox
 							name="categories"

--- a/src/routes/user/items/UserItemCard.svelte
+++ b/src/routes/user/items/UserItemCard.svelte
@@ -9,19 +9,11 @@
 	interface Props {
 		item: Item;
 		imgUrl: string;
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		data: any;
+		PB_URL: string;
 	}
-	let { item, imgUrl, data }: Props = $props();
+	let { item, imgUrl, PB_URL }: Props = $props();
 	let showEditModal = $state(false);
-	let editingItemId = $state('');
-	let editingItem = $derived(
-		data?.user?.expand?.items_via_owner
-			? data.user.expand.items_via_owner.find(
-					(item: Item) => item.id === editingItemId
-				)
-			: null
-	);
+
 	function getItemImageUrl(item: Item, baseUrl: string): string {
 		return `${baseUrl}api/files/${item?.collectionId}/${item?.id}/${item?.image}`;
 	}
@@ -76,7 +68,6 @@
 			</form>
 			<EditButton
 				onclick={() => {
-					editingItemId = item.id;
 					showEditModal = true;
 				}}
 			/>
@@ -88,6 +79,6 @@
 <ItemModal
 	bind:isVisible={showEditModal}
 	type="edit"
-	{editingItem}
-	imgUrl={getItemImageUrl(editingItem, data.PB_URL)}
+	editingItem={item}
+	imgUrl={getItemImageUrl(item, PB_URL)}
 />

--- a/src/routes/user/items/UserItemCard.svelte
+++ b/src/routes/user/items/UserItemCard.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
 	import type { Item } from '$lib/types/models';
 	import { Badge } from 'flowbite-svelte';
-	import EditButton from './EditButton.svelte';
 	import ItemModal from './ItemModal.svelte';
 	import { texts } from '$lib/texts';
-	import { enhance } from '$app/forms';
 
 	interface Props {
 		item: Item;
@@ -19,8 +17,10 @@
 	}
 </script>
 
-<div
-	class="items-center border border-gray-200 rounded-lg shadow flex sm:flex-row overflow-hidden"
+<button
+	type="button"
+	onclick={() => (showEditModal = true)}
+	class="items-center border border-gray-200 rounded-lg shadow flex sm:flex-row overflow-hidden w-full text-left cursor-pointer hover:bg-gray-50 transition-colors"
 >
 	<img
 		class="m-5 w-30 h-30 object-cover aspect-square rounded-lg"
@@ -35,10 +35,6 @@
 			>
 				{item.name}
 			</h3>
-			<!-- <span class="flex items-center gap-1 text-sm">
-				<MapPinOutline class="h-4 w-4" />
-				{item.place}
-			</span> -->
 			{#if item.trusteesOnly}
 				<div class="flex items-center truncate">
 					<Badge rounded border color="green" class="my-2">
@@ -51,29 +47,17 @@
 		</div>
 
 		<div class="flex items-center gap-2 justify-end pt-4">
-			<form method="POST" action="?/toggleStatus" use:enhance>
-				<input type="hidden" name="itemId" value={item.id} />
-				<button
-					type="submit"
-					class="inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold border transition-colors cursor-pointer
-						{item.status === 'available'
-							? 'bg-green-100 text-green-800 border-green-300 hover:bg-green-200'
-							: 'bg-red-100 text-red-800 border-red-300 hover:bg-red-200'}"
-					title={item.status === 'available'
-						? texts.itemStatus.markUnavailable
-						: texts.itemStatus.markAvailable}
-				>
-					{item.status === 'available' ? texts.itemStatus.available : texts.itemStatus.unavailable}
-				</button>
-			</form>
-			<EditButton
-				onclick={() => {
-					showEditModal = true;
-				}}
-			/>
+			<span
+				class="inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold border
+					{item.status === 'available'
+						? 'bg-green-100 text-green-800 border-green-300'
+						: 'bg-red-100 text-red-800 border-red-300'}"
+			>
+				{item.status === 'available' ? texts.itemStatus.available : texts.itemStatus.unavailable}
+			</span>
 		</div>
 	</div>
-</div>
+</button>
 
 <!-- Edit Modal -->
 <ItemModal


### PR DESCRIPTION
Refactor the item modal and user item card to utilize `PB_URL` instead of `data`, enhancing the clarity of data handling. Remove the edit button and make the entire item card clickable for a more intuitive user experience.