### PR TITLE
Add lending terms flow

### DIFF
--- a/src/lib/server/lendingTerms.ts
+++ b/src/lib/server/lendingTerms.ts
@@ -1,0 +1,102 @@
+import type PocketBase from 'pocketbase';
+import type { LendingTerms, TermAcceptance } from '$lib/types/models';
+
+/**
+ * Normalises HTML coming from PocketBase's richtext editor for display.
+ *
+ * The editor stores well-formed HTML but adds some annotations that don't sit
+ * well in our theme (inline dark-mode colours) and occasionally leaves markdown
+ * fragments unconverted (e.g. `## Heading` inside a `<div>`, or `[text](url)`
+ * link patterns wrapped in styled spans). This helper makes the output legible
+ * inside our prose styles. It is intentionally conservative — no real sanitizer,
+ * because the source is admin-only (institution accounts via the PB admin UI).
+ *
+ * The cleaned form is what we render to the user AND what we snapshot into
+ * `term_acceptances.termsBody`, so that what was shown == what was accepted.
+ */
+export function cleanTermsHtml(raw: string | undefined | null): string {
+	if (!raw) return '';
+	let html = raw;
+
+	// Strip inline style attributes (PB editor injects dark-mode colour hints
+	// that clash with our light/dark theme). Both quote styles handled.
+	html = html.replace(/\s+style="[^"]*"/gi, '');
+	html = html.replace(/\s+style='[^']*'/gi, '');
+
+	// Unwrap inline spans that lost their styling and now only add noise.
+	html = html.replace(/<span>\s*([\s\S]*?)\s*<\/span>/gi, '$1');
+
+	// Convert leftover markdown link pattern  [label](url)  → real <a> tag.
+	// Done after style stripping so any spans inside have already been unwrapped.
+	html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+
+	// Convert markdown-style headings stored as plain text inside <div> blocks:
+	//   <div>## Heading</div>  →  <h3>Heading</h3>
+	//   <div># Heading</div>   →  <h2>Heading</h2>
+	html = html.replace(/<div>\s*###\s+([^<]+?)\s*<\/div>/gi, '<h4>$1</h4>');
+	html = html.replace(/<div>\s*##\s+([^<]+?)\s*<\/div>/gi, '<h3>$1</h3>');
+	html = html.replace(/<div>\s*#\s+([^<]+?)\s*<\/div>/gi, '<h2>$1</h2>');
+
+	// Collapse standalone `<br>` between block-level elements — the prose
+	// styles already produce vertical rhythm between divs/paragraphs.
+	html = html.replace(/(<\/(?:div|h\d|p|li|ul|ol)>)\s*<br\s*\/?>\s*/gi, '$1');
+
+	return html.trim();
+}
+
+/**
+ * Returns the currently active `lending_terms` record for the given owner (institution),
+ * or `null` if the owner has no active terms.
+ *
+ * Active = `active == true`. We additionally require `effectiveFrom <= now` so that
+ * future-dated versions can be staged without going live.
+ */
+export async function getActiveTerms(
+	pb: PocketBase,
+	ownerId: string
+): Promise<LendingTerms | null> {
+	try {
+		const nowIso = new Date().toISOString().replace('T', ' ').replace('Z', '');
+		return await pb.collection('lending_terms').getFirstListItem<LendingTerms>(
+			`owner = "${ownerId}" && active = true && effectiveFrom <= "${nowIso}"`,
+			{ sort: '-effectiveFrom' }
+		);
+	} catch {
+		// PocketBase throws 404 if no record matches — translate to null.
+		return null;
+	}
+}
+
+/**
+ * Returns the most recent acceptance by `userId` of the given `termsId`, or `null`
+ * if the user has not yet accepted that exact version.
+ */
+export async function getAcceptance(
+	pb: PocketBase,
+	userId: string,
+	termsId: string
+): Promise<TermAcceptance | null> {
+	try {
+		return await pb.collection('term_acceptances').getFirstListItem<TermAcceptance>(
+			`user = "${userId}" && terms = "${termsId}"`,
+			{ sort: '-acceptedAt' }
+		);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Convenience: true if the user has already accepted the currently active terms
+ * of the given owner. Returns false if there are no active terms (no gating needed).
+ */
+export async function hasAcceptedActiveTerms(
+	pb: PocketBase,
+	userId: string,
+	ownerId: string
+): Promise<boolean> {
+	const active = await getActiveTerms(pb, ownerId);
+	if (!active) return true; // no terms → nothing to accept → consider satisfied
+	const acceptance = await getAcceptance(pb, userId, active.id);
+	return acceptance !== null;
+}

--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -803,6 +803,36 @@ export const texts = {
 		institutionCardTitle: 'Über die Institution',
 		aboutOwnerTitle: (name: string) => `Über ${name}`,
 	},
+	// Lending terms acceptance (Leihbedingungen for institutional partners)
+	lendingTerms: {
+		pageTitle: 'Leihbedingungen zustimmen',
+		introWithOwner: (ownerName: string) =>
+			`Bevor du diesen Gegenstand bei ${ownerName} anfragst, musst du den Leihbedingungen zustimmen.`,
+		introGeneric: 'Bevor du diesen Gegenstand anfragst, musst du den Leihbedingungen zustimmen.',
+		responsibleNote: (contact: string) =>
+			`Verantwortlich für den Verleih und im Sinne der DSGVO: ${contact}.`,
+		platformOnlyNote:
+			'AllerLeih ist nicht Vertragspartner des Verleihs, sondern vermittelt nur die Anfrage zwischen dir und der oben genannten Stelle.',
+		versionLabel: (version: string) => `Version ${version}`,
+		effectiveFromLabel: (date: string) => `Gültig ab ${date}`,
+		confirmAdultLabel: (minAge: number) =>
+			`Ich bestätige, dass ich mindestens ${minAge} Jahre alt bin.`,
+		minorHintTitle: 'Du bist 14–17?',
+		minorHintBody:
+			'Komm bitte mit einer erziehungsberechtigten Person zum Ausleihen. Vor Ort gibt es ein Einwilligungsformular, das einmalig unterschrieben wird – danach kannst du selbstständig ausleihen.',
+		confirmTermsLabel: (version: string) =>
+			`Ich habe die Leihbedingungen (Version ${version}) gelesen und stimme ihnen zu.`,
+		acceptAndRequestButton: 'Zustimmen und Anfrage senden',
+		cancel: 'Abbrechen',
+		errors: {
+			notFound: 'Für diesen Gegenstand sind keine Leihbedingungen hinterlegt.',
+			mustConfirmAdult: 'Bitte bestätige dein Mindestalter.',
+			mustConfirmTerms: 'Bitte stimme den Leihbedingungen zu.',
+			acceptanceFailed: 'Die Zustimmung konnte nicht gespeichert werden. Bitte versuche es erneut.',
+		},
+		alreadyAcceptedNote: 'Du hast diese Leihbedingungen bereits akzeptiert.',
+	},
+
 	counterfactual: {
 		title: 'Eine ganz kurze Frage!',
 		question: 'Was wäre passiert, wenn du diesen Artikel nicht geliehen hättest?',

--- a/src/lib/types/models.ts
+++ b/src/lib/types/models.ts
@@ -233,3 +233,77 @@ export interface Notification extends PocketBaseEntity {
 	/** Whether the recipient has seen this notification */
 	read: boolean;
 }
+
+// --- LENDING TERMS ---
+
+/**
+ * Versioned terms of use ("Leihbedingungen") published by an institutional owner.
+ * Each institution (e.g. Mosaique, Commons Zentrum) maintains one record per version.
+ * Exactly one record per owner should have `active = true` at any time.
+ *
+ * Records are treated as immutable once any acceptance refers to them — to update
+ * the text, create a new record with a bumped version and flip `active`.
+ */
+export interface LendingTerms extends PocketBaseEntity {
+	/** Foreign key: institution user that issues these terms (must have isInstitution = true) */
+	owner: UserId;
+
+	/** Semantic or date-based version string, e.g. "1.0" or "2026-05" */
+	version: string;
+
+	/** Human-readable title shown to users, e.g. "Leihbedingungen Leihregal im mosaique" */
+	title: string;
+
+	/** Full text of the terms — rendered as-is to the user. Plain text with paragraphs. */
+	body: string;
+
+	/** ISO datetime — earliest point at which these terms apply */
+	effectiveFrom: string;
+
+	/** Whether this is the currently active version for this owner. Max one per owner. */
+	active: boolean;
+
+	/** Minimum age (in years) required to digitally accept these terms. Default 18. */
+	minAge: number;
+
+	/** Optional: name of the legally responsible person/body for display */
+	contactPerson?: string;
+}
+
+/**
+ * Audit-trail record of one user accepting one specific version of LendingTerms.
+ *
+ * Body of the terms is snapshotted at acceptance time so the acceptance remains
+ * legally interpretable even if the source `LendingTerms` record changes.
+ */
+export interface TermAcceptance extends PocketBaseEntity {
+	/** Foreign key: user who accepted */
+	user: UserId;
+
+	/** Foreign key: the exact LendingTerms record (and thus version) accepted */
+	terms: string;
+
+	/** Server-stamped acceptance timestamp (ISO) */
+	acceptedAt: string;
+
+	/** Separate confirmation the user is at least minAge years old */
+	confirmedAdult: boolean;
+
+	/** Snapshot of the user's username at acceptance time (username may change later) */
+	fullNameSnapshot: string;
+
+	/** Snapshot of the full terms body at acceptance time (robust acceptance copy) */
+	termsBody: string;
+
+	/** Snapshot of version string for quick display */
+	termsVersion?: string;
+
+	/** Snapshot of terms title for quick display */
+	termsTitle?: string;
+
+	/** Client IP at acceptance (best-effort, may be proxy IP) */
+	userIp?: string;
+
+	/** User-Agent string at acceptance */
+	userAgent?: string;
+}

--- a/src/routes/items/[id]/+page.server.ts
+++ b/src/routes/items/[id]/+page.server.ts
@@ -4,6 +4,7 @@ import type { Item } from '$lib/types/models';
 import type { ClientResponseError } from 'pocketbase';
 import { texts } from '$lib/texts';
 import { createNotification, sendPushToUser } from '$lib/server/notifications.js';
+import { getActiveTerms, hasAcceptedActiveTerms } from '$lib/server/lendingTerms';
 
 export async function load({ params, locals }) {
 	let item: Item;
@@ -44,6 +45,18 @@ export async function load({ params, locals }) {
 		}
 	}
 
+	// Does this owner publish lending terms, and if so has the viewer accepted them?
+	// We only gate the request flow on terms when the viewer is logged in and not the owner.
+	let requiresTermsAcceptance = false;
+	if (currentUserId && !isOwnItem) {
+		const ownerId = item.expand?.owner?.id ?? item.owner;
+		const activeTerms = await getActiveTerms(locals.pb, ownerId);
+		if (activeTerms) {
+			const accepted = await hasAcceptedActiveTerms(locals.pb, currentUserId, ownerId);
+			requiresTermsAcceptance = !accepted;
+		}
+	}
+
 	// Total items listed by this owner (all statuses).
 	let ownerItemCount = 0;
 	if (item.expand?.owner?.id) {
@@ -81,6 +94,7 @@ export async function load({ params, locals }) {
 		ownerItemCount,
 		preferredTransportMode: locals.user?.preferredTransportMode ?? 'bicycle',
 		existingConversation,
+		requiresTermsAcceptance,
 	};
 }
 
@@ -121,6 +135,18 @@ export const actions = {
 			itemRecord = await locals.pb.collection('items').getOne(params.id);
 		} catch {
 			return fail(404, { fail: true, message: texts.errors.itemNotFound });
+		}
+
+		// If the item's owner publishes lending terms and the user has not accepted
+		// the active version, divert them through the terms acceptance flow. This
+		// guards against POSTing directly to ?/startConversation past the CTA UI.
+		const termsOk = await hasAcceptedActiveTerms(
+			locals.pb,
+			locals.user.id,
+			itemRecord.owner
+		);
+		if (!termsOk) {
+			redirect(303, `/items/${params.id}/terms`);
 		}
 
 		// Consume form data (itemId kept for the conversation filter; ownerId ignored).

--- a/src/routes/items/[id]/+page.svelte
+++ b/src/routes/items/[id]/+page.svelte
@@ -125,6 +125,7 @@
 			{isTrustRestricted}
 			{isArchived}
 			existingConversation={data.existingConversation}
+			requiresTermsAcceptance={data.requiresTermsAcceptance}
 		/>
 	</div>
 

--- a/src/routes/items/[id]/ItemCta.svelte
+++ b/src/routes/items/[id]/ItemCta.svelte
@@ -13,9 +13,28 @@
 		isTrustRestricted: boolean;
 		isArchived: boolean;
 		existingConversation: { id: string; lendingStatus: string } | null;
+		requiresTermsAcceptance?: boolean;
 	}
 
-	const { item, isExternal, isOwnItem, isTrustRestricted, isArchived, existingConversation }: Props = $props();
+	const {
+		item,
+		isExternal,
+		isOwnItem,
+		isTrustRestricted,
+		isArchived,
+		existingConversation,
+		requiresTermsAcceptance = false,
+	}: Props = $props();
+
+
+	const ctaHref = $derived(
+		existingConversation
+			? resolve(`/conversations/${existingConversation.id}`)
+			: resolve(`/items/${item.id}/terms`),
+	);
+	const ctaLabel = $derived(
+		existingConversation ? texts.lending.goToConversation : texts.pages.itemDetail.requestButton,
+	);
 </script>
 
 <div class="flex items-center gap-3">
@@ -77,13 +96,11 @@
 		<Tooltip triggeredBy="#anfragen-disabled" type="light" placement="top" trigger="click">
 			{texts.pages.itemDetail.trustRestrictedTooltip}
 		</Tooltip>
-	{:else if existingConversation}
-		<a
-			href={resolve(`/conversations/${existingConversation.id}`)}
-			class="inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold bg-primary-200 hover:bg-primary text-tinte-900 transition-colors"
-		>
+	{:else if existingConversation || requiresTermsAcceptance}
+		<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+		<a href={ctaHref} class="inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold bg-primary-200 hover:bg-primary text-tinte-900 transition-colors">
 			<MessagesOutline class="h-4 w-4 mr-2" />
-			{texts.lending.goToConversation}
+			{ctaLabel}
 		</a>
 	{:else}
 		<form method="POST" action="?/startConversation">

--- a/src/routes/items/[id]/terms/+page.server.ts
+++ b/src/routes/items/[id]/terms/+page.server.ts
@@ -1,0 +1,198 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { error, fail, redirect } from '@sveltejs/kit';
+import type { Item, LendingTerms } from '$lib/types/models';
+import type { ClientResponseError } from 'pocketbase';
+import { texts } from '$lib/texts';
+import {
+	getActiveTerms,
+	getAcceptance,
+	cleanTermsHtml,
+} from '$lib/server/lendingTerms';
+import { createNotification, sendPushToUser } from '$lib/server/notifications';
+
+export async function load({ params, locals, url }) {
+	// Auth is required to accept terms. Bounce through login if needed.
+	if (!locals.user) {
+		redirect(303, `/auth/login?redirectTo=${encodeURIComponent(url.pathname)}`);
+	}
+
+	let item: Item;
+	try {
+		item = await locals.pb.collection('items').getOne(params.id, {
+			expand: 'owner',
+		});
+	} catch (err) {
+		const e = err as Partial<ClientResponseError>;
+		error(e.status === 404 ? 404 : 500, texts.errors.itemNotFound);
+	}
+
+	const ownerId = item.expand?.owner?.id ?? item.owner;
+	const ownerName = item.expand?.owner?.username ?? '';
+
+	const activeTerms = await getActiveTerms(locals.pb, ownerId);
+	if (!activeTerms) {
+		// Owner has no active terms → no gating, send user back to item.
+		redirect(303, `/items/${params.id}`);
+	}
+
+	const existingAcceptance = await getAcceptance(locals.pb, locals.user.id, activeTerms.id);
+
+	// Strip sensitive fields from owner expand before returning.
+	if (item.expand?.owner) {
+		delete item.expand.owner.geolocation;
+		delete item.expand.owner.trusts;
+		delete item.expand.owner.email;
+	}
+
+	// Normalise the richtext body once on the server so display and snapshot stay in sync.
+	const cleanedTerms: LendingTerms = {
+		...(activeTerms as LendingTerms),
+		body: cleanTermsHtml(activeTerms.body),
+	};
+
+	return {
+		item,
+		ownerName,
+		terms: cleanedTerms,
+		alreadyAccepted: !!existingAcceptance,
+	};
+}
+
+export const actions = {
+	accept: async ({ locals, request, params, getClientAddress }) => {
+		if (!locals.user) {
+			redirect(303, `/auth/login?redirectTo=/items/${params.id}/terms`);
+		}
+
+		// Re-fetch the item so we trust nothing from form data.
+		let itemRecord: Item;
+		try {
+			itemRecord = await locals.pb.collection('items').getOne(params.id);
+		} catch {
+			return fail(404, { error: true, message: texts.errors.itemNotFound });
+		}
+
+		const ownerId = itemRecord.owner;
+
+		// Re-fetch the active terms — never trust an id sent from the client.
+		const activeTerms = await getActiveTerms(locals.pb, ownerId);
+		if (!activeTerms) {
+			return fail(404, { error: true, message: texts.lendingTerms.errors.notFound });
+		}
+
+		const formData = await request.formData();
+		const confirmAdult = formData.get('confirmAdult') === 'on';
+		const confirmTerms = formData.get('confirmTerms') === 'on';
+
+		if (!confirmAdult) {
+			return fail(400, { error: true, message: texts.lendingTerms.errors.mustConfirmAdult });
+		}
+		if (!confirmTerms) {
+			return fail(400, { error: true, message: texts.lendingTerms.errors.mustConfirmTerms });
+		}
+
+		// Idempotency: skip insert if the user has already accepted this exact version.
+		const existing = await getAcceptance(locals.pb, locals.user.id, activeTerms.id);
+		if (!existing) {
+			let userIp = '';
+			try {
+				userIp = getClientAddress();
+			} catch {
+				// SvelteKit throws if no adapter provides it — non-critical.
+			}
+			const userAgent = request.headers.get('user-agent') ?? '';
+
+			try {
+				await locals.pb.collection('term_acceptances').create({
+					user: locals.user.id,
+					terms: activeTerms.id,
+					acceptedAt: new Date().toISOString(),
+					confirmedAdult: true,
+					fullNameSnapshot: (locals.user.username as string) ?? '',
+					// Snapshot the cleaned HTML — same thing the user actually saw.
+					termsBody: cleanTermsHtml(activeTerms.body),
+					termsVersion: activeTerms.version,
+					termsTitle: activeTerms.title,
+					userIp,
+					userAgent,
+				});
+			} catch (err) {
+				const e = err as Partial<ClientResponseError>;
+				console.error('term_acceptance create failed:', e?.message ?? err);
+				return fail(500, {
+					error: true,
+					message: texts.lendingTerms.errors.acceptanceFailed,
+				});
+			}
+		}
+
+		// After acceptance, kick off the actual lending request flow.
+		await startConversationForItem(locals, itemRecord);
+
+		// If we got here, startConversation didn't redirect — fall back.
+		redirect(303, `/items/${params.id}`);
+	},
+};
+
+/**
+ * Mirrors the startConversation logic in /items/[id]/+page.server.ts so that
+ * accepting the terms transparently kicks off the request. Centralising this
+ * is out of scope for the first cut; if the request flow grows further we
+ * should extract a shared helper.
+ */
+async function startConversationForItem(
+	locals: any,
+	itemRecord: Item
+): Promise<never> {
+	const requesterId = locals.user.id;
+	const itemOwnerId = itemRecord.owner;
+
+	let targetConversationId = '';
+	let existingConversations;
+	try {
+		existingConversations = await locals.pb.collection('conversations').getFullList({
+			filter: `requester = "${requesterId}" && requestedItem = "${itemRecord.id}" && lendingStatus!="rejected" && lendingStatus!="completed" && lendingStatus!=""`,
+			sort: '-created',
+		});
+	} catch {
+		existingConversations = [];
+	}
+
+	if (existingConversations.length > 0) {
+		targetConversationId = existingConversations[0].id;
+	} else {
+		const conversation = await locals.pb.collection('conversations').create({
+			requester: requesterId,
+			itemOwner: itemOwnerId,
+			requestedItem: itemRecord.id,
+			lendingStatus: 'pending',
+			readByRequester: true,
+			readByOwner: false,
+		});
+		targetConversationId = conversation.id;
+
+		const requesterName =
+			locals.user.username ?? locals.user.name ?? texts.pages.itemDetail.unknownRequester;
+		const itemName = itemRecord.name ?? texts.pages.itemDetail.unknownItem;
+		const notificationBody = texts.notifications.newRequest(requesterName, itemName);
+		const conversationUrl = `/conversations/${targetConversationId}`;
+
+		await createNotification(
+			locals.pb,
+			itemOwnerId,
+			locals.user.id,
+			'new_request',
+			targetConversationId,
+			notificationBody
+		);
+		await sendPushToUser(
+			locals.pb,
+			itemOwnerId,
+			texts.notifications.pushTitle,
+			notificationBody,
+			conversationUrl
+		);
+	}
+
+	redirect(303, `/conversations/${targetConversationId}`);
+}

--- a/src/routes/items/[id]/terms/+page.svelte
+++ b/src/routes/items/[id]/terms/+page.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+	import { Alert, Button, Checkbox } from 'flowbite-svelte';
+	import { enhance } from '$app/forms';
+	import { resolve } from '$app/paths';
+	import { texts } from '$lib/texts';
+	import { formatTimestamp } from '$lib/utils/utils';
+
+	const { data, form } = $props();
+
+	let confirmAdult = $state(false);
+	let confirmTerms = $state(false);
+
+	const canSubmit = $derived(confirmAdult && confirmTerms);
+
+	const effectiveFromDisplay = $derived(
+		data.terms.effectiveFrom ? formatTimestamp(data.terms.effectiveFrom) : ''
+	);
+</script>
+
+<svelte:head>
+	<title>{texts.lendingTerms.pageTitle} – {data.item.name}</title>
+	<meta name="robots" content="noindex, nofollow" />
+</svelte:head>
+
+<div class="mx-auto max-w-3xl px-4 py-6 space-y-6">
+	<a
+		href={resolve(`/items/${data.item.id}`)}
+		class="inline-block text-sm text-tinte-500 dark:text-tinte-400 hover:text-tinte-700 dark:hover:text-tinte-200"
+	>
+		← {data.item.name}
+	</a>
+
+	<h1 class="text-3xl font-bold tracking-tight text-tinte-900 dark:text-white">
+		{data.terms.title}
+	</h1>
+
+	<p class="text-tinte-700 dark:text-tinte-300">
+		{data.ownerName
+			? texts.lendingTerms.introWithOwner(data.ownerName)
+			: texts.lendingTerms.introGeneric}
+	</p>
+
+	<!-- Verantwortlicher / Plattform-Hinweis -->
+	<Alert color="blue" class="text-sm">
+		{#if data.terms.contactPerson}
+			<p class="mb-1">
+				{texts.lendingTerms.responsibleNote(data.terms.contactPerson)}
+			</p>
+		{/if}
+		<p>{texts.lendingTerms.platformOnlyNote}</p>
+	</Alert>
+
+	<!-- Versions-Meta -->
+	<div class="flex flex-wrap gap-3 text-xs text-tinte-500 dark:text-tinte-400">
+		<span class="rounded-full border border-tinte-200 dark:border-tinte-700 px-2 py-0.5">
+			{texts.lendingTerms.versionLabel(data.terms.version)}
+		</span>
+		{#if effectiveFromDisplay}
+			<span class="rounded-full border border-tinte-200 dark:border-tinte-700 px-2 py-0.5">
+				{texts.lendingTerms.effectiveFromLabel(effectiveFromDisplay)}
+			</span>
+		{/if}
+	</div>
+
+	<!-- Vollständiger Bedingungstext (PocketBase richtext = HTML; bereits server-seitig
+	     normalisiert in lendingTerms.cleanTermsHtml). Quelle ist admin-only. -->
+	<article
+		class="terms-body rounded-2xl border border-tinte-200 dark:border-tinte-700 bg-sand dark:bg-tinte-800 p-6 leading-relaxed text-tinte-800 dark:text-tinte-200"
+	>
+		{@html data.terms.body}
+	</article>
+
+	<!-- Minderjährigen-Hinweis -->
+	<div class="rounded-2xl bg-secondary-100 dark:bg-tinte-700 p-4 text-sm text-tinte-800 dark:text-tinte-100">
+		<p class="font-semibold">{texts.lendingTerms.minorHintTitle}</p>
+		<p class="mt-1">{texts.lendingTerms.minorHintBody}</p>
+	</div>
+
+	{#if form?.error && form?.message}
+		<Alert color="red">{form.message}</Alert>
+	{/if}
+
+	{#if data.alreadyAccepted}
+		<Alert color="green">{texts.lendingTerms.alreadyAcceptedNote}</Alert>
+	{/if}
+
+	<!-- Zustimmungs-Form -->
+	<form method="POST" action="?/accept" use:enhance class="space-y-4">
+		<Checkbox bind:checked={confirmAdult} name="confirmAdult">
+			{texts.lendingTerms.confirmAdultLabel(data.terms.minAge ?? 18)}
+		</Checkbox>
+
+		<Checkbox bind:checked={confirmTerms} name="confirmTerms">
+			{texts.lendingTerms.confirmTermsLabel(data.terms.version)}
+		</Checkbox>
+
+		<div class="flex flex-wrap gap-3 items-center pt-2">
+			<Button
+				type="submit"
+				pill
+				disabled={!canSubmit}
+				class="cursor-pointer bg-primary-200 hover:bg-primary disabled:opacity-50"
+			>
+				{texts.lendingTerms.acceptAndRequestButton}
+			</Button>
+			<a
+				href={resolve(`/items/${data.item.id}`)}
+				class="text-sm text-tinte-500 dark:text-tinte-400 hover:text-tinte-700 dark:hover:text-tinte-200"
+			>
+				{texts.lendingTerms.cancel}
+			</a>
+		</div>
+	</form>
+</div>
+
+<style>
+	/* Lokale Typografie nur für den Bedingungs-Block — wir wollen nicht von einem
+	   globalen `.prose`-Plugin abhängen, und PB liefert eine eher schlichte
+	   <div>/<h2>/<a>-Struktur, der wir hier passende Abstände geben. */
+	.terms-body :global(h2) {
+		font-size: 1.25rem;
+		font-weight: 700;
+		margin-top: 1.25rem;
+		margin-bottom: 0.5rem;
+	}
+	.terms-body :global(h3) {
+		font-size: 1.1rem;
+		font-weight: 600;
+		margin-top: 1rem;
+		margin-bottom: 0.4rem;
+	}
+	.terms-body :global(h4) {
+		font-size: 1rem;
+		font-weight: 600;
+		margin-top: 0.8rem;
+		margin-bottom: 0.3rem;
+	}
+	.terms-body :global(div),
+	.terms-body :global(p) {
+		margin-top: 0.5rem;
+		margin-bottom: 0.5rem;
+	}
+	.terms-body :global(div:first-child),
+	.terms-body :global(p:first-child) {
+		margin-top: 0;
+	}
+	.terms-body :global(ul),
+	.terms-body :global(ol) {
+		margin: 0.5rem 0 0.5rem 1.25rem;
+		list-style: disc;
+	}
+	.terms-body :global(ol) {
+		list-style: decimal;
+	}
+	.terms-body :global(li) {
+		margin-bottom: 0.25rem;
+	}
+	.terms-body :global(a) {
+		color: #1d4ed8;
+		text-decoration: underline;
+	}
+	.terms-body :global(strong) {
+		font-weight: 700;
+	}
+	.terms-body :global(em) {
+		font-style: italic;
+	}
+</style>


### PR DESCRIPTION
Implement a flow for users to accept lending terms before requesting items from institutional partners. This includes checks for active terms and user acceptance status, ensuring compliance with lending policies. Additional text resources for terms acceptance are also provided.