### PR TITLE
Read trust & privacy data through the new backend hooks, collections, and views (+ trustees-only items in search)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Documentation for [AllerLeih](https://github.com/share-open-sharing-infrastructu
 
 - [architecture.md](architecture.md) — system overview: tech stack, deployment pipeline, auth flow, AI integrations, and external API boundaries. **Start here.**
 - [domain-model.md](domain-model.md) — conceptual model: class diagrams, lending workflow state machine, trust model, and institutional partner model.
-- [data-model.md](data-model.md) — ER diagram mapping directly onto PocketBase collections and the `items_public` SQL view.
+- [data-model.md](data-model.md) — ER diagram mapping directly onto PocketBase collections and the `items_public` / `items_searchable` SQL views.
 - [best-practices.md](best-practices.md) — SvelteKit form patterns and Svelte 5 reactivity conventions used throughout the codebase.
 - [testing-strategy.md](testing-strategy.md) — testing approach (Vitest unit tests), CI integration, and example patterns.
 - [text-management.md](text-management.md) — centralized German UI string system (`src/lib/texts.ts`) and full category reference.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,12 +18,13 @@ graph TD
     Browser -->|"HTTP (pages + form actions)"| SK
     Browser -->|"WebSocket subscription"| PB
     SK -->|"PocketBase SDK — per-request"| PB
-    SK -->|"REST — server-side only"| ORS
+    SK -->|"REST — geocoding (server-side)"| ORS
+    PB -->|"REST — travel times (server-side hook)"| ORS
     SK -->|"REST — server-side only"| Mistral
     SK -->|"Web Push VAPID — server-side"| Push
 ```
 
-**Key constraint:** All calls to external services (ORS, Mistral, Web Push) are made server-side only. Raw geolocation coordinates and API credentials never reach the browser. The browser connects directly to PocketBase only for real-time WebSocket subscriptions — and only with a token passed through `page.data`, since the auth cookie is httpOnly.
+**Key constraint:** All calls to external services (ORS, Mistral, Web Push) are made server-side only. Raw geolocation coordinates and API credentials never reach the browser. User coordinates live in an **owner-only** `user_geolocations` collection (only the owner can read their own row) and are read solely by a PocketBase backend hook (`POST /api/travel-times`) that calls ORS and returns only bucketed minutes — so travel-time ORS calls run from the backend and coordinates never leave it. The browser connects directly to PocketBase only for real-time WebSocket subscriptions — and only with a token passed through `page.data`, since the auth cookie is httpOnly.
 
 ---
 
@@ -51,6 +52,15 @@ For client-side PocketBase WebSocket subscriptions (live chat), the auth token i
 | Static | `/misc/contact`, `/misc/imprint`, `/misc/privacy`, `/misc/tos`, `/misc/guide`, `/sitemap.xml` | No |
 
 All mutations go through SvelteKit **form actions** (`action="?/actionName"`). There is no REST API layer between the frontend and PocketBase — server load functions fetch data, form actions write it.
+
+### PocketBase server hooks (`pb_hooks`)
+
+Some logic runs inside PocketBase itself (JS hooks) so it can use backend privileges without exposing data to the client:
+
+| Hook route | Auth | Purpose |
+|---|---|---|
+| `GET /api/invite/{code}` | public | Resolves an invite code to `{ id, username }` only, so guests can follow `/invite/<code>` without the public user view exposing every code |
+| `POST /api/travel-times` | required | Reads owner coordinates from the owner-only `user_geolocations` collection, calls ORS, and returns only bucketed minutes (coordinates never leave the backend). The SvelteKit `/api/travel-times/{item,search}` endpoints relay to this hook. |
 
 ---
 
@@ -80,7 +90,7 @@ All mutations go through SvelteKit **form actions** (`action="?/actionName"`). T
 | Service | Direction | Purpose | Notes |
 |---|---|---|---|
 | OpenRouteService (ORS) | Server → ORS | Address autocomplete (`/api/geocode`) | Restricted to Germany (`boundary.country=DEU`) |
-| OpenRouteService (ORS) | Server → ORS | Travel time matrix (`/api/travel-times/*`) | Supports foot, bicycle, car; coordinates never sent to browser |
+| OpenRouteService (ORS) | PocketBase hook → ORS | Travel time matrix (`POST /api/travel-times` hook) | Supports foot, bicycle, car; reads coords from owner-only `user_geolocations`, returns only bucketed minutes; SvelteKit `/api/travel-times/{item,search}` relay to it |
 | Mistral AI | Server → Mistral | Item photo analysis (`/api/analyze-item`) | pixtral-12b-2409 vision model; server-side only |
 | Web Push (VAPID) | Server → Push service | Push notifications | Per-device subscriptions stored in `push_subscriptions`; stale subscriptions auto-removed on HTTP 410/404 |
 
@@ -93,7 +103,7 @@ All mutations go through SvelteKit **form actions** (`action="?/actionName"`). T
 - **Process restart:** `supervisorctl restart svelte`
 - **Build-time secrets injected:** `PUBLIC_PB_URL`, `ORS_API_KEY`, `MISTRAL_API_KEY`, VAPID keys (`PUBLIC_VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`), `LOGIN_SECRET`
 - **Body size limit:** 10 MB, set via `BODY_SIZE_LIMIT` env var on the server after each deploy
-- **PocketBase:** runs as a separate process on Uberspace; SQLite data and file uploads live on the server filesystem — not managed by the CI/CD pipeline
+- **PocketBase:** runs as a separate process on Uberspace (repo `allerleih-backend`; schema + JS hooks version-controlled, migrations auto-applied on start); SQLite data and file uploads live on the server filesystem — not managed by the SvelteKit CI/CD pipeline. ⚠️ The backend now requires **`ORS_API_KEY`** in **its own** environment (used by the `/api/travel-times` hook) — not only in the SvelteKit build.
 
 **CI on pull requests:** Vitest runs with coverage (json + lcov) on every PR to `main` via `.github/workflows/vitest.yaml`. Coverage is posted as a PR comment via `davelosert/vitest-coverage-report-action`. The build step also catches TypeScript and Svelte compilation errors before merging.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,6 +61,7 @@ Some logic runs inside PocketBase itself (JS hooks) so it can use backend privil
 |---|---|---|
 | `GET /api/invite/{code}` | public | Resolves an invite code to `{ id, username }` only, so guests can follow `/invite/<code>` without the public user view exposing every code |
 | `POST /api/travel-times` | required | Reads owner coordinates from the owner-only `user_geolocations` collection, calls ORS, and returns only bucketed minutes (coordinates never leave the backend). The SvelteKit `/api/travel-times/{item,search}` endpoints relay to this hook. |
+| `GET /api/contact/{userId}` | required | Returns a user's telegram/signal handles for the caller, honouring the per-handle "visible to trusted only" flags + trust at the data layer (handles live in the owner-only `user_contacts` collection). |
 
 ---
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -24,7 +24,6 @@ erDiagram
         bool telegramVisibleToTrustedOnly
         string signalLink
         bool signalVisibleToTrustedOnly
-        json geolocation "GeoPoint lat/lon"
         string preferredTransportMode "foot|bicycle|car"
         bool hasOnboarded
         string inviteCode
@@ -35,6 +34,14 @@ erDiagram
     }
 
     USER 1 to zero or more USER: "trusts"
+
+    USER_GEOLOCATION{
+        string id PK
+        User user FK "owner only — unique"
+        json geolocation "GeoPoint lat/lon"
+    }
+
+    USER 1 to zero or one USER_GEOLOCATION: "location (private)"
 
     ITEM{
         string id PK
@@ -167,17 +174,21 @@ erDiagram
     ITEM 1 to zero or more OUTBOUND_CLICK: tracked by
 ```
 
+## user_geolocations
+
+Coordinates are **not** stored on `users` — they live in a separate `user_geolocations` collection so they can be locked to the owner. All API rules (`listRule`/`viewRule`/`createRule`/`updateRule`/`deleteRule`) are `@request.auth.id = user`, so a user can only ever read/write **their own** row; no account can query another user's coordinates. The `users` collection no longer has a `geolocation` field at all. Travel-time computation reads coordinates with backend privileges via the `/api/travel-times` hook (see below).
+
 ## items_public View
 
-`items_public` is a read-only PocketBase SQL view — not a writeable collection. It joins `items` with `users` to provide trust-filtered, privacy-safe flat rows for the search feature.
+`items_public` is a read-only PocketBase SQL view — not a writeable collection. It joins `items` with `users` (and `user_geolocations` for the location flag) to provide trust-filtered, privacy-safe flat rows for the search feature.
 
-**Key privacy guarantee:** raw `geolocation` coordinates are never included. The view exposes only `ownerHasLocation` (0 or 1), computed via a SQL expression. Travel times are calculated server-side via OpenRouteService and surfaced to the client without exposing coordinates.
+**Key privacy guarantee:** raw coordinates are never included. Coordinates live only in the owner-only `user_geolocations` collection; the view exposes just `ownerHasLocation` (0 or 1). Travel times are computed in the backend `/api/travel-times` hook, which reads coordinates server-side and returns only **bucketed minutes** — coordinates never reach the client.
 
 | Field | Source | Notes |
 |---|---|---|
 | id, name, image, externalImgUrl, externalUrl, description, trusteesOnly, status, categories, updated | items | Direct columns |
 | userId, username, trusts, isInstitution, bio, verified, profileImage, userCreated | users | Joined from owner |
-| ownerHasLocation | SQL expression | 1 if geolocation ≠ (0,0), else 0 |
+| ownerHasLocation | SQL expression on `user_geolocations` | 1 if the owner has a non-(0,0) location, else 0 |
 
 ## Impact Research: `counterfactual`
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -20,10 +20,6 @@ erDiagram
         bool isInstitution
         string profileImage
         string bio
-        string telegramUsername
-        bool telegramVisibleToTrustedOnly
-        string signalLink
-        bool signalVisibleToTrustedOnly
         string preferredTransportMode "foot|bicycle|car"
         bool hasOnboarded
         string inviteCode
@@ -42,6 +38,17 @@ erDiagram
     }
 
     USER 1 to zero or one USER_GEOLOCATION: "location (private)"
+
+    USER_CONTACT{
+        string id PK
+        User user FK "owner only — unique"
+        string telegramUsername
+        string signalLink
+        bool telegramVisibleToTrustedOnly
+        bool signalVisibleToTrustedOnly
+    }
+
+    USER 1 to zero or one USER_CONTACT: "contact handles (private)"
 
     ITEM{
         string id PK
@@ -177,6 +184,10 @@ erDiagram
 ## user_geolocations
 
 Coordinates are **not** stored on `users` — they live in a separate `user_geolocations` collection so they can be locked to the owner. All API rules (`listRule`/`viewRule`/`createRule`/`updateRule`/`deleteRule`) are `@request.auth.id = user`, so a user can only ever read/write **their own** row; no account can query another user's coordinates. The `users` collection no longer has a `geolocation` field at all. Travel-time computation reads coordinates with backend privileges via the `/api/travel-times` hook (see below).
+
+## user_contacts
+
+Messenger handles (`telegramUsername`, `signalLink`) and their per-handle "visible to trusted only" flags live here, **not** on `users`. All API rules are `@request.auth.id = user` (owner-only). They reach other users only through the `GET /api/contact/{userId}` hook, which returns a handle to a caller only if it's public (flag off), the caller is the owner, or the owner trusts the caller — so the "trusted only" toggle is enforced at the data layer, not just in the UI.
 
 ## items_public View
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -189,17 +189,31 @@ Coordinates are **not** stored on `users` — they live in a separate `user_geol
 
 Messenger handles (`telegramUsername`, `signalLink`) and their per-handle "visible to trusted only" flags live here, **not** on `users`. All API rules are `@request.auth.id = user` (owner-only). They reach other users only through the `GET /api/contact/{userId}` hook, which returns a handle to a caller only if it's public (flag off), the caller is the owner, or the owner trusts the caller — so the "trusted only" toggle is enforced at the data layer, not just in the UI.
 
-## items_public View
+## items_public and items_searchable Views
 
-`items_public` is a read-only PocketBase SQL view — not a writeable collection. It joins `items` with `users` (and `user_geolocations` for the location flag) to provide trust-filtered, privacy-safe flat rows for the search feature.
+Two read-only PocketBase SQL views expose `items` joined with `users` (and `user_geolocations` for the location flag) as flat, privacy-safe rows. Neither exposes the owner's `trusts` list, and neither includes raw coordinates — they expose only `ownerHasLocation` (0 or 1); travel times are computed in the backend `/api/travel-times` hook, which returns only **bucketed minutes** so coordinates never reach the client.
 
-**Key privacy guarantee:** raw coordinates are never included. Coordinates live only in the owner-only `user_geolocations` collection; the view exposes just `ownerHasLocation` (0 or 1). Travel times are computed in the backend `/api/travel-times` hook, which reads coordinates server-side and returns only **bucketed minutes** — coordinates never reach the client.
+### `items_public` — public, content-masked
+
+Fully public (`listRule`/`viewRule` are open). For **trustees-only** items the content columns (`name`, `image`, `externalImgUrl`, `externalUrl`, `description`) are masked to `NULL`; only metadata (`categories`, `status`, owner, `trusteesOnly`) stays visible — so the *existence* of a trustees-only item can be shown without leaking its details. The profile and item-detail pages read from this view and, for the owner and trusted viewers, fetch the unmasked details from the base `items` collection (trust rule below).
+
+### `items_searchable` — trust-filtered, unmasked
+
+Used by the search page. Its row-level rule
+`trusteesOnly = false || (@request.auth.id != "" && (@request.auth.id = userId || userId.trusts.id ?= @request.auth.id))`
+returns public items to everyone, and trustees-only items only to the owner and to users the owner trusts. Content is **not** masked here, because rows a viewer may not see are filtered out entirely. The owner's `trusts` list is only traversed inside the rule, never returned as a column.
 
 | Field | Source | Notes |
 |---|---|---|
-| id, name, image, externalImgUrl, externalUrl, description, trusteesOnly, status, categories, updated | items | Direct columns |
-| userId, username, trusts, isInstitution, bio, verified, profileImage, userCreated | users | Joined from owner |
+| id, name, image, externalImgUrl, externalUrl, description, trusteesOnly, status, categories, updated | items | Direct columns (masked to `NULL` for trustees-only items in `items_public`) |
+| userId, username, isInstitution, bio, verified, profileImage, userCreated | users | Joined from owner (`trusts` is **not** exposed) |
 | ownerHasLocation | SQL expression on `user_geolocations` | 1 if the owner has a non-(0,0) location, else 0 |
+
+### Base `items` trust rule
+
+The base `items` collection's `listRule`/`viewRule` are
+`@request.auth.id != "" && (trusteesOnly = false || @request.auth.id = owner || owner.trusts.id ?= @request.auth.id)`,
+so a trustees-only item's full record is readable only by the owner and trusted users. The profile and item-detail pages use this to un-mask details for trusted viewers.
 
 ## Impact Research: `counterfactual`
 

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -63,6 +63,7 @@ classDiagram
 ## Item
 
 - `trusteesOnly` is `true` when the item owner wants to lend this item only to users they have explicitly trusted; otherwise `false`.
+- Visibility of `trusteesOnly` items is enforced at the **data layer**, not just the UI: the public `items_public` view masks their content (name/description/images → `NULL`) for everyone, the base `items` collection returns the full record only to the owner and trusted users, and the search view `items_searchable` returns trustees-only rows only to the owner and trusted users. See [data-model.md](data-model.md).
 - `status` reflects current availability: `available`, `unavailable` (actively on loan), or `unknown`.
 - `categories` is an array of up to 3 values drawn from the fixed `ITEM_CATEGORIES` list in `src/lib/texts.ts`.
 

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -58,7 +58,7 @@ classDiagram
 ## User entity
 
 - A user can "trust" 0 to n other users. Building on this, they can select some of their items to only be visible to their "trustees".
-- **Trust is explicit and 1-hop only.** If A trusts B and B trusts C, A does **not** automatically gain visibility of C's trustees-only items. The trust check reads directly from `item.expand.owner.trusts[]` — there is no transitive or graph-based trust resolution.
+- **Trust is explicit and 1-hop only.** If A trusts B and B trusts C, A does **not** automatically gain visibility of C's trustees-only items. The trust check is based on the item owner's `trusts` list — there is no transitive or graph-based trust resolution.
 
 ## Item
 
@@ -93,7 +93,7 @@ stateDiagram-v2
 
 | Transition | Triggered by | Side effects |
 |---|---|---|
-| → pending | Requester | Creates `Conversation` record |
+| → pending | Requester | Creates `Conversation` record. A request for a `trusteesOnly` item is only allowed if the requester is the owner or is in the owner's `trusts` — enforced by the `conversations` create rule (data layer), not just the UI. |
 | pending → accepted | Owner | Sets item `status = unavailable`; auto-rejects all other `pending` conversations for the same item; sends `request_accepted` notification |
 | pending → rejected | Owner | Sends `request_rejected` notification |
 | accepted → active | Owner | Sends `handover_confirmed` notification |

--- a/src/lib/server/contacts.ts
+++ b/src/lib/server/contacts.ts
@@ -1,0 +1,57 @@
+import type PocketBase from 'pocketbase';
+
+export type UserContact = {
+	telegramUsername: string;
+	signalLink: string;
+	telegramVisibleToTrustedOnly: boolean;
+	signalVisibleToTrustedOnly: boolean;
+};
+
+export type ResolvedContact = {
+	telegramUsername: string | null;
+	telegramHidden: boolean;
+	signalLink: string | null;
+	signalHidden: boolean;
+};
+
+/** The current user's own contact row (for prefilling their own profile/onboarding forms). */
+export async function getOwnContact(pb: PocketBase, userId: string): Promise<Partial<UserContact>> {
+	try {
+		const rec = await pb
+			.collection('user_contacts')
+			.getFirstListItem(pb.filter('user = {:u}', { u: userId }));
+		return {
+			telegramUsername: (rec.telegramUsername as string) ?? '',
+			signalLink: (rec.signalLink as string) ?? '',
+			telegramVisibleToTrustedOnly: (rec.telegramVisibleToTrustedOnly as boolean) ?? true,
+			signalVisibleToTrustedOnly: (rec.signalVisibleToTrustedOnly as boolean) ?? true,
+		};
+	} catch {
+		return {};
+	}
+}
+
+/** Upserts the current user's own contact row. */
+export async function upsertOwnContact(pb: PocketBase, userId: string, contact: UserContact): Promise<void> {
+	let existingId: string | null = null;
+	try {
+		const rec = await pb
+			.collection('user_contacts')
+			.getFirstListItem(pb.filter('user = {:u}', { u: userId }));
+		existingId = rec.id;
+	} catch {
+		// no existing row
+	}
+	const data = { user: userId, ...contact };
+	if (existingId) await pb.collection('user_contacts').update(existingId, data);
+	else await pb.collection('user_contacts').create(data);
+}
+
+/** Resolves another user's visible contact handles via the privileged `/api/contact` hook. */
+export async function fetchPartnerContact(pb: PocketBase, userId: string): Promise<ResolvedContact> {
+	try {
+		return await pb.send<ResolvedContact>(`/api/contact/${encodeURIComponent(userId)}`, { method: 'GET' });
+	} catch {
+		return { telegramUsername: null, telegramHidden: false, signalLink: null, signalHidden: false };
+	}
+}

--- a/src/lib/server/geolocation.ts
+++ b/src/lib/server/geolocation.ts
@@ -1,0 +1,40 @@
+import type PocketBase from 'pocketbase';
+
+export type GeoPoint = { lon: number; lat: number };
+
+/** Reads the current user's own stored geolocation, or null if none/null-island. */
+export async function getUserGeolocation(pb: PocketBase, userId: string): Promise<GeoPoint | null> {
+	try {
+		const rec = await pb
+			.collection('user_geolocations')
+			.getFirstListItem(pb.filter('user = {:u}', { u: userId }));
+		const geo = rec.geolocation as GeoPoint | undefined;
+		return geo && !(geo.lon === 0 && geo.lat === 0) ? geo : null;
+	} catch {
+		return null;
+	}
+}
+
+/** Upserts (or clears, when geo is null) the user's own geolocation entry. */
+export async function upsertUserGeolocation(
+	pb: PocketBase,
+	userId: string,
+	geo: GeoPoint | null
+): Promise<void> {
+	let existingId: string | null = null;
+	try {
+		const rec = await pb
+			.collection('user_geolocations')
+			.getFirstListItem(pb.filter('user = {:u}', { u: userId }));
+		existingId = rec.id;
+	} catch {
+		// no existing entry
+	}
+
+	if (geo) {
+		if (existingId) await pb.collection('user_geolocations').update(existingId, { geolocation: geo });
+		else await pb.collection('user_geolocations').create({ user: userId, geolocation: geo });
+	} else if (existingId) {
+		await pb.collection('user_geolocations').delete(existingId);
+	}
+}

--- a/src/lib/server/registration.test.ts
+++ b/src/lib/server/registration.test.ts
@@ -23,10 +23,14 @@ function mockFilter(raw: string, params?: Record<string, unknown>): string {
 	return result;
 }
 
-function makeMockPb(collectionImpl: (name: string) => object): PocketBase {
+function makeMockPb(
+	collectionImpl: (name: string) => object,
+	sendImpl?: (...args: unknown[]) => unknown
+): PocketBase {
 	return {
 		collection: vi.fn((name: string) => collectionImpl(name)),
-		filter: vi.fn(mockFilter)
+		filter: vi.fn(mockFilter),
+		send: vi.fn(sendImpl)
 	} as unknown as PocketBase;
 }
 
@@ -162,16 +166,16 @@ describe('resolveInviter', () => {
 	});
 
 	it('returns the user when invite code matches', async () => {
-		const mockGetFirstListItem = vi.fn().mockResolvedValue(stubUser);
-		const pb = makeMockPb(() => ({ getFirstListItem: mockGetFirstListItem }));
+		const mockSend = vi.fn().mockResolvedValue({ id: 'u1', username: 'inviter' });
+		const pb = makeMockPb(() => ({}), mockSend);
 		const result = await resolveInviter(pb, 'valid-code');
-		expect(result).toEqual(stubUser);
-		expect(mockGetFirstListItem).toHaveBeenCalledWith("inviteCode = 'valid-code'");
+		expect(result).toEqual({ id: 'u1', username: 'inviter' });
+		expect(mockSend).toHaveBeenCalledWith('/api/invite/valid-code', { method: 'GET' });
 	});
 
 	it('returns null when invite code is not found', async () => {
-		const mockGetFirstListItem = vi.fn().mockRejectedValue(new Error('not found'));
-		const pb = makeMockPb(() => ({ getFirstListItem: mockGetFirstListItem }));
+		const mockSend = vi.fn().mockRejectedValue(new Error('not found'));
+		const pb = makeMockPb(() => ({}), mockSend);
 		expect(await resolveInviter(pb, 'bad-code')).toBeNull();
 	});
 });

--- a/src/lib/server/registration.ts
+++ b/src/lib/server/registration.ts
@@ -69,12 +69,13 @@ export function validateRegistrationForm(data: FormData): ValidationResult {
 // Invite code lookup
 // ---------------------------------------------------------------------------
 
-export async function resolveInviter(pb: PocketBase, inviteCode: string | null): Promise<User | null> {
+export async function resolveInviter(
+	pb: PocketBase,
+	inviteCode: string | null
+): Promise<{ id: string; username: string } | null> {
 	if (!inviteCode) return null;
 	try {
-		return await pb
-			.collection('users_public')
-			.getFirstListItem<User>(pb.filter('inviteCode = {:code}', { code: inviteCode }));
+		return await pb.send(`/api/invite/${encodeURIComponent(inviteCode)}`, { method: 'GET' });
 	} catch {
 		return null;
 	}
@@ -152,7 +153,7 @@ export async function signUpForNewsletter(email: string, username: string): Prom
 	}
 }
 
-export async function handleInviterRelationship(pb: PocketBase, newUser: User, inviter: User): Promise<void> {
+export async function handleInviterRelationship(pb: PocketBase, newUser: User, inviter: { id: string }): Promise<void> {
 	try {
 		await pb.collection('users').update(newUser.id, { trusts: [inviter.id] });
 	} catch (error) {

--- a/src/lib/server/travelTimes.ts
+++ b/src/lib/server/travelTimes.ts
@@ -1,134 +1,6 @@
-import { ORS_API_KEY } from '$env/static/private';
-import type { Item, OwnerLocation } from '$lib/types/models';
+import type PocketBase from 'pocketbase';
 
 export type TransportMode = 'foot' | 'bicycle' | 'car';
-
-const ORS_PROFILE: Record<TransportMode, string> = {
-	foot: 'foot-walking',
-	bicycle: 'cycling-regular',
-	car: 'driving-car',
-};
-
-const ORS_TIMEOUT_MS = 8_000;
-// Log a warning when ORS takes longer than this — indicates degraded performance before a full timeout
-const ORS_SLOW_THRESHOLD_MS = 5_000;
-
-function isNullIsland(geo: { lon: number; lat: number } | undefined | null) {
-	return !geo || (geo.lon === 0 && geo.lat === 0);
-}
-
-/** Extracts unique owner locations from a list of items, skipping owners with no valid geolocation. */
-export function extractOwnerLocations(items: Item[]): OwnerLocation[] {
-	const seen = new Map<string, OwnerLocation>();
-	for (const item of items) {
-		const owner = item.expand?.owner;
-		if (!owner?.id || seen.has(owner.id)) continue;
-		const geo = owner.geolocation as { lon: number; lat: number } | undefined;
-		if (!isNullIsland(geo)) {
-			seen.set(owner.id, { id: owner.id, lon: geo!.lon, lat: geo!.lat });
-		}
-	}
-	return Array.from(seen.values());
-}
-
-/** Calls the ORS matrix API and returns raw travel durations in seconds, one per owner.
- * We have 500 requests per day on our free plan, use them wisely!
-*/
-async function fetchDurationsFromOrs(
-	userLocation: { lon: number; lat: number },
-	transportMode: TransportMode,
-	owners: OwnerLocation[]
-): Promise<number[]> {
-	const locations = [
-		[userLocation.lon, userLocation.lat],
-		...owners.map((o) => [o.lon, o.lat]),
-	];
-
-	const requestStart = Date.now();
-	let response: Response;
-	try {
-		response = await fetch(
-			`https://api.openrouteservice.org/v2/matrix/${ORS_PROFILE[transportMode]}`,
-			{
-				signal: AbortSignal.timeout(ORS_TIMEOUT_MS),
-				method: 'POST',
-				headers: {
-					Accept: 'application/json',
-					Authorization: ORS_API_KEY ?? '',
-					'Content-Type': 'application/json',
-				},
-				body: JSON.stringify({
-					locations,
-					sources: [0],
-					destinations: owners.map((_, i) => i + 1),
-					metrics: ['duration'],
-				}),
-			}
-		);
-	} catch (err) {
-		// Covers both network failures and AbortSignal timeout (TimeoutError)
-		console.error('[TRAVEL_DIAG]', JSON.stringify({
-			event: 'ors_error',
-			transport_mode: transportMode,
-			owner_count: owners.length,
-			duration_ms: Date.now() - requestStart,
-			error: err instanceof Error ? err.message : String(err),
-		}));
-		return [];
-	}
-
-	const durationMs = Date.now() - requestStart;
-
-	if (!response.ok) {
-		const responseBody = await response.text().catch(() => '');
-		console.error('[TRAVEL_DIAG]', JSON.stringify({
-			event: 'ors_error',
-			transport_mode: transportMode,
-			owner_count: owners.length,
-			duration_ms: durationMs,
-			status: response.status,
-			body: responseBody.slice(0, 200),
-		}));
-		return [];
-	}
-
-	if (durationMs > ORS_SLOW_THRESHOLD_MS) {
-		console.warn('[TRAVEL_DIAG]', JSON.stringify({
-			event: 'ors_slow',
-			transport_mode: transportMode,
-			owner_count: owners.length,
-			duration_ms: durationMs,
-		}));
-	}
-
-	const data = await response.json();
-	return data.durations?.[0] ?? [];
-}
-
-/**
- * Rounds minutes to a 5-minute bucket to prevent triangulation of user locations.
- * Returns the upper bound of each bucket, with 35 as the sentinel for >30 min.
- *   <5 min → 5 | 5-10 → 10 | 10-15 → 15 | 15-20 → 20 | 20-25 → 25 | 25-30 → 30 | >30 → 35
- */
-function bucketize(minutes: number): number {
-	if (minutes < 5) return 5;
-	if (minutes < 10) return 10;
-	if (minutes < 15) return 15;
-	if (minutes < 20) return 20;
-	if (minutes < 25) return 25;
-	if (minutes < 30) return 30;
-	return 35;
-}
-
-/** Maps raw ORS durations (seconds) to an owner ID → bucketed travel minutes record. */
-function mapDurationsToOwners(owners: OwnerLocation[], durations: number[]): Record<string, number> {
-	const result: Record<string, number> = {};
-	owners.forEach((owner, i) => {
-		const seconds = durations[i];
-		if (seconds != null) result[owner.id] = bucketize(Math.round(seconds / 60));
-	});
-	return result;
-}
 
 // ---------------------------------------------------------------------------
 // Server-side cache
@@ -139,19 +11,14 @@ const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 type CacheEntry = { result: Record<string, number>; expiresAt: number };
 const travelTimesCache = new Map<string, CacheEntry>();
 
-/**
- * Builds a stable cache key from the user location (rounded to ~110 m),
- * transport mode, and the sorted set of owner IDs.
- */
 function buildCacheKey(
 	userLocation: { lon: number; lat: number },
 	transportMode: TransportMode,
-	owners: OwnerLocation[]
+	ownerIds: string[]
 ): string {
 	const lat = userLocation.lat.toFixed(3);
 	const lon = userLocation.lon.toFixed(3);
-	const ownerIds = owners.map((o) => o.id).sort().join(',');
-	return `${lat}:${lon}:${transportMode}:${ownerIds}`;
+	return `${lat}:${lon}:${transportMode}:${[...ownerIds].sort().join(',')}`;
 }
 
 function getCached(key: string): Record<string, number> | null {
@@ -171,27 +38,32 @@ function setCached(key: string, result: Record<string, number>) {
 // ---------------------------------------------------------------------------
 
 /**
- * Returns a map of owner ID → travel minutes from `userLocation` to the given owners.
- * Results are cached server-side for 10 minutes per (location, mode, owner set).
+ * Returns a map of owner ID → bucketed travel minutes from `userLocation`.
+ * Coordinate lookup + ORS call happen in the backend `/api/travel-times` hook
+ * so owner coordinates never reach this server or the client. Cached 10 min.
  */
 export async function getTravelTimesForOwners(
+	pb: PocketBase,
 	userLocation: { lon: number; lat: number },
 	transportMode: TransportMode,
-	owners: OwnerLocation[]
+	ownerIds: string[]
 ): Promise<Record<string, number>> {
-	if (owners.length === 0) return {};
+	if (ownerIds.length === 0) return {};
 
-	const cacheKey = buildCacheKey(userLocation, transportMode, owners);
+	const cacheKey = buildCacheKey(userLocation, transportMode, ownerIds);
 	const cached = getCached(cacheKey);
 	if (cached) return cached;
 
 	try {
-		const durations = await fetchDurationsFromOrs(userLocation, transportMode, owners);
-		const result = mapDurationsToOwners(owners, durations);
-		setCached(cacheKey, result);
-		return result;
+		const result = await pb.send<Record<string, number>>('/api/travel-times', {
+			method: 'POST',
+			body: { transportMode, userLocation, ownerIds },
+		});
+		const safe = result ?? {};
+		setCached(cacheKey, safe);
+		return safe;
 	} catch (err) {
-		console.error('ORS fetch failed:', err);
+		console.error('Travel-times hook failed:', err);
 		return {};
 	}
 }

--- a/src/lib/types/models.ts
+++ b/src/lib/types/models.ts
@@ -202,7 +202,6 @@ export interface ItemPublic extends PocketBaseEntity {
 	/** joined user fields */
     userId: UserId;
 	username: string;
-	trusts: string[]; 
 	isInstitution: boolean;
 	bio: string;
 	verified: boolean;

--- a/src/routes/api/travel-times/item/+server.ts
+++ b/src/routes/api/travel-times/item/+server.ts
@@ -36,29 +36,24 @@ export async function POST({ request, locals }) {
 		error(400, 'Invalid user location');
 	}
 
-	let ownerGeo: { lon: number; lat: number } | null = null;
 	let ownerId: string | null = null;
-
 	try {
-		const item = await locals.pb.collection('items').getOne(itemId, { expand: 'owner' });
-		ownerId = item.expand?.owner?.id ?? null;
-		const geo = item.expand?.owner?.geolocation as { lon: number; lat: number } | undefined;
-		if (geo && !(geo.lon === 0 && geo.lat === 0)) {
-			ownerGeo = geo;
-		}
+		const item = await locals.pb.collection('items').getOne(itemId);
+		ownerId = (item.owner as string) ?? null;
 	} catch (err) {
 		const e = err as Partial<ClientResponseError>;
 		error(e.status === 404 ? 404 : 500, 'Item not found');
 	}
 
-	if (!ownerGeo || !ownerId) {
+	if (!ownerId) {
 		return json({ minutes: null });
 	}
 
 	const result = await getTravelTimesForOwners(
+		locals.pb,
 		userLocation as { lon: number; lat: number },
 		transportMode as TransportMode,
-		[{ id: ownerId, lon: ownerGeo.lon, lat: ownerGeo.lat }]
+		[ownerId]
 	);
 
 	return json({ minutes: result[ownerId] ?? null });

--- a/src/routes/api/travel-times/search/+server.ts
+++ b/src/routes/api/travel-times/search/+server.ts
@@ -1,6 +1,5 @@
 import { json, error } from '@sveltejs/kit';
 import { getTravelTimesForOwners, type TransportMode } from '$lib/server/travelTimes';
-import type { ClientResponseError } from 'pocketbase';
 
 const VALID_MODES = new Set<string>(['foot', 'bicycle', 'car']);
 const MAX_OWNERS = 50;
@@ -32,26 +31,11 @@ export async function POST({ request, locals }) {
 	if (ownerIds.length > MAX_OWNERS) error(400, 'Too many owners');
 	if (ownerIds.some((id: unknown) => typeof id !== 'string' || !PB_ID_RE.test(id))) error(400, 'Invalid owner ID format');
 
-	const idFilter = ownerIds.map((id: string) => `id = "${id}"`).join(' || ');
-
-	let users: { id: string; geolocation?: { lon: number; lat: number } }[] = [];
-	try {
-		users = await locals.pb.collection('users').getFullList({ filter: idFilter, fields: 'id,geolocation' });
-	} catch (err) {
-		const e = err as Partial<ClientResponseError>;
-		error(e.status === 403 ? 403 : 500, 'Failed to fetch owner locations');
-	}
-
-	const ownersWithGeo = users
-		.filter((u) => u.geolocation && !(u.geolocation.lon === 0 && u.geolocation.lat === 0))
-		.map((u) => ({ id: u.id, lon: u.geolocation!.lon, lat: u.geolocation!.lat }));
-
-	if (ownersWithGeo.length === 0) return json({});
-
 	const result = await getTravelTimesForOwners(
+		locals.pb,
 		userLocation as { lon: number; lat: number },
 		transportMode as TransportMode,
-		ownersWithGeo
+		ownerIds as string[]
 	);
 
 	return json(result);

--- a/src/routes/auth/register/+page.server.ts
+++ b/src/routes/auth/register/+page.server.ts
@@ -1,6 +1,5 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { texts } from '$lib/texts';
-import type { User } from '$lib/types/models';
 import { generateInviteSlug } from '$lib/inviteSlug';
 import {
 	validateRegistrationForm,
@@ -23,9 +22,10 @@ export async function load({ locals, url }) {
 	}
 
 	try {
-		const inviter = await locals.pb
-			.collection('users_public')
-			.getFirstListItem<User>(locals.pb.filter('inviteCode = {:code}', { code: inviteCode }));
+		const inviter = await locals.pb.send<{ id: string; username: string }>(
+			`/api/invite/${encodeURIComponent(inviteCode)}`,
+			{ method: 'GET' }
+		);
 		return { inviter: { id: inviter.id, username: inviter.username }, inviteCode };
 	} catch {
 		return { inviter: null, inviteCode };

--- a/src/routes/auth/register/+page.svelte
+++ b/src/routes/auth/register/+page.svelte
@@ -18,7 +18,7 @@
 	let usernameStatus: 'idle' | 'checking' | 'available' | 'taken' | 'invalid' = $state('idle');
 	const checkUsername = debounce(async (value: string) => {
 		try {
-			await pb.collection('users_public').getFirstListItem(`username = "${value}"`);
+			await pb.collection('users_public').getFirstListItem(pb.filter('username = {:username}', { username: value }));
 			usernameStatus = 'taken';
 		} catch {
 			usernameStatus = 'available';

--- a/src/routes/conversations/[conversationId]/+page.server.ts
+++ b/src/routes/conversations/[conversationId]/+page.server.ts
@@ -5,6 +5,7 @@ import type { Conversation, CounterfactualAnswer } from '$lib/types/models.js';
 import { texts } from '$lib/texts';
 import * as lending from './lending.server.js';
 import * as messaging from './conversation.server.js';
+import { fetchPartnerContact } from '$lib/server/contacts';
 
 export async function load({ params, locals }) {
 	const conversationId: string = params.conversationId;
@@ -73,7 +74,13 @@ export async function load({ params, locals }) {
 		}
 	}
 
-	return { conversation, PB_URL: PUBLIC_PB_URL };
+	const partnerId =
+		conversationRecord.requester === locals.user?.id
+			? conversationRecord.itemOwner
+			: conversationRecord.requester;
+	const partnerContact = await fetchPartnerContact(locals.pb, partnerId);
+
+	return { conversation, PB_URL: PUBLIC_PB_URL, partnerContact };
 }
 
 export const actions = {

--- a/src/routes/conversations/[conversationId]/+page.svelte
+++ b/src/routes/conversations/[conversationId]/+page.svelte
@@ -142,7 +142,7 @@
 	PB_URL={PUBLIC_PB_URL}
 	onDelete={() => (deleteConversationModal = true)}
 	{loggedInUserIsItemOwner}
-	currentUser={data.currentUser}
+	partnerContact={data.partnerContact}
 />
 
 <LendingStatusBar

--- a/src/routes/conversations/[conversationId]/ConversationHeader.svelte
+++ b/src/routes/conversations/[conversationId]/ConversationHeader.svelte
@@ -10,42 +10,24 @@
 	import telegramLogo from '$lib/images/telegram-logo.svg';
 	import signalLogo from '$lib/images/Signal-Logo-White.svg';
 
-	let { chatPartner, conversation, PB_URL, onDelete, loggedInUserIsItemOwner = false, currentUser } : {
+	let { chatPartner, conversation, PB_URL, onDelete, loggedInUserIsItemOwner = false, partnerContact } : {
 		chatPartner: User;
 		conversation: Conversation;
 		PB_URL: string;
 		onDelete?: () => void;
 		loggedInUserIsItemOwner?: boolean;
-		currentUser: User;
+		partnerContact: { telegramUsername: string | null; telegramHidden: boolean; signalLink: string | null; signalHidden: boolean };
 	} = $props();
 
-	const isUserTrusted = $derived(chatPartner.trusts?.includes(currentUser.id) ?? false);
+	// Visibility (trusted-only handling) is resolved server-side by the /api/contact
+	// hook; here we just render what the partner is allowed to see.
+	const telegramAvailable = $derived(!!partnerContact?.telegramUsername);
+	const telegramHidden = $derived(!!partnerContact?.telegramHidden);
+	const signalAvailable = $derived(!!partnerContact?.signalLink);
+	const signalHidden = $derived(!!partnerContact?.signalHidden);
 
-	const telegramAvailable = $derived(
-		!!(chatPartner.telegramUsername &&
-			chatPartner.telegramUsername.trim() !== '' &&
-			(!chatPartner.telegramVisibleToTrustedOnly || isUserTrusted))
-	);
-	const telegramHidden = $derived(
-		!!(chatPartner.telegramUsername &&
-			chatPartner.telegramUsername.trim() !== '' &&
-			chatPartner.telegramVisibleToTrustedOnly &&
-			!isUserTrusted)
-	);
-	const signalAvailable = $derived(
-		!!(chatPartner.signalLink &&
-			chatPartner.signalLink.trim() !== '' &&
-			(!chatPartner.signalVisibleToTrustedOnly || isUserTrusted))
-	);
-	const signalHidden = $derived(
-		!!(chatPartner.signalLink &&
-			chatPartner.signalLink.trim() !== '' &&
-			chatPartner.signalVisibleToTrustedOnly &&
-			!isUserTrusted)
-	);
-
-	const telegramLink = $derived(telegramAvailable ? `https://t.me/${chatPartner.telegramUsername}` : null);
-	const signalLink = $derived(signalAvailable ? (chatPartner.signalLink ?? null) : null);
+	const telegramLink = $derived(telegramAvailable ? `https://t.me/${partnerContact.telegramUsername}` : null);
+	const signalLink = $derived(signalAvailable ? partnerContact.signalLink : null);
 
 	const showMessengerSection = $derived(telegramAvailable || telegramHidden || signalAvailable || signalHidden);
 

--- a/src/routes/invite/[slug]/+page.server.ts
+++ b/src/routes/invite/[slug]/+page.server.ts
@@ -1,12 +1,11 @@
-import type { User } from '$lib/types/models';
-
 export async function load({ locals, params }) {
 	const { slug } = params;
 
 	try {
-		const inviter = await locals.pb
-			.collection('users_public')
-			.getFirstListItem<User>(locals.pb.filter('inviteCode = {:code}', { code: slug }));
+		const inviter = await locals.pb.send<{ id: string; username: string }>(
+			`/api/invite/${encodeURIComponent(slug)}`,
+			{ method: 'GET' }
+		);
 		return { inviterName: inviter.username, slug };
 	} catch {
 		return { inviterName: null, slug };

--- a/src/routes/items/[id]/+page.server.ts
+++ b/src/routes/items/[id]/+page.server.ts
@@ -215,8 +215,17 @@ export const actions = {
 			targetConversationId = conversation.id;
 
 			const requesterName = locals.user.username ?? locals.user.name ?? texts.pages.itemDetail.unknownRequester;
-			const itemName = itemRecord.name ?? texts.pages.itemDetail.unknownItem;
-			const notificationBody = texts.notifications.newRequest(requesterName, itemName);
+			// items_public masks trustees-only item names; the requester is authorized
+			// (the conversation was just created), so read the real name from base items.
+			let itemName = itemRecord.name;
+			if (!itemName) {
+				try {
+					itemName = (await locals.pb.collection('items').getOne(params.id, { fields: 'name' })).name;
+				} catch {
+					// fall back to the generic label below
+				}
+			}
+			const notificationBody = texts.notifications.newRequest(requesterName, itemName ?? texts.pages.itemDetail.unknownItem);
 			const conversationUrl = `/conversations/${targetConversationId}`;
 
 			await createNotification(locals.pb, itemOwnerId, locals.user.id, 'new_request', targetConversationId, notificationBody);

--- a/src/routes/items/[id]/+page.server.ts
+++ b/src/routes/items/[id]/+page.server.ts
@@ -17,14 +17,46 @@ export async function load({ params, locals }) {
 
 	const currentUserId = locals.user?.id ?? null;
 	const isAuthenticated = locals.pb.authStore.isValid;
-	const ownerTrusts: string[] = item.trusts ?? [];
-	const isTrustRestricted =
-		item.trusteesOnly && isAuthenticated && !ownerTrusts.includes(currentUserId);
 	const isOwnItem = currentUserId === item.userId;
 	const viewerTrustsOwner = locals.user?.trusts?.includes(item.userId) ?? false;
 
 	// Whether the item owner trusts the logged-in viewer (Owner → Viewer direction).
-	const ownerTrustsViewer = currentUserId ? ownerTrusts.includes(currentUserId) : false;
+	// Resolved server-side so the owner's trusts list never reaches the client
+	// (items_public no longer exposes it).
+	let ownerTrustsViewer = false;
+	if (currentUserId && !isOwnItem) {
+		try {
+			await locals.pb
+				.collection('users')
+				.getFirstListItem(
+					locals.pb.filter('id = {:oid} && trusts.id ?= {:vid}', { oid: item.userId, vid: currentUserId }),
+					{ fields: 'id' }
+				);
+			ownerTrustsViewer = true;
+		} catch {
+			ownerTrustsViewer = false;
+		}
+	}
+
+	const isTrustRestricted =
+		item.trusteesOnly && isAuthenticated && !isOwnItem && !ownerTrustsViewer;
+
+	// items_public masks trustees-only items (name/image/description are NULL). The owner
+	// and trusted viewers may see full details, read here from the trust-gated base `items`.
+	if (item.trusteesOnly && (isOwnItem || ownerTrustsViewer)) {
+		try {
+			const full = await locals.pb.collection('items').getOne(item.id, {
+				fields: 'id,name,image,externalImgUrl,externalUrl,description',
+			});
+			item.name = full.name;
+			item.image = full.image;
+			item.externalImgUrl = full.externalImgUrl;
+			item.externalUrl = full.externalUrl;
+			item.description = full.description;
+		} catch (err) {
+			console.error('Failed to load trusted item details', err);
+		}
+	}
 
 	// Find an in-progress conversation for this viewer + item so the CTA can link
 	// to it instead of creating a duplicate. We exclude rejected/completed states

--- a/src/routes/onboarding/+page.server.ts
+++ b/src/routes/onboarding/+page.server.ts
@@ -6,6 +6,7 @@ import type { User } from '$lib/types/models';
 import { createNotification, sendPushToUser } from '$lib/server/notifications';
 import { generateInviteSlug } from '$lib/inviteSlug';
 import { getUserGeolocation, upsertUserGeolocation } from '$lib/server/geolocation';
+import { getOwnContact, upsertOwnContact } from '$lib/server/contacts';
 
 export async function load({ locals, url }) {
 	let inviteCode = locals.user.inviteCode as string | undefined;
@@ -16,6 +17,7 @@ export async function load({ locals, url }) {
 
 	const users = await locals.pb.collection('users').getFullList<User>();
 	const geolocation = await getUserGeolocation(locals.pb, locals.user.id);
+	const contact = await getOwnContact(locals.pb, locals.user.id);
 
 	return {
 		PB_URL: PUBLIC_PB_URL,
@@ -24,6 +26,7 @@ export async function load({ locals, url }) {
 		users,
 		trustIds: (locals.user.trusts as string[]) ?? [],
 		geolocation,
+		contact,
 	};
 }
 
@@ -127,7 +130,12 @@ export const actions = {
 	complete: async ({ locals, request }) => {
 		const formData = await request.formData();
 
-		const updateData: Record<string, any> = { hasOnboarded: true };
+		const contact = {
+			telegramUsername: '',
+			signalLink: '',
+			telegramVisibleToTrustedOnly: formData.get('telegramVisibleToTrustedOnly') === 'on',
+			signalVisibleToTrustedOnly: formData.get('signalVisibleToTrustedOnly') === 'on',
+		};
 
 		const telegramUsername = formData.get('telegramUsername')?.toString();
 		if (telegramUsername !== undefined) {
@@ -137,12 +145,9 @@ export const actions = {
 				if (!/^[a-zA-Z0-9_]{5,32}$/.test(cleaned)) {
 					return fail(400, { error: true, message: texts.errors.invalidTelegramUsername });
 				}
-				updateData['telegramUsername'] = cleaned;
+				contact.telegramUsername = cleaned;
 			}
 		}
-
-		updateData['telegramVisibleToTrustedOnly'] =
-			formData.get('telegramVisibleToTrustedOnly') === 'on';
 
 		const signalLink = formData.get('signalLink')?.toString();
 		if (signalLink !== undefined) {
@@ -151,15 +156,13 @@ export const actions = {
 				if (!trimmed.includes('signal.me')) {
 					return fail(400, { error: true, message: texts.errors.invalidSignalLink });
 				}
-				updateData['signalLink'] = trimmed;
+				contact.signalLink = trimmed;
 			}
 		}
 
-		updateData['signalVisibleToTrustedOnly'] =
-			formData.get('signalVisibleToTrustedOnly') === 'on';
-
 		try {
-			await locals.pb.collection('users').update(locals.user.id, updateData);
+			await locals.pb.collection('users').update(locals.user.id, { hasOnboarded: true });
+			await upsertOwnContact(locals.pb, locals.user.id, contact);
 			return { success: true };
 		} catch {
 			return fail(500, { error: true, message: texts.errors.somethingWentWrong });

--- a/src/routes/onboarding/+page.server.ts
+++ b/src/routes/onboarding/+page.server.ts
@@ -5,6 +5,7 @@ import { PUBLIC_PB_URL } from '../../hooks.server';
 import type { User } from '$lib/types/models';
 import { createNotification, sendPushToUser } from '$lib/server/notifications';
 import { generateInviteSlug } from '$lib/inviteSlug';
+import { getUserGeolocation, upsertUserGeolocation } from '$lib/server/geolocation';
 
 export async function load({ locals, url }) {
 	let inviteCode = locals.user.inviteCode as string | undefined;
@@ -14,6 +15,7 @@ export async function load({ locals, url }) {
 	}
 
 	const users = await locals.pb.collection('users').getFullList<User>();
+	const geolocation = await getUserGeolocation(locals.pb, locals.user.id);
 
 	return {
 		PB_URL: PUBLIC_PB_URL,
@@ -21,6 +23,7 @@ export async function load({ locals, url }) {
 		username: locals.user.username as string,
 		users,
 		trustIds: (locals.user.trusts as string[]) ?? [],
+		geolocation,
 	};
 }
 
@@ -35,20 +38,22 @@ export const actions = {
 			updateData['city'] = city.trim();
 		}
 
+		let geo: { lon: number; lat: number } | null | undefined;
 		const geoLon = formData.get('geolocation_lon')?.toString();
 		const geoLat = formData.get('geolocation_lat')?.toString();
 		if (geoLon && geoLat) {
 			const lon = parseFloat(geoLon);
 			const lat = parseFloat(geoLat);
 			if (!isNaN(lon) && !isNaN(lat)) {
-				updateData['geolocation'] = { lon, lat };
+				geo = { lon, lat };
 			}
 		} else if (city === '') {
-			updateData['geolocation'] = null;
+			geo = null;
 		}
 
 		try {
 			await locals.pb.collection('users').update(locals.user.id, updateData);
+			if (geo !== undefined) await upsertUserGeolocation(locals.pb, locals.user.id, geo);
 			return { success: true };
 		} catch {
 			return fail(500, { error: true, message: texts.errors.somethingWentWrong });

--- a/src/routes/onboarding/+page.svelte
+++ b/src/routes/onboarding/+page.svelte
@@ -70,7 +70,7 @@
 			<StepLocation
 				onNext={next}
 				initialCity={data.currentUser.city}
-				initialGeolocation={data.currentUser.geolocation?.lon || data.currentUser.geolocation?.lat ? data.currentUser.geolocation : null}
+				initialGeolocation={data.geolocation}
 			/>
 		{:else if step === 6}
 			<StepTransportMode onNext={next} preferredTransportMode={data.currentUser.preferredTransportMode} />

--- a/src/routes/onboarding/+page.svelte
+++ b/src/routes/onboarding/+page.svelte
@@ -75,7 +75,7 @@
 		{:else if step === 6}
 			<StepTransportMode onNext={next} preferredTransportMode={data.currentUser.preferredTransportMode} />
 		{:else if step === 7}
-			<StepContact onNext={next} currentUser={data.currentUser} />
+			<StepContact onNext={next} currentUser={data.contact} />
 		{:else if step === 8}
 			<StepTrustees
 				onNext={next}

--- a/src/routes/search/+page.server.ts
+++ b/src/routes/search/+page.server.ts
@@ -19,7 +19,7 @@ export async function load({ locals, url }) {
 
 	let result: ListResult<ItemPublic> = { page: 1, perPage: fetchPerPage, totalItems: 0, totalPages: 0, items: [] };
 	try {
-		result = await locals.pb.collection('items_public').getList<ItemPublic>(fetchPage, fetchPerPage, {
+		result = await locals.pb.collection('items_searchable').getList<ItemPublic>(fetchPage, fetchPerPage, {
 			sort: fetchSort,
 			filter,
 		});

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -167,7 +167,6 @@
 			PB_IMG_URL={data.PB_IMG_URL}
 			{travelTimes}
 			transportMode={transportMode ?? undefined}
-			currentUserId={data.currentUser?.id}
 		/>
 	{/if}
 

--- a/src/routes/search/ItemCard.svelte
+++ b/src/routes/search/ItemCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { ItemPublic } from '$lib/types/models';
 	import { Card } from 'flowbite-svelte';
-	import { UserCircleOutline, HeartSolid, HomeOutline } from 'flowbite-svelte-icons';
+	import { UserCircleOutline, HomeOutline } from 'flowbite-svelte-icons';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { texts } from '$lib/texts';
@@ -19,7 +19,6 @@
 		/** Travel time in minutes. undefined = not yet fetched, null = owner has no location */
 		travelMinutes?: number | null;
 		transportMode?: TransportMode;
-		currentUserId?: string;
 	}
 	let {
 		item,
@@ -28,12 +27,8 @@
 		profileView = false,
 		travelMinutes,
 		transportMode = 'bicycle',
-		currentUserId,
 	}: Props = $props();
 
-	const isTrusted = $derived(
-		!!currentUserId && !!item.trusts.includes(currentUserId)
-	);
 	const isInstitution = $derived(!!item.isInstitution);
 	const hasRealImage = $derived(!!imgUrl);
 	const categoryPlaceholder = $derived(getCategoryPlaceholder(item.categories));
@@ -97,9 +92,7 @@
 						e.preventDefault();
 						goto(resolve('/users/[id]', { id: item.userId ?? '' }));
 					}}
-					class="relative inline-flex items-center rounded-full border hover:cursor-pointer pl-1 pr-2 py-0.5 {isTrusted
-						? 'bg-green-50/90 text-green-800 border-green-300 hover:bg-green-100/90'
-						: 'bg-white/90 text-tinte-700 border-tinte-300 hover:bg-tinte-50/90'}"
+					class="relative inline-flex items-center rounded-full border hover:cursor-pointer pl-1 pr-2 py-0.5 bg-white/90 text-tinte-700 border-tinte-300 hover:bg-tinte-50/90"
 				>
 					{#if ownerImgUrl}
 						<img src={ownerImgUrl} alt="" class="h-6 w-6 rounded-full object-cover" />
@@ -112,9 +105,6 @@
 					<div class="absolute top-0 -right-1.5 flex flex-col gap-0.1 items-center">
 						{#if item.verified}
 							<VerifiedIcon class="h-3.5 w-3.5" />
-						{/if}
-						{#if isTrusted}
-							<HeartSolid class="h-3.5 w-3.5 text-green-500 bg-white rounded-full" />
 						{/if}
 					</div>
 				</button>

--- a/src/routes/search/ResultsList.svelte
+++ b/src/routes/search/ResultsList.svelte
@@ -10,13 +10,11 @@
 		PB_IMG_URL,
 		travelTimes = {},
 		transportMode = 'bicycle',
-		currentUserId,
 	}: {
 		filteredItemList: ItemPublic[];
 		PB_IMG_URL: string;
 		travelTimes: Record<string, number | null>;
 		transportMode?: TransportMode;
-		currentUserId?: string;
 	} = $props();
 </script>
 
@@ -30,7 +28,6 @@
 				: undefined}
 			travelMinutes={travelTimes[item.userId]}
 			{transportMode}
-			{currentUserId}
 		/>
 	{/each}
 </Gallery>

--- a/src/routes/search/searchFilter.ts
+++ b/src/routes/search/searchFilter.ts
@@ -65,12 +65,13 @@ export function parseSearchParameters(url: URL): SearchParameters {
 }
 
 /**
- * Builds the complete PocketBase filter string for the `items_public` view by combining all
- * active search constraints (name, owner, categories, trust, availability, owner type) with `&&`.
+ * Builds the complete PocketBase filter string for the `items_searchable` view by combining all
+ * active search constraints (name, owner, categories, availability, owner type) with `&&`.
+ * Trust-based visibility is enforced by the view's own rule, not here.
  * All field references are validated at compile time via `col()` against `ItemPublic`.
  * @param params the parsed search parameters produced by `parseSearchParameters`
  * @param userId the id of the logged-in user, or `undefined` if unauthenticated; used to exclude
- *   the user's own items and to apply trust-based visibility rules
+ *   the user's own items from results
  * @returns a PocketBase filter string, or `undefined` if no constraints are active
  */
 export function buildItemFilter(params: SearchParameters, userId?: string): string | undefined {
@@ -84,10 +85,9 @@ export function buildItemFilter(params: SearchParameters, userId?: string): stri
 			? `(${params.selectedCategories.map((c) => `${validateFilterField('categories')} ~ '${escapeCategoryValue(c)}'`).join(params.op === 'and' ? ' && ' : ' || ')})`
 			: null;
 
-	const trustFilter = userId
-		? `(${validateFilterField('trusteesOnly')} = false || ${validateFilterField('trusts')} ~ "${userId}")`
-		: `${validateFilterField('trusteesOnly')} = false`;
-
+	// Trust visibility is enforced by the `items_searchable` view's rule (public items
+	// for everyone; trustees-only items only for the owner and users they trust), so no
+	// trust filter is applied here.
 	const availabilityFilter = params.onlyAvailable ? `${validateFilterField('status')} != 'unavailable'` : null;
 
 	const institutionFilter =
@@ -98,7 +98,7 @@ export function buildItemFilter(params: SearchParameters, userId?: string): stri
 				: null;
 
 	return (
-		[nameFilter, ownerFilter, categoryFilter, trustFilter, availabilityFilter, institutionFilter]
+		[nameFilter, ownerFilter, categoryFilter, availabilityFilter, institutionFilter]
 			.filter(Boolean)
 			.join(' && ') || undefined
 	);

--- a/src/routes/user/profile/+page.server.ts
+++ b/src/routes/user/profile/+page.server.ts
@@ -2,6 +2,7 @@ import { PUBLIC_PB_URL } from '../../../hooks.server';
 import { texts } from '$lib/texts';
 import { generateInviteSlug } from '$lib/inviteSlug';
 import { upsertUserGeolocation } from '$lib/server/geolocation';
+import { upsertOwnContact, getOwnContact } from '$lib/server/contacts';
 
 export async function load({ locals, url }) {
 	// Fetch directly so the profile page always has fresh data regardless of
@@ -16,11 +17,13 @@ export async function load({ locals, url }) {
 	}
 
 	const inviteUrl = `${url.origin}/invite/${inviteCode}`;
+	const contact = await getOwnContact(locals.pb, locals.user.id);
 
 	return {
 		PB_URL: PUBLIC_PB_URL,
 		inviteUrl,
 		currentUser,
+		contact,
 	};
 }
 
@@ -72,56 +75,35 @@ export const actions = {
 			updateData['city'] = city.trim();
 		}
 
-		// Handle Telegram username
+		// Handle contact fields → owner-only user_contacts collection (not users)
+		const contact = {
+			telegramUsername: '',
+			signalLink: '',
+			telegramVisibleToTrustedOnly: formData?.get('telegramVisibleToTrustedOnly') === 'on',
+			signalVisibleToTrustedOnly: formData?.get('signalVisibleToTrustedOnly') === 'on',
+		};
+
 		const telegramUsername = formData?.get('telegramUsername')?.toString();
-		if (telegramUsername) {
-			const trimmedTelegram = telegramUsername.trim();
-			if (trimmedTelegram !== '') {
-				// Strip @ prefix if provided
-				const cleanedTelegram = trimmedTelegram.startsWith('@')
-					? trimmedTelegram.slice(1)
-					: trimmedTelegram;
-
-				// Validate Telegram username (alphanumeric and underscore only, 5-32 chars)
-				if (!/^[a-zA-Z0-9_]{5,32}$/.test(cleanedTelegram)) {
-					return {
-						error: true,
-						message: texts.errors.invalidTelegramUsername,
-					};
-				}
-				updateData['telegramUsername'] = cleanedTelegram;
-			} else {
-				updateData['telegramUsername'] = null;
+		if (telegramUsername && telegramUsername.trim() !== '') {
+			const cleanedTelegram = telegramUsername.trim().startsWith('@')
+				? telegramUsername.trim().slice(1)
+				: telegramUsername.trim();
+			// Validate Telegram username (alphanumeric and underscore only, 5-32 chars)
+			if (!/^[a-zA-Z0-9_]{5,32}$/.test(cleanedTelegram)) {
+				return { error: true, message: texts.errors.invalidTelegramUsername };
 			}
+			contact.telegramUsername = cleanedTelegram;
 		}
 
-		// Handle Telegram visibility toggle
-		const telegramVisibleToTrustedOnly =
-			formData?.get('telegramVisibleToTrustedOnly') === 'on';
-		updateData['telegramVisibleToTrustedOnly'] = telegramVisibleToTrustedOnly;
-
-		// Handle Signal link
 		const signalLink = formData?.get('signalLink')?.toString();
-		if (signalLink) {
+		if (signalLink && signalLink.trim() !== '') {
 			const trimmedSignal = signalLink.trim();
-			if (trimmedSignal !== '') {
-				// Validate Signal link format (should contain signal.me or similar)
-				if (!trimmedSignal.includes('signal.me')) {
-					return {
-						error: true,
-						message: texts.errors.invalidSignalLink,
-					};
-				}
-				updateData['signalLink'] = trimmedSignal;
-			} else {
-				updateData['signalLink'] = null;
+			// Validate Signal link format (should contain signal.me or similar)
+			if (!trimmedSignal.includes('signal.me')) {
+				return { error: true, message: texts.errors.invalidSignalLink };
 			}
+			contact.signalLink = trimmedSignal;
 		}
-
-		// Handle Signal visibility toggle
-		const signalVisibleToTrustedOnly =
-			formData?.get('signalVisibleToTrustedOnly') === 'on';
-		updateData['signalVisibleToTrustedOnly'] = signalVisibleToTrustedOnly;
 
 		// Handle geolocation → owner-only user_geolocations collection
 		// (undefined = leave unchanged; only set when a geocode suggestion was picked).
@@ -157,6 +139,7 @@ export const actions = {
 
 		try {
 			const hasUserUpdate = Object.keys(updateData).length > 0 || hasProfileImage;
+			await upsertOwnContact(locals.pb, locals.user.id, contact);
 			if (hasUserUpdate || geo !== undefined) {
 				if (hasUserUpdate) {
 					// Build a FormData for PocketBase so file uploads work correctly alongside scalar fields

--- a/src/routes/user/profile/+page.server.ts
+++ b/src/routes/user/profile/+page.server.ts
@@ -1,6 +1,7 @@
 import { PUBLIC_PB_URL } from '../../../hooks.server';
 import { texts } from '$lib/texts';
 import { generateInviteSlug } from '$lib/inviteSlug';
+import { upsertUserGeolocation } from '$lib/server/geolocation';
 
 export async function load({ locals, url }) {
 	// Fetch directly so the profile page always has fresh data regardless of
@@ -122,18 +123,20 @@ export const actions = {
 			formData?.get('signalVisibleToTrustedOnly') === 'on';
 		updateData['signalVisibleToTrustedOnly'] = signalVisibleToTrustedOnly;
 
-		// Handle geolocation (only set when user explicitly selected a geocode suggestion)
+		// Handle geolocation → owner-only user_geolocations collection
+		// (undefined = leave unchanged; only set when a geocode suggestion was picked).
+		let geo: { lon: number; lat: number } | null | undefined;
 		const geoLon = formData?.get('geolocation_lon')?.toString();
 		const geoLat = formData?.get('geolocation_lat')?.toString();
 		if (geoLon && geoLat) {
 			const lon = parseFloat(geoLon);
 			const lat = parseFloat(geoLat);
 			if (!isNaN(lon) && !isNaN(lat)) {
-				updateData['geolocation'] = { lon, lat };
+				geo = { lon, lat };
 			}
 		} else if (city === ''){
 			// If city is cleared, also clear geolocation
-			updateData['geolocation'] = null;
+			geo = null;
 		}
 
 		// Handle preferred transport mode
@@ -153,21 +156,27 @@ export const actions = {
 		const hasProfileImage = profileImageFile instanceof File && profileImageFile.size > 0;
 
 		try {
-			if (Object.keys(updateData).length > 0 || hasProfileImage) {
-				// Build a FormData for PocketBase so file uploads work correctly alongside scalar fields
-				for (const [key, value] of Object.entries(updateData)) {
-					if (value === null) {
-						pbFormData.append(key, '');
-					} else if (typeof value === 'object') {
-						pbFormData.append(key, JSON.stringify(value));
-					} else {
-						pbFormData.append(key, String(value));
+			const hasUserUpdate = Object.keys(updateData).length > 0 || hasProfileImage;
+			if (hasUserUpdate || geo !== undefined) {
+				if (hasUserUpdate) {
+					// Build a FormData for PocketBase so file uploads work correctly alongside scalar fields
+					for (const [key, value] of Object.entries(updateData)) {
+						if (value === null) {
+							pbFormData.append(key, '');
+						} else if (typeof value === 'object') {
+							pbFormData.append(key, JSON.stringify(value));
+						} else {
+							pbFormData.append(key, String(value));
+						}
 					}
+					if (hasProfileImage) {
+						pbFormData.append('profileImage', profileImageFile as File);
+					}
+					await locals.pb.collection('users').update(locals.user.id, pbFormData);
 				}
-				if (hasProfileImage) {
-					pbFormData.append('profileImage', profileImageFile as File);
+				if (geo !== undefined) {
+					await upsertUserGeolocation(locals.pb, locals.user.id, geo);
 				}
-				await locals.pb.collection('users').update(locals.user.id, pbFormData);
 				return {
 					success: true,
 					message: texts.success.dataUpdated,

--- a/src/routes/user/profile/+page.svelte
+++ b/src/routes/user/profile/+page.svelte
@@ -133,9 +133,9 @@
 						fieldName="telegramUsername"
 						label={texts.messenger.telegramUsername}
 						placeholder={texts.messenger.telegramUsernamePlaceholder}
-						value={data.currentUser.telegramUsername ?? ''}
+						value={data.contact.telegramUsername ?? ''}
 						visibilityToggleName="telegramVisibleToTrustedOnly"
-						visibilityToggleChecked={data.currentUser.telegramVisibleToTrustedOnly ?? true}
+						visibilityToggleChecked={data.contact.telegramVisibleToTrustedOnly ?? true}
 						tooltipId="telegram-tooltip"
 						tooltipTitle={texts.messenger.telegramTooltipTitle}
 						tooltipText={texts.messenger.telegramTooltipText}
@@ -144,9 +144,9 @@
 						fieldName="signalLink"
 						label={texts.messenger.signalLink}
 						placeholder={texts.messenger.signalLinkPlaceholder}
-						value={data.currentUser.signalLink ?? ''}
+						value={data.contact.signalLink ?? ''}
 						visibilityToggleName="signalVisibleToTrustedOnly"
-						visibilityToggleChecked={data.currentUser.signalVisibleToTrustedOnly ?? true}
+						visibilityToggleChecked={data.contact.signalVisibleToTrustedOnly ?? true}
 						tooltipId="signal-tooltip"
 						tooltipTitle={texts.messenger.signalTooltipTitle}
 						tooltipText={texts.messenger.signalTooltipText}

--- a/src/routes/users/[id]/+page.server.ts
+++ b/src/routes/users/[id]/+page.server.ts
@@ -28,7 +28,22 @@ export async function load({ params, locals }) {
 	const currentUser = locals.user;
 	const isOwnProfile = currentUser?.id === profileUser.id;
 	const viewerTrustsProfile = currentUser?.trusts?.includes(profileUser.id) ?? false;
-	const profileTrustsViewer = currentUser ? (profileUser.trusts?.includes(currentUser.id) ?? false) : false;
+	// Does the profile owner trust the viewer? Resolved server-side so the owner's
+	// full trusts list never leaves the server (users_public no longer exposes it).
+	let profileTrustsViewer = false;
+	if (currentUser) {
+		try {
+			await locals.pb
+				.collection('users')
+				.getFirstListItem(
+					locals.pb.filter('id = {:pid} && trusts.id ?= {:vid}', { pid: profileUser.id, vid: currentUser.id }),
+					{ fields: 'id' }
+				);
+			profileTrustsViewer = true;
+		} catch {
+			profileTrustsViewer = false;
+		}
+	}
 
 	const publicItems = allItems.filter((item) => !item.trusteesOnly);
 	const trustedItemsAll = allItems.filter((item) => item.trusteesOnly);

--- a/src/routes/users/[id]/+page.server.ts
+++ b/src/routes/users/[id]/+page.server.ts
@@ -50,6 +50,29 @@ export async function load({ params, locals }) {
 	// Owner is never in their own trusts array, so isOwnProfile must be checked separately
 	const trustedItems = (profileTrustsViewer || isOwnProfile) ? trustedItemsAll : null;
 
+	// items_public masks trustees-only items (name/image/description are NULL). The owner
+	// and trusted viewers may see full details, read here from the trust-gated base `items`.
+	if (trustedItems && trustedItems.length > 0) {
+		try {
+			const full = await locals.pb.collection('items').getFullList({
+				filter: locals.pb.filter('owner = {:ownerId} && trusteesOnly = true', { ownerId: profileUser.id }),
+				fields: 'id,name,image,externalImgUrl,externalUrl,description',
+			});
+			const byId = new Map(full.map((f) => [f.id, f] as const));
+			for (const item of trustedItems) {
+				const f = byId.get(item.id);
+				if (!f) continue;
+				item.name = f.name;
+				item.image = f.image;
+				item.externalImgUrl = f.externalImgUrl;
+				item.externalUrl = f.externalUrl;
+				item.description = f.description;
+			}
+		} catch (err) {
+			console.error('Failed to load trusted item details', err);
+		}
+	}
+
 	// Strip fields that must not reach the client: sensitive data and fields not used by this page.
 	const fieldsToStrip = [
 		'email', 'trusts', 'geolocation', 'inviteCode', 'invitedBy',


### PR DESCRIPTION
## Summary

Frontend companion to the backend data-layer hardening (`allerleih-backend#1`). The app now reads trust- and privacy-sensitive data through the new backend hooks, owner-only collections, and views instead of reading it directly, drops fields that the backend no longer exposes, and surfaces trustees-only items in search to the users an owner trusts.

Requires the backend branch (`allerleih-backend` `security-hardening`) to be deployed first — the new hooks/collections/views must exist.

## What's included

### Invites and trust
- Resolve invite codes through `GET /api/invite/{code}` instead of reading the public user view.
- Whether a profile owner trusts the viewer is computed server-side with a filtered query, so the owner's trusts list never reaches the client.

### Geolocation and travel times
- Read/write the user's own location through the owner-only `user_geolocations` collection.
- Travel times are requested from the `POST /api/travel-times` hook (which returns only bucketed minutes) instead of reading owner coordinates here. Onboarding and profile updated accordingly.

### Contact handles
- The conversation header gets the partner's messenger handles from `GET /api/contact/{userId}` (resolved server-side, honouring the visibility flags and trust).
- Profile and onboarding read/write the user's own handles through `user_contacts`.

### Item visibility and search
- The profile and item-detail pages load the masked `items_public` row and, for the owner and trusted viewers, read the full details from the trust-gated base `items` collection.
- Search reads the new `items_searchable` view, so trusted users see trusted owners' trustees-only items in search; everyone else sees only public items.
- Removed the now-unused `trusts` field from `ItemPublic` and the obsolete trust indicator on search cards. Request notifications use the real item name.

### Misc
- The username-availability check builds its filter with `pb.filter()`.
- Docs updated: `architecture.md`, `data-model.md`, `domain-model.md`, `README.md`.

## Tests

`npm run check` is clean and the vitest suite passes (100/100); the `resolveInviter` unit test was updated for the `/api/invite` path.

## Merge note (PR #400)

This branch overlaps with #400 (leihlokal integration) in two documentation files only — `docs/README.md` and `docs/architecture.md` — and the conflicts are trivial and purely additive (both add entries/sections; resolve by keeping both). The code (including `src/lib/types/models.ts`) and `docs/data-model.md` auto-merge cleanly. Easiest path: merge after #400, then rebase and keep both sides in the two docs.

## Verification

Tested locally across all roles (owner / trusted / non-trusted / guest): public items stay visible to everyone, trustees-only item content and search results reach only the owner and trusted users, and coordinates/contact handles are read only through the backend hooks.
