### PR TITLE
fix(notifications): scope push subscriptions to the logged-in user (#191)

### DIFF
--- a/src/lib/components/NavBarComponent.svelte
+++ b/src/lib/components/NavBarComponent.svelte
@@ -18,6 +18,7 @@
 	import { page } from '$app/state';
 	import { BellOutline, ChevronDownOutline, ChevronRightOutline, GlobeOutline, UserCircleOutline } from 'flowbite-svelte-icons';
 	import FeedbackButton from './FeedbackButton.svelte';
+	import { teardownPushSubscription } from '$lib/utils/pushSubscription';
 
 	let { loggedIn, currentUser, unreadCount = 0 } = $props<{
 		loggedIn: boolean;
@@ -32,6 +33,11 @@
 	);
 
 	async function logout(): Promise<void> {
+		// Detach this device's push subscription while still authenticated, so the
+		// next user on this device does not keep receiving the previous user's
+		// notifications. Must run before the auth store is cleared below.
+		await teardownPushSubscription();
+
 		await fetch('/auth/logout', {
 			method: 'POST',
 		});

--- a/src/lib/server/pushSubscriptions.test.ts
+++ b/src/lib/server/pushSubscriptions.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest';
+import type PocketBase from 'pocketbase';
+import {
+	upsertPushSubscription,
+	deletePushSubscription,
+	deleteAllPushSubscriptions,
+} from './pushSubscriptions';
+
+function mockFilter(raw: string, params?: Record<string, unknown>): string {
+	if (!params) return raw;
+	let result = raw;
+	for (const [key, value] of Object.entries(params)) {
+		const escaped = typeof value === 'string' ? `'${value.replace(/'/g, "\\'")}'` : `${value}`;
+		result = result.replaceAll(`{:${key}}`, escaped);
+	}
+	return result;
+}
+
+type Stub = Record<string, ReturnType<typeof vi.fn>>;
+
+function makeMockPb(stub: Stub): { pb: PocketBase; filter: ReturnType<typeof vi.fn> } {
+	const filter = vi.fn(mockFilter);
+	const pb = { collection: vi.fn(() => stub), filter } as unknown as PocketBase;
+	return { pb, filter };
+}
+
+const payload = { endpoint: 'https://push.example/abc', keys: { p256dh: 'P', auth: 'A' } };
+
+describe('upsertPushSubscription', () => {
+	it('reassigns an already-registered endpoint to the new user and refreshes keys', async () => {
+		const stub: Stub = {
+			getList: vi.fn().mockResolvedValue({ items: [{ id: 'sub1' }] }),
+			update: vi.fn().mockResolvedValue({}),
+			create: vi.fn(),
+		};
+		const { pb, filter } = makeMockPb(stub);
+		await upsertPushSubscription(pb, 'userB', payload);
+		// Lookup is by endpoint only — intentional: an endpoint is reassigned to whoever
+		// last registered it. The filter must be parameterized (no injection).
+		expect(filter).toHaveBeenCalledWith('endpoint={:endpoint}', {
+			endpoint: 'https://push.example/abc',
+		});
+		expect(stub.update).toHaveBeenCalledWith('sub1', { user: 'userB', p256dh: 'P', auth: 'A' });
+		expect(stub.create).not.toHaveBeenCalled();
+	});
+
+	it('creates a new record when the endpoint is unknown', async () => {
+		const stub: Stub = {
+			getList: vi.fn().mockResolvedValue({ items: [] }),
+			update: vi.fn(),
+			create: vi.fn().mockResolvedValue({}),
+		};
+		const { pb } = makeMockPb(stub);
+		await upsertPushSubscription(pb, 'userA', payload);
+		expect(stub.create).toHaveBeenCalledWith({
+			user: 'userA',
+			endpoint: 'https://push.example/abc',
+			p256dh: 'P',
+			auth: 'A',
+		});
+		expect(stub.update).not.toHaveBeenCalled();
+	});
+
+	it('treats a failed lookup as "not found" and creates instead of throwing', async () => {
+		const stub: Stub = {
+			getList: vi.fn().mockRejectedValue(new Error('db down')),
+			update: vi.fn(),
+			create: vi.fn().mockResolvedValue({}),
+		};
+		const { pb } = makeMockPb(stub);
+		await expect(upsertPushSubscription(pb, 'userA', payload)).resolves.toBeUndefined();
+		expect(stub.create).toHaveBeenCalled();
+	});
+});
+
+describe('deletePushSubscription', () => {
+	it('deletes the matching record, scoped to BOTH endpoint and the caller’s user id', async () => {
+		const stub: Stub = {
+			getList: vi.fn().mockResolvedValue({ items: [{ id: 'sub1' }] }),
+			delete: vi.fn().mockResolvedValue(true),
+		};
+		const { pb, filter } = makeMockPb(stub);
+		await deletePushSubscription(pb, 'userA', 'https://push.example/abc');
+		expect(stub.delete).toHaveBeenCalledWith('sub1');
+		// The user filter is what prevents removing another user's subscription.
+		expect(filter).toHaveBeenCalledWith(
+			expect.stringContaining('user='),
+			expect.objectContaining({ endpoint: 'https://push.example/abc', userId: 'userA' })
+		);
+	});
+
+	it('no-ops when no matching record exists', async () => {
+		const stub: Stub = {
+			getList: vi.fn().mockResolvedValue({ items: [] }),
+			delete: vi.fn(),
+		};
+		const { pb } = makeMockPb(stub);
+		await deletePushSubscription(pb, 'userA', 'https://push.example/abc');
+		expect(stub.delete).not.toHaveBeenCalled();
+	});
+
+	it('swallows a failed lookup and neither throws nor deletes', async () => {
+		const stub: Stub = {
+			getList: vi.fn().mockRejectedValue(new Error('db down')),
+			delete: vi.fn(),
+		};
+		const { pb } = makeMockPb(stub);
+		await expect(
+			deletePushSubscription(pb, 'userA', 'https://push.example/abc')
+		).resolves.toBeUndefined();
+		expect(stub.delete).not.toHaveBeenCalled();
+	});
+});
+
+describe('deleteAllPushSubscriptions', () => {
+	it('deletes every subscription belonging to the user', async () => {
+		const stub: Stub = {
+			getFullList: vi.fn().mockResolvedValue([{ id: 's1' }, { id: 's2' }]),
+			delete: vi.fn().mockResolvedValue(true),
+		};
+		const { pb } = makeMockPb(stub);
+		await deleteAllPushSubscriptions(pb, 'userA');
+		expect(stub.delete).toHaveBeenCalledTimes(2);
+		expect(stub.delete).toHaveBeenCalledWith('s1');
+		expect(stub.delete).toHaveBeenCalledWith('s2');
+	});
+});

--- a/src/lib/utils/pushSubscription.test.ts
+++ b/src/lib/utils/pushSubscription.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// pushSubscription.ts reads the VAPID public key from here at import time.
+vi.mock('$env/static/public', () => ({ PUBLIC_VAPID_PUBLIC_KEY: 'dGVzdA' }));
+
+import { teardownPushSubscription, nextPushRegistration } from './pushSubscription';
+
+describe('nextPushRegistration', () => {
+	it('registers on first login when permission is granted', () => {
+		expect(nextPushRegistration('userA', undefined, true)).toEqual({
+			register: true,
+			lastRegisteredUserId: 'userA',
+		});
+	});
+
+	it('does not re-register while the same user stays logged in', () => {
+		expect(nextPushRegistration('userA', 'userA', true)).toEqual({
+			register: false,
+			lastRegisteredUserId: 'userA',
+		});
+	});
+
+	it('registers when a different user logs in on the device', () => {
+		expect(nextPushRegistration('userB', 'userA', true)).toEqual({
+			register: true,
+			lastRegisteredUserId: 'userB',
+		});
+	});
+
+	it('does not register without granted permission', () => {
+		expect(nextPushRegistration('userA', undefined, false)).toEqual({
+			register: false,
+			lastRegisteredUserId: undefined,
+		});
+	});
+
+	it('re-arms on logout by clearing the tracked id', () => {
+		expect(nextPushRegistration(undefined, 'userA', true)).toEqual({
+			register: false,
+			lastRegisteredUserId: undefined,
+		});
+	});
+
+	it('re-registers the SAME user after a logout dip (regression guard for prior finding #1)', () => {
+		// logged in as A → registers
+		let state = nextPushRegistration('userA', undefined, true);
+		expect(state).toEqual({ register: true, lastRegisteredUserId: 'userA' });
+		// logout → re-arms (tracked id cleared)
+		state = nextPushRegistration(undefined, state.lastRegisteredUserId, true);
+		expect(state).toEqual({ register: false, lastRegisteredUserId: undefined });
+		// same user logs back in (same tab) → MUST register again
+		state = nextPushRegistration('userA', state.lastRegisteredUserId, true);
+		expect(state).toEqual({ register: true, lastRegisteredUserId: 'userA' });
+	});
+});
+
+describe('teardownPushSubscription', () => {
+	let unsubscribe: ReturnType<typeof vi.fn>;
+	let getSubscription: ReturnType<typeof vi.fn>;
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		unsubscribe = vi.fn().mockResolvedValue(true);
+		getSubscription = vi.fn();
+		fetchMock = vi.fn().mockResolvedValue({ ok: true });
+		vi.stubGlobal('fetch', fetchMock);
+		vi.stubGlobal('window', { PushManager: function PushManager() {} });
+		vi.stubGlobal('navigator', {
+			serviceWorker: { ready: Promise.resolve({ pushManager: { getSubscription } }) },
+		});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.clearAllMocks();
+	});
+
+	it('unsubscribes the device and DELETEs the subscription by endpoint (with an abort signal)', async () => {
+		getSubscription.mockResolvedValue({ endpoint: 'https://push.example/abc', unsubscribe });
+
+		await teardownPushSubscription();
+
+		expect(unsubscribe).toHaveBeenCalledOnce();
+		expect(fetchMock).toHaveBeenCalledOnce();
+		const [url, opts] = fetchMock.mock.calls[0];
+		expect(url).toBe('/api/push-subscribe');
+		expect(opts.method).toBe('DELETE');
+		expect(JSON.parse(opts.body)).toEqual({ endpoint: 'https://push.example/abc' });
+		// timeout guard so a hanging network can't stall the caller (logout)
+		expect(opts.signal).toBeInstanceOf(AbortSignal);
+	});
+
+	it('no-ops when this device has no subscription', async () => {
+		getSubscription.mockResolvedValue(null);
+
+		await teardownPushSubscription();
+
+		expect(unsubscribe).not.toHaveBeenCalled();
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('never throws when the server DELETE fails (so logout is never blocked)', async () => {
+		getSubscription.mockResolvedValue({ endpoint: 'https://push.example/abc', unsubscribe });
+		fetchMock.mockRejectedValue(new Error('network down'));
+
+		await expect(teardownPushSubscription()).resolves.toBeUndefined();
+		// local unsubscribe still ran before the (failed) network call
+		expect(unsubscribe).toHaveBeenCalledOnce();
+	});
+
+	it('returns early when push is unsupported (no serviceWorker)', async () => {
+		vi.stubGlobal('navigator', {});
+
+		await teardownPushSubscription();
+
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/utils/pushSubscription.ts
+++ b/src/lib/utils/pushSubscription.ts
@@ -12,6 +12,29 @@ function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
 	return output;
 }
 
+/**
+ * Pure decision for the layout's push re-registration effect: given the current
+ * logged-in user id, the id this device last registered a subscription for, and
+ * whether notification permission is granted, returns whether to (re-)register
+ * now and the id to remember next.
+ *
+ * Resetting to `undefined` on logout (no current user) re-arms registration for
+ * the next login — including a re-login by the SAME user, whose subscription was
+ * torn down on logout. Without this reset a same-tab same-user logout→login is
+ * left with no push subscription.
+ */
+export function nextPushRegistration(
+	currentUserId: string | undefined,
+	lastRegisteredUserId: string | undefined,
+	permissionGranted: boolean
+): { register: boolean; lastRegisteredUserId: string | undefined } {
+	if (!currentUserId) return { register: false, lastRegisteredUserId: undefined };
+	if (currentUserId !== lastRegisteredUserId && permissionGranted) {
+		return { register: true, lastRegisteredUserId: currentUserId };
+	}
+	return { register: false, lastRegisteredUserId };
+}
+
 /** Sets up the Web Push subscription and registers it with the server.
  *  Called either silently (permission already granted) or after the user
  *  taps "Aktivieren" (satisfying the user-gesture requirement). */
@@ -74,11 +97,23 @@ export async function teardownPushSubscription(): Promise<void> {
 
 		await subscription.unsubscribe();
 
-		await fetch('/api/push-subscribe', {
-			method: 'DELETE',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ endpoint: subscription.endpoint }),
-		});
+		// Bound the server round-trip: callers (e.g. logout) await this, and a slow
+		// or hanging connection must not stall them. The local unsubscribe above has
+		// already detached this device, so aborting the DELETE doesn't weaken the
+		// guarantee — the server record is also cleaned up lazily on the next push
+		// (410 Gone) if this request never lands.
+		const controller = new AbortController();
+		const timeout = setTimeout(() => controller.abort(), 4000);
+		try {
+			await fetch('/api/push-subscribe', {
+				method: 'DELETE',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ endpoint: subscription.endpoint }),
+				signal: controller.signal,
+			});
+		} finally {
+			clearTimeout(timeout);
+		}
 	} catch (err) {
 		console.error('Push unsubscription failed:', err);
 	}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,7 +6,7 @@
 	import PwaPrompts from '$lib/components/PwaPrompts.svelte';
 	import OnboardingPrompt from '$lib/components/OnboardingPrompt.svelte';
 	import { getClientPB, syncClientPBAuth } from '$lib/client-pb';
-	import { setupPushSubscription } from '$lib/utils/pushSubscription';
+	import { setupPushSubscription, nextPushRegistration } from '$lib/utils/pushSubscription';
 	import { onMount } from 'svelte';
 	import { page } from '$app/state';
 	import { beforeNavigate, afterNavigate } from '$app/navigation';
@@ -49,6 +49,22 @@
 		syncClientPBAuth(data.pbAuthToken ?? null, data.currentUser ?? null);
 	});
 
+	// Register/refresh this device's push subscription whenever the logged-in user
+	// changes. Login is a client-side navigation that does NOT remount this layout,
+	// so an onMount-only registration would miss it — leaving the user without a
+	// subscription until a hard reload (a regression once logout tears the previous
+	// subscription down). The tracked id makes this fire once per user, not on every
+	// invalidateAll().
+	let _pushUserId: string | undefined = undefined;
+	$effect(() => {
+		const granted = 'Notification' in window && Notification.permission === 'granted';
+		// Reads data.currentUser?.id reactively; the helper re-arms on logout (uid
+		// undefined) so a subsequent login of any user — incl. the same one — re-registers.
+		const decision = nextPushRegistration(data.currentUser?.id, _pushUserId, granted);
+		_pushUserId = decision.lastRegisteredUserId;
+		if (decision.register) setupPushSubscription();
+	});
+
 	onMount(() => {
 		// Capture Chrome/Edge's install prompt before it shows the mini-infobar
 		window.addEventListener('beforeinstallprompt', (e) => {
@@ -56,17 +72,11 @@
 			installPromptEvent = e as BeforeInstallPromptEvent;
 		});
 
-		// If push permission was already granted on a previous session, re-register
-		// the subscription silently (covers cleared browser data / new device scenarios)
-		if (data.currentUser && 'Notification' in window && Notification.permission === 'granted') {
-			setupPushSubscription();
-		}
-
-		// Set up once at mount rather than in $effect — $effect's cleanup/re-run cycle
-		// tears down and re-creates the subscription on every invalidateAll(), which
-		// causes PocketBase to auto-cancel concurrent getList requests.
-		// Login/logout are full-page navigations in SvelteKit, so remounting handles
-		// user changes correctly without needing $effect reactivity here.
+		// The realtime notification subscription below is set up once at mount, not in
+		// an $effect: an $effect's cleanup/re-run cycle would tear it down and recreate
+		// it on every invalidateAll(), making PocketBase auto-cancel concurrent getList
+		// requests. (Push re-registration is handled by the navigation-reactive $effect
+		// above, because login is a client-side navigation that does not remount here.)
 		const userId = data.currentUser?.id;
 		if (!userId) return;
 


### PR DESCRIPTION
## What & why
Closes #191. A device kept its Web Push subscription after logout, so the next
user to log in on the same device received the previous user's push notifications.

## Changes
- **Tear down on logout** (`NavBarComponent.svelte`): `logout()` now removes this
  device's push subscription (browser `pushManager.unsubscribe()` + server record)
  *before* clearing auth — the `DELETE /api/push-subscribe` endpoint requires
  authentication, so it must run while the session is still valid.
- **Re-register on user change** (`+layout.svelte`): login is a client-side
  navigation that does not remount the layout, so an `onMount`-only registration
  missed it. A navigation-reactive effect now (re)registers the subscription
  whenever the logged-in user changes. The gating decision — including re-arming
  after logout so the same user re-registers on the next login — lives in a pure,
  unit-tested `nextPushRegistration()` helper.
- **Bounded teardown** (`pushSubscription.ts`): the teardown `DELETE` is wrapped in
  a 4 s `AbortController` timeout so a slow/hanging network can't stall logout. The
  local unsubscribe runs first, so the on-device guarantee holds even if the request
  is aborted (a stale server record is also cleaned up lazily on the next push via
  410 Gone).

## Tests
- New unit tests: push-subscription server helpers (`deletePushSubscription` is
  scoped to endpoint **and** user — no cross-user deletion), `teardownPushSubscription`
  (unsubscribe-before-DELETE ordering, abort signal, never throws), and the
  `nextPushRegistration` gating, incl. a logout→same-user-relogin regression guard.
- Full suite green (125 tests); `npm run check` clean.
- Verified end-to-end against a local PocketBase: logout removes the subscription;
  logging in as another user re-registers the device; a push addressed to the
  logged-out user no longer reaches the device.
