### PR TITLE
Add in-app password reset confirmation

### DIFF
--- a/src/lib/components/PasswordInput.svelte
+++ b/src/lib/components/PasswordInput.svelte
@@ -3,17 +3,21 @@
 	import { EyeOutline, EyeSlashOutline } from 'flowbite-svelte-icons';
 	import { texts } from '$lib/texts';
 
-	let { autocomplete = 'current-password' }: { autocomplete?: AutoFill | null } = $props();
+	let {
+		autocomplete = 'current-password',
+		name = 'password',
+		label = texts.forms.password,
+	}: { autocomplete?: AutoFill | null; name?: string; label?: string } = $props();
 
 	let showPassword = $state(false);
 </script>
 
 <Label class="space-y-2">
-	<span>{texts.forms.password}</span>
+	<span>{label}</span>
 	<div class="relative">
 		<Input
 			type={showPassword ? 'text' : 'password'}
-			name="password"
+			{name}
 			placeholder={texts.auth.passwordPlaceholder}
 			class="focus:border-primary-700 focus:ring-primary-700 pr-10"
 			{autocomplete}

--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -81,6 +81,9 @@ export const texts = {
 		usernameRequired: 'Bitte gib einen Nutzernamen ein.',
 		usernameTaken: 'Dieser Nutzername ist bereits vergeben.',
 		passwordTooShort: 'Das Passwort muss mindestens 8 Zeichen lang sein.',
+		passwordsDoNotMatch: 'Die Passwörter stimmen nicht überein.',
+		invalidOrExpiredResetToken:
+			'Dieser Link ist ungültig oder abgelaufen. Bitte fordere einen neuen Link zum Zurücksetzen des Passworts an.',
 		invalidTelegramUsername: 'Ungültiger Telegram-Nutzername. Bitte gib nur den Namen ohne Sonderzeichen ein.',
 		invalidSignalLink: 'Ungültiger Signal-Link. Signal-Links sollten mit "signal.me/" beginnen.',
 		feedbackFailed: 'Feedback konnte nicht gesendet werden.',
@@ -97,6 +100,8 @@ export const texts = {
 		loggedOut: 'Erfolgreich ausgeloggt',
 		passwordResetSent:
 			'Falls diese E-Mail zu einem Account passt, wurde eine E-Mail zum Zurücksetzen des Passworts gesendet!',
+		passwordResetConfirmed:
+			'Dein Passwort wurde erfolgreich geändert. Du kannst dich jetzt anmelden.',
 		dataUpdated: 'Daten wurden erfolgreich aktualisiert.',
 		feedbackSent: 'Feedback erfolgreich gesendet. Vielen Dank!',
 		trusteeAdded: (username: string) => `${username} wurde deinem Netzwerk hinzugefügt.`,
@@ -403,6 +408,13 @@ export const texts = {
 			title: 'Passwort zurücksetzen',
 			emailLabel: 'Deine E-Mail Adresse',
 			resetButton: 'Setze mein Passwort zurück!',
+			confirm: {
+				title: 'Neues Passwort festlegen',
+				newPasswordLabel: 'Neues Passwort',
+				confirmPasswordLabel: 'Passwort bestätigen',
+				submitButton: 'Passwort speichern',
+				backToReset: 'Neuen Link anfordern',
+			},
 		},
 		updatemail: {
 			title: 'Mailadresse ändern',

--- a/src/routes/auth/reset/confirm/+page.server.ts
+++ b/src/routes/auth/reset/confirm/+page.server.ts
@@ -1,0 +1,56 @@
+import { fail, redirect } from '@sveltejs/kit';
+import type { ClientResponseError } from 'pocketbase';
+import { texts } from '$lib/texts';
+
+export async function load({ url }) {
+	return { token: url.searchParams.get('token') };
+}
+
+export const actions = {
+	confirm: async ({ locals, request, cookies }) => {
+		const data = await request.formData();
+		const token = data.get('token');
+		const password = data.get('password');
+		const passwordConfirm = data.get('passwordConfirm');
+
+		if (!token) {
+			return fail(400, { fail: true, message: texts.errors.invalidOrExpiredResetToken });
+		}
+
+		if (!password || !passwordConfirm) {
+			return fail(400, { fail: true, message: texts.errors.somethingWentWrong });
+		}
+
+		if (password.toString().length < 8) {
+			return fail(400, { fail: true, message: texts.errors.passwordTooShort });
+		}
+
+		if (password.toString() !== passwordConfirm.toString()) {
+			return fail(400, { fail: true, message: texts.errors.passwordsDoNotMatch });
+		}
+
+		try {
+			await locals.pb
+				.collection('users')
+				.confirmPasswordReset(token.toString(), password.toString(), passwordConfirm.toString());
+		} catch (error) {
+			const errorObj = error as ClientResponseError;
+			console.error('Password reset confirmation error:', errorObj);
+			return fail(400, { fail: true, message: texts.errors.invalidOrExpiredResetToken });
+		}
+
+		// universal flash pattern:
+		cookies.set(
+			'flash',
+			JSON.stringify({
+				type: 'success',
+				message: texts.success.passwordResetConfirmed,
+			}),
+			{
+				path: '/',
+				maxAge: 60, // seconds
+			}
+		);
+		redirect(303, '/auth/login');
+	},
+};

--- a/src/routes/auth/reset/confirm/+page.svelte
+++ b/src/routes/auth/reset/confirm/+page.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import type { ActionData, PageData } from './$types';
+	import { Section, Register } from 'flowbite-svelte-blocks';
+	import { Button, A } from 'flowbite-svelte';
+	import { resolve } from '$app/paths';
+	import { texts } from '$lib/texts';
+	import CustomAlert from '$lib/components/CustomAlert.svelte';
+	import PasswordInput from '$lib/components/PasswordInput.svelte';
+
+	let { data, form }: { data: PageData; form: ActionData } = $props();
+</script>
+
+<Section name="reset">
+	{#if form?.fail}
+		<div class="variant-soft-error rounded-token mb-2 px-4 py-2">
+			<CustomAlert type="error" message={form?.message} />
+		</div>
+	{/if}
+
+	<Register href={resolve('/')} class="w-full sm:max-w-md">
+		{#snippet top()}
+			{texts.pages.reset.confirm.title}
+		{/snippet}
+		<div class="space-y-4 p-6 sm:p-8 md:space-y-6">
+			{#if data.token}
+				<form class="flex flex-col space-y-5" action="?/confirm" method="post">
+					<input type="hidden" name="token" value={data.token} />
+					<PasswordInput
+						name="password"
+						label={texts.pages.reset.confirm.newPasswordLabel}
+						autocomplete="new-password"
+					/>
+					<PasswordInput
+						name="passwordConfirm"
+						label={texts.pages.reset.confirm.confirmPasswordLabel}
+						autocomplete="new-password"
+					/>
+					<Button
+						type="submit"
+						class="min-button bg-primary-200 hover:bg-primary cursor-pointer w-full"
+						>{texts.pages.reset.confirm.submitButton}</Button
+					>
+				</form>
+			{:else}
+				<CustomAlert type="error" message={texts.errors.invalidOrExpiredResetToken} />
+				<A href={resolve('/auth/reset')} class="block text-center"
+					>{texts.pages.reset.confirm.backToReset}</A
+				>
+			{/if}
+		</div>
+	</Register>
+</Section>

--- a/src/routes/auth/reset/confirm/page.server.test.ts
+++ b/src/routes/auth/reset/confirm/page.server.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { isRedirect } from '@sveltejs/kit';
+import { actions, load } from './+page.server';
+import { texts } from '$lib/texts';
+
+type ActionEvent = Parameters<typeof actions.confirm>[0];
+
+describe('Reset confirm page', () => {
+	let mockLocals: { pb: { collection: ReturnType<typeof vi.fn> } };
+	let mockCookies: { set: ReturnType<typeof vi.fn> };
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		mockCookies = { set: vi.fn() };
+
+		mockLocals = {
+			pb: {
+				collection: vi.fn(() => ({
+					confirmPasswordReset: vi.fn().mockResolvedValue(undefined),
+				})),
+			},
+		};
+	});
+
+	function buildRequest(fields: Record<string, string>) {
+		const data = new FormData();
+		for (const [key, value] of Object.entries(fields)) {
+			data.append(key, value);
+		}
+		return { formData: vi.fn().mockResolvedValue(data) };
+	}
+
+	function callConfirm(request: ReturnType<typeof buildRequest>) {
+		return actions.confirm({
+			locals: mockLocals,
+			request,
+			cookies: mockCookies,
+		} as unknown as ActionEvent);
+	}
+
+	describe('load', () => {
+		it('returns the token from the URL', async () => {
+			const url = new URL('https://allerleih.org/auth/reset/confirm?token=abc123');
+			expect(await load({ url } as Parameters<typeof load>[0])).toEqual({ token: 'abc123' });
+		});
+
+		it('returns null when no token is present', async () => {
+			const url = new URL('https://allerleih.org/auth/reset/confirm');
+			expect(await load({ url } as Parameters<typeof load>[0])).toEqual({ token: null });
+		});
+	});
+
+	describe('actions.confirm', () => {
+		it('fails when the token is missing', async () => {
+			const request = buildRequest({ password: 'password123', passwordConfirm: 'password123' });
+
+			const result = await callConfirm(request);
+
+			expect(result?.status).toBe(400);
+			expect(result?.data?.message).toBe(texts.errors.invalidOrExpiredResetToken);
+		});
+
+		it('fails when the password is too short', async () => {
+			const request = buildRequest({
+				token: 'tok',
+				password: 'short',
+				passwordConfirm: 'short',
+			});
+
+			const result = await callConfirm(request);
+
+			expect(result?.status).toBe(400);
+			expect(result?.data?.message).toBe(texts.errors.passwordTooShort);
+		});
+
+		it('fails when the passwords do not match', async () => {
+			const request = buildRequest({
+				token: 'tok',
+				password: 'password123',
+				passwordConfirm: 'password456',
+			});
+
+			const result = await callConfirm(request);
+
+			expect(result?.status).toBe(400);
+			expect(result?.data?.message).toBe(texts.errors.passwordsDoNotMatch);
+		});
+
+		it('fails with an invalid-token message when PocketBase rejects the token', async () => {
+			const confirmPasswordReset = vi.fn().mockRejectedValue(new Error('invalid token'));
+			mockLocals.pb.collection = vi.fn(() => ({ confirmPasswordReset }));
+
+			const request = buildRequest({
+				token: 'expired-token',
+				password: 'password123',
+				passwordConfirm: 'password123',
+			});
+
+			const result = await callConfirm(request);
+
+			expect(result?.status).toBe(400);
+			expect(result?.data?.message).toBe(texts.errors.invalidOrExpiredResetToken);
+		});
+
+		it('confirms the reset, sets a flash cookie and redirects to login', async () => {
+			const confirmPasswordReset = vi.fn().mockResolvedValue(undefined);
+			mockLocals.pb.collection = vi.fn(() => ({ confirmPasswordReset }));
+
+			const request = buildRequest({
+				token: 'valid-token',
+				password: 'password123',
+				passwordConfirm: 'password123',
+			});
+
+			try {
+				await callConfirm(request);
+				expect.unreachable('expected redirect to be thrown');
+			} catch (error) {
+				if (!isRedirect(error)) throw error;
+				expect(error.status).toBe(303);
+				expect(error.location).toBe('/auth/login');
+			}
+
+			expect(mockLocals.pb.collection).toHaveBeenCalledWith('users');
+			expect(confirmPasswordReset).toHaveBeenCalledWith('valid-token', 'password123', 'password123');
+			expect(mockCookies.set).toHaveBeenCalledWith(
+				'flash',
+				JSON.stringify({ type: 'success', message: texts.success.passwordResetConfirmed }),
+				{ path: '/', maxAge: 60 }
+			);
+		});
+	});
+});


### PR DESCRIPTION
Implement an in-app confirmation for password resets to enhance user experience and prevent routing to the PocketBase UI. This includes validation for token, password length, and matching passwords, along with appropriate error messages. 