### PR TITLE
Add diagnostics API and improve travel time fetch error handling

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -17,6 +17,7 @@ const unprotectedPrefix = [
 	'/invite',
 	'/sitemap.xml',
 	'/api/redirect',
+	'/api/diagnostics',
 ];
 
 export const authentication: Handle = async ({ event, resolve }) => {

--- a/src/lib/server/travelTimes.ts
+++ b/src/lib/server/travelTimes.ts
@@ -9,6 +9,10 @@ const ORS_PROFILE: Record<TransportMode, string> = {
 	car: 'driving-car',
 };
 
+const ORS_TIMEOUT_MS = 8_000;
+// Log a warning when ORS takes longer than this — indicates degraded performance before a full timeout
+const ORS_SLOW_THRESHOLD_MS = 5_000;
+
 function isNullIsland(geo: { lon: number; lat: number } | undefined | null) {
 	return !geo || (geo.lon === 0 && geo.lat === 0);
 }
@@ -27,9 +31,6 @@ export function extractOwnerLocations(items: Item[]): OwnerLocation[] {
 	return Array.from(seen.values());
 }
 
-const ORS_TIMEOUT_MS = 8_000;
-const ORS_SLOW_MS = 5_000;
-
 /** Calls the ORS matrix API and returns raw travel durations in seconds, one per owner.
  * We have 500 requests per day on our free plan, use them wisely!
 */
@@ -43,7 +44,7 @@ async function fetchDurationsFromOrs(
 		...owners.map((o) => [o.lon, o.lat]),
 	];
 
-	const t0 = Date.now();
+	const requestStart = Date.now();
 	let response: Response;
 	try {
 		response = await fetch(
@@ -65,27 +66,38 @@ async function fetchDurationsFromOrs(
 			}
 		);
 	} catch (err) {
+		// Covers both network failures and AbortSignal timeout (TimeoutError)
 		console.error('[TRAVEL_DIAG]', JSON.stringify({
-			event: 'ors_error', transport_mode: transportMode, owner_count: owners.length,
-			duration_ms: Date.now() - t0, error: err instanceof Error ? err.message : String(err)
+			event: 'ors_error',
+			transport_mode: transportMode,
+			owner_count: owners.length,
+			duration_ms: Date.now() - requestStart,
+			error: err instanceof Error ? err.message : String(err),
 		}));
 		return [];
 	}
 
-	const duration_ms = Date.now() - t0;
+	const durationMs = Date.now() - requestStart;
 
 	if (!response.ok) {
-		const body = await response.text().catch(() => '');
+		const responseBody = await response.text().catch(() => '');
 		console.error('[TRAVEL_DIAG]', JSON.stringify({
-			event: 'ors_error', transport_mode: transportMode, owner_count: owners.length,
-			duration_ms, status: response.status, body: body.slice(0, 200)
+			event: 'ors_error',
+			transport_mode: transportMode,
+			owner_count: owners.length,
+			duration_ms: durationMs,
+			status: response.status,
+			body: responseBody.slice(0, 200),
 		}));
 		return [];
 	}
 
-	if (duration_ms > ORS_SLOW_MS) {
+	if (durationMs > ORS_SLOW_THRESHOLD_MS) {
 		console.warn('[TRAVEL_DIAG]', JSON.stringify({
-			event: 'ors_slow', transport_mode: transportMode, owner_count: owners.length, duration_ms
+			event: 'ors_slow',
+			transport_mode: transportMode,
+			owner_count: owners.length,
+			duration_ms: durationMs,
 		}));
 	}
 

--- a/src/lib/server/travelTimes.ts
+++ b/src/lib/server/travelTimes.ts
@@ -27,7 +27,10 @@ export function extractOwnerLocations(items: Item[]): OwnerLocation[] {
 	return Array.from(seen.values());
 }
 
-/** Calls the ORS matrix API and returns raw travel durations in seconds, one per owner. 
+const ORS_TIMEOUT_MS = 8_000;
+const ORS_SLOW_MS = 5_000;
+
+/** Calls the ORS matrix API and returns raw travel durations in seconds, one per owner.
  * We have 500 requests per day on our free plan, use them wisely!
 */
 async function fetchDurationsFromOrs(
@@ -40,27 +43,50 @@ async function fetchDurationsFromOrs(
 		...owners.map((o) => [o.lon, o.lat]),
 	];
 
-	const response = await fetch(
-		`https://api.openrouteservice.org/v2/matrix/${ORS_PROFILE[transportMode]}`,
-		{
-			method: 'POST',
-			headers: {
-				Accept: 'application/json',
-				Authorization: ORS_API_KEY ?? '',
-				'Content-Type': 'application/json',
-			},
-			body: JSON.stringify({
-				locations,
-				sources: [0],
-				destinations: owners.map((_, i) => i + 1),
-				metrics: ['duration'],
-			}),
-		}
-	);
+	const t0 = Date.now();
+	let response: Response;
+	try {
+		response = await fetch(
+			`https://api.openrouteservice.org/v2/matrix/${ORS_PROFILE[transportMode]}`,
+			{
+				signal: AbortSignal.timeout(ORS_TIMEOUT_MS),
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					Authorization: ORS_API_KEY ?? '',
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					locations,
+					sources: [0],
+					destinations: owners.map((_, i) => i + 1),
+					metrics: ['duration'],
+				}),
+			}
+		);
+	} catch (err) {
+		console.error('[TRAVEL_DIAG]', JSON.stringify({
+			event: 'ors_error', transport_mode: transportMode, owner_count: owners.length,
+			duration_ms: Date.now() - t0, error: err instanceof Error ? err.message : String(err)
+		}));
+		return [];
+	}
+
+	const duration_ms = Date.now() - t0;
 
 	if (!response.ok) {
-		console.error('ORS API error:', response.status, await response.text());
+		const body = await response.text().catch(() => '');
+		console.error('[TRAVEL_DIAG]', JSON.stringify({
+			event: 'ors_error', transport_mode: transportMode, owner_count: owners.length,
+			duration_ms, status: response.status, body: body.slice(0, 200)
+		}));
 		return [];
+	}
+
+	if (duration_ms > ORS_SLOW_MS) {
+		console.warn('[TRAVEL_DIAG]', JSON.stringify({
+			event: 'ors_slow', transport_mode: transportMode, owner_count: owners.length, duration_ms
+		}));
 	}
 
 	const data = await response.json();

--- a/src/routes/api/diagnostics/+server.ts
+++ b/src/routes/api/diagnostics/+server.ts
@@ -1,8 +1,13 @@
+// Fire-and-forget diagnostics endpoint called by the client on travel time failures.
+// Events are written to the server log with a [TRAVEL_DIAG] prefix for easy grepping.
+// Always returns 200 so client errors never cascade into visible UI failures.
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ request }) => {
 	const data = await request.json().catch(() => null);
-	if (data?.event) console.log('[TRAVEL_DIAG]', JSON.stringify({ ts: new Date().toISOString(), ...data }));
+	if (data?.event) {
+		console.log('[TRAVEL_DIAG]', JSON.stringify({ ts: new Date().toISOString(), ...data }));
+	}
 	return json({});
 };

--- a/src/routes/api/diagnostics/+server.ts
+++ b/src/routes/api/diagnostics/+server.ts
@@ -1,0 +1,8 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const POST: RequestHandler = async ({ request }) => {
+	const data = await request.json().catch(() => null);
+	if (data?.event) console.log('[TRAVEL_DIAG]', JSON.stringify({ ts: new Date().toISOString(), ...data }));
+	return json({});
+};

--- a/src/routes/items/[id]/ItemTravelTime.svelte
+++ b/src/routes/items/[id]/ItemTravelTime.svelte
@@ -23,19 +23,26 @@
 	let cachedUserLocation: { lon: number; lat: number } | null = null;
 
 	async function fetchTravelTime(mode: TransportMode, userLocation: { lon: number; lat: number }) {
+		const controller = new AbortController();
+		const timeoutId = setTimeout(() => controller.abort(), 15_000);
 		try {
 			const res = await fetch('/api/travel-times/item', {
 				method: 'POST',
+				signal: controller.signal,
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({ itemId, userLocation, transportMode: mode }),
 			});
 			if (res.ok) {
 				const { minutes } = await res.json();
 				travelMinutes = minutes ?? null;
+			} else {
+				fetch('/api/diagnostics', { method: 'POST', body: JSON.stringify({ event: 'fetch_error', page: 'item_detail', status: res.status }) }).catch(() => {});
 			}
-		} catch {
-			// silently skip
+		} catch (err) {
+			const isTimeout = err instanceof DOMException && err.name === 'AbortError';
+			fetch('/api/diagnostics', { method: 'POST', body: JSON.stringify({ event: isTimeout ? 'fetch_timeout' : 'fetch_error', page: 'item_detail' }) }).catch(() => {});
 		} finally {
+			clearTimeout(timeoutId);
 			calculating = false;
 		}
 	}

--- a/src/routes/items/[id]/ItemTravelTime.svelte
+++ b/src/routes/items/[id]/ItemTravelTime.svelte
@@ -22,7 +22,13 @@
 	let calculating = $state(false);
 	let cachedUserLocation: { lon: number; lat: number } | null = null;
 
+	// Fire-and-forget: sends a diagnostic event to the server log. Never throws.
+	function sendDiag(payload: Record<string, unknown>) {
+		fetch('/api/diagnostics', { method: 'POST', body: JSON.stringify(payload) }).catch(() => {});
+	}
+
 	async function fetchTravelTime(mode: TransportMode, userLocation: { lon: number; lat: number }) {
+		// Abort after 15s so a hanging ORS response doesn't leave `calculating` stuck as true indefinitely
 		const controller = new AbortController();
 		const timeoutId = setTimeout(() => controller.abort(), 15_000);
 		try {
@@ -36,11 +42,12 @@
 				const { minutes } = await res.json();
 				travelMinutes = minutes ?? null;
 			} else {
-				fetch('/api/diagnostics', { method: 'POST', body: JSON.stringify({ event: 'fetch_error', page: 'item_detail', status: res.status }) }).catch(() => {});
+				sendDiag({ event: 'fetch_error', page: 'item_detail', status: res.status });
 			}
 		} catch (err) {
+			// AbortError means our 15s timeout fired; any other error is a network failure
 			const isTimeout = err instanceof DOMException && err.name === 'AbortError';
-			fetch('/api/diagnostics', { method: 'POST', body: JSON.stringify({ event: isTimeout ? 'fetch_timeout' : 'fetch_error', page: 'item_detail' }) }).catch(() => {});
+			sendDiag({ event: isTimeout ? 'fetch_timeout' : 'fetch_error', page: 'item_detail' });
 		} finally {
 			clearTimeout(timeoutId);
 			calculating = false;

--- a/src/routes/search/TravelTimeFilter.svelte
+++ b/src/routes/search/TravelTimeFilter.svelte
@@ -52,15 +52,26 @@
 	async function fetchTravelTimes(mode: TransportMode, userLocation: { lon: number; lat: number }) {
 		const owners = extractOwnerLocations();
 		if (owners.length === 0) return;
+		const controller = new AbortController();
+		const timeoutId = setTimeout(() => controller.abort(), 15_000);
 		try {
 			const response = await fetch('/api/travel-times', {
 				method: 'POST',
+				signal: controller.signal,
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({ userLocation, transportMode: mode, owners }),
 			});
-			if (response.ok) travelTimes = await response.json();
+			if (response.ok) {
+				travelTimes = await response.json();
+			} else {
+				fetch('/api/diagnostics', { method: 'POST', body: JSON.stringify({ event: 'fetch_error', page: 'search', status: response.status }) }).catch(() => {});
+			}
 		} catch (err) {
+			const isTimeout = err instanceof DOMException && err.name === 'AbortError';
+			fetch('/api/diagnostics', { method: 'POST', body: JSON.stringify({ event: isTimeout ? 'fetch_timeout' : 'fetch_error', page: 'search' }) }).catch(() => {});
 			console.error('Travel time fetch failed:', err);
+		} finally {
+			clearTimeout(timeoutId);
 		}
 	}
 

--- a/src/routes/search/TravelTimeFilter.svelte
+++ b/src/routes/search/TravelTimeFilter.svelte
@@ -49,9 +49,16 @@
 		return result;
 	}
 
+	// Fire-and-forget: sends a diagnostic event to the server log. Never throws.
+	function sendDiag(payload: Record<string, unknown>) {
+		fetch('/api/diagnostics', { method: 'POST', body: JSON.stringify(payload) }).catch(() => {});
+	}
+
 	async function fetchTravelTimes(mode: TransportMode, userLocation: { lon: number; lat: number }) {
 		const owners = extractOwnerLocations();
 		if (owners.length === 0) return;
+
+		// Abort after 15s so a hanging ORS response doesn't leave the UI stuck indefinitely
 		const controller = new AbortController();
 		const timeoutId = setTimeout(() => controller.abort(), 15_000);
 		try {
@@ -64,11 +71,12 @@
 			if (response.ok) {
 				travelTimes = await response.json();
 			} else {
-				fetch('/api/diagnostics', { method: 'POST', body: JSON.stringify({ event: 'fetch_error', page: 'search', status: response.status }) }).catch(() => {});
+				sendDiag({ event: 'fetch_error', page: 'search', status: response.status });
 			}
 		} catch (err) {
+			// AbortError means our 15s timeout fired; any other error is a network failure
 			const isTimeout = err instanceof DOMException && err.name === 'AbortError';
-			fetch('/api/diagnostics', { method: 'POST', body: JSON.stringify({ event: isTimeout ? 'fetch_timeout' : 'fetch_error', page: 'search' }) }).catch(() => {});
+			sendDiag({ event: isTimeout ? 'fetch_timeout' : 'fetch_error', page: 'search' });
 			console.error('Travel time fetch failed:', err);
 		} finally {
 			clearTimeout(timeoutId);


### PR DESCRIPTION
I couldn't reproduce errors users were reporting (travel-time compute loading forever, ...), but this should at least give us clues in the future on what is actually broken