### PR TITLE
fix(notifications): resync unread badge on navigation (#376)

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * SvelteKit load dependency key for the unread-notification count.
+ *
+ * Shared by the root layout load (which calls `depends(NOTIFICATIONS_DEP)`) and
+ * every place that wants to force a badge resync via `invalidate(NOTIFICATIONS_DEP)`.
+ * Keep it a single constant so the two sides can never drift apart and silently
+ * turn the invalidation into a no-op (issue #376).
+ */
+export const NOTIFICATIONS_DEP = 'app:notifications';

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,4 +1,9 @@
+import { NOTIFICATIONS_DEP } from '$lib/constants';
+
 export const load = async (event) => {
+	// Lets invalidate(NOTIFICATIONS_DEP) re-fetch just the unread count (issue #376).
+	event.depends(NOTIFICATIONS_DEP);
+
 	const currentUser = event.locals.user;
 
 	let unreadNotificationCount = 0;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,10 +6,11 @@
 	import PwaPrompts from '$lib/components/PwaPrompts.svelte';
 	import OnboardingPrompt from '$lib/components/OnboardingPrompt.svelte';
 	import { getClientPB, syncClientPBAuth } from '$lib/client-pb';
+	import { NOTIFICATIONS_DEP } from '$lib/constants';
 	import { setupPushSubscription } from '$lib/utils/pushSubscription';
 	import { onMount } from 'svelte';
 	import { page } from '$app/state';
-	import { beforeNavigate, afterNavigate } from '$app/navigation';
+	import { beforeNavigate, afterNavigate, invalidate } from '$app/navigation';
 	import { dev } from '$app/environment';
 	import { fade } from 'svelte/transition';
 	import AllerLoader from '$lib/components/AllerLoader.svelte';
@@ -22,7 +23,16 @@
 
 	let isNavigating = $state(false);
 	beforeNavigate(() => { isNavigating = true; });
-	afterNavigate(() => { isNavigating = false; });
+	afterNavigate(() => {
+		isNavigating = false;
+		// Resync the badge after every navigation (issue #376): a destination load can
+		// mark notifications read server-side, and realtime may miss it. afterNavigate
+		// runs after that destination load has committed, so the re-fetch reflects it.
+		// (Paths that mark read via a fire-and-forget request instead of in the load —
+		// see notifications/+page.svelte — resync separately when that request resolves.)
+		// Don't filter by navigation type: in-app navigations here report type 'enter'.
+		invalidate(NOTIFICATIONS_DEP);
+	});
 
 	// svelte-ignore state_referenced_locally
 	let unreadCount = $state(data.unreadNotificationCount ?? 0);

--- a/src/routes/layout.server.test.ts
+++ b/src/routes/layout.server.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { load } from './+layout.server';
+import { NOTIFICATIONS_DEP } from '$lib/constants';
+
+type LoadEvent = Parameters<typeof load>[0];
+
+describe('Root layout load', () => {
+	let getList: ReturnType<typeof vi.fn>;
+	let depends: ReturnType<typeof vi.fn>;
+	let filter: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		getList = vi.fn().mockResolvedValue({ totalItems: 3 });
+		depends = vi.fn();
+		filter = vi.fn((raw: string) => raw);
+	});
+
+	function buildEvent(user: { id: string } | null) {
+		return {
+			depends,
+			locals: {
+				user,
+				pb: {
+					collection: vi.fn(() => ({ getList })),
+					filter,
+					authStore: { token: 'jwt-token' },
+				},
+			},
+		} as unknown as LoadEvent;
+	}
+
+	it('registers the notifications dependency so the badge can be invalidated on navigation (issue #376)', async () => {
+		await load(buildEvent({ id: 'user1' }));
+		// Asserted against the shared constant the client invalidates with, so a rename
+		// on one side that silently no-ops the fix breaks this test.
+		expect(depends).toHaveBeenCalledWith(NOTIFICATIONS_DEP);
+	});
+
+	it('returns the unread notification count for an authenticated user', async () => {
+		const result = await load(buildEvent({ id: 'user1' }));
+		expect(result.unreadNotificationCount).toBe(3);
+		expect(filter).toHaveBeenCalledWith('recipient={:userId} && read=false', { userId: 'user1' });
+	});
+
+	it('returns a zero count without querying when there is no user', async () => {
+		const result = await load(buildEvent(null));
+		expect(result.unreadNotificationCount).toBe(0);
+		expect(getList).not.toHaveBeenCalled();
+		// dependency is still registered so an invalidate() never silently no-ops
+		expect(depends).toHaveBeenCalledWith(NOTIFICATIONS_DEP);
+	});
+
+	it('falls back to zero when the notifications query fails', async () => {
+		getList.mockRejectedValueOnce(new Error('collection missing'));
+		const result = await load(buildEvent({ id: 'user1' }));
+		expect(result.unreadNotificationCount).toBe(0);
+		// prove the zero came from the catch branch, not an untaken query path,
+		// and that the dependency is still registered even when the query throws
+		expect(getList).toHaveBeenCalled();
+		expect(depends).toHaveBeenCalledWith(NOTIFICATIONS_DEP);
+	});
+});

--- a/src/routes/notifications/+page.svelte
+++ b/src/routes/notifications/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
+	import { invalidate } from '$app/navigation';
+	import { NOTIFICATIONS_DEP } from '$lib/constants';
 	import { texts } from '$lib/texts';
 	import { formatTimestamp } from '$lib/utils/utils';
 	import { enhance } from '$app/forms';
@@ -53,10 +55,15 @@
 							// Fire-and-forget: navigation proceeds immediately while the server
 							// marks the notification as read in the background. SvelteKit's
 							// client-side routing does not cancel in-flight fetches on navigate.
+							// Once it resolves, resync the badge — the destination load may not
+							// mark it read itself (e.g. trust_added/invite_accepted -> /users/[id]),
+							// so afterNavigate's invalidate could otherwise race this write (#376).
 							if (!notification.read) {
 								const fd = new FormData();
 								fd.append('id', notification.id);
-								fetch('?/markRead', { method: 'POST', body: fd });
+								fetch('?/markRead', { method: 'POST', body: fd })
+									.then(() => invalidate(NOTIFICATIONS_DEP))
+									.catch(() => {});
 							}
 						}}
 					>


### PR DESCRIPTION
## Problem

Closes #376. The unread-notifications badge in the nav sometimes did not vanish after all notifications were marked read.

## Root cause

After a notification is marked read — e.g. opening its conversation marks it read inside the page `load()` — the badge count was only refreshed by the realtime subscription. Whenever that realtime event was missed or delayed (a dropped/reconnecting SSE connection, a proxy timeout, a throttled background tab, or simply the root layout's count query racing the server-side read-marking), the badge stayed stale until a full page reload. This is not specific to any platform or to the PWA.

## Fix

- The root layout load registers a dependency key (`NOTIFICATIONS_DEP`); the layout invalidates it in `afterNavigate`, re-fetching the count after every navigation. `afterNavigate` runs once the destination load has committed, so the re-fetch reflects any read-marking it did — independent of realtime.
- Notifications whose destination load does not mark them read (`trust_added` / `invite_accepted` → `/users/[id]`) resync when their fire-and-forget `markRead` request resolves.
- The dependency key lives in a single shared constant so the `depends()` and `invalidate()` sides cannot silently drift apart into a no-op.

## Tests

- New unit tests for the layout load: dependency registration, unread count, no-user path, error fallback.
- Manually verified against a production preview build with the realtime SSE connection blocked — the badge clears correctly on both the conversation and trust/invite paths (previously it stayed stale).

## Follow-up (out of scope)

`src/app.html` sets `data-sveltekit-preload-data="hover"` and the conversation `load()` mutates read-state, so notifications can be marked read on link hover via speculative preloading. Pre-existing; worth a separate issue to move read-marking out of `load()` into an explicit action/endpoint.
