### PR TITLE
fix(items): clean up notifications when deleting an item's conversations (#406)

### DIFF
--- a/src/routes/conversations/[conversationId]/conversation.server.test.ts
+++ b/src/routes/conversations/[conversationId]/conversation.server.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import type PocketBase from 'pocketbase';
+
+// Avoid loading the real notifications module (web-push + VAPID env) at import time.
+vi.mock('$lib/server/notifications.js', () => ({
+	createNotification: vi.fn(),
+	sendPushToUser: vi.fn(),
+	isMessageNotificationThrottled: vi.fn(),
+}));
+
+import { deleteConversation } from './conversation.server';
+
+function mockFilter(raw: string, params?: Record<string, unknown>): string {
+	if (!params) return raw;
+	let result = raw;
+	for (const [key, value] of Object.entries(params)) {
+		const escaped = typeof value === 'string' ? `'${value.replace(/'/g, "\\'")}'` : `${value}`;
+		result = result.replaceAll(`{:${key}}`, escaped);
+	}
+	return result;
+}
+
+function makeMockPb(impls: Record<string, Record<string, ReturnType<typeof vi.fn>>>): PocketBase {
+	return {
+		collection: vi.fn((name: string) => impls[name]),
+		filter: vi.fn(mockFilter),
+	} as unknown as PocketBase;
+}
+
+describe('deleteConversation', () => {
+	it('deletes the conversation and every notification referencing it', async () => {
+		const convDelete = vi.fn().mockResolvedValue(true);
+		const notifDelete = vi.fn().mockResolvedValue(true);
+		const pb = makeMockPb({
+			conversations: { delete: convDelete },
+			notifications: {
+				getFullList: vi.fn().mockResolvedValue([{ id: 'n1' }, { id: 'n2' }]),
+				delete: notifDelete,
+			},
+		});
+
+		await deleteConversation(pb, 'conv1');
+
+		expect(convDelete).toHaveBeenCalledWith('conv1');
+		expect(notifDelete).toHaveBeenCalledTimes(2);
+		expect(notifDelete).toHaveBeenCalledWith('n1');
+		expect(notifDelete).toHaveBeenCalledWith('n2');
+	});
+
+	it('deletes the conversation even when no notifications reference it', async () => {
+		const convDelete = vi.fn().mockResolvedValue(true);
+		const notifDelete = vi.fn();
+		const pb = makeMockPb({
+			conversations: { delete: convDelete },
+			notifications: { getFullList: vi.fn().mockResolvedValue([]), delete: notifDelete },
+		});
+
+		await deleteConversation(pb, 'conv1');
+
+		expect(convDelete).toHaveBeenCalledWith('conv1');
+		expect(notifDelete).not.toHaveBeenCalled();
+	});
+
+	it('swallows a notification-cleanup failure (does not rethrow)', async () => {
+		const pb = makeMockPb({
+			conversations: { delete: vi.fn().mockResolvedValue(true) },
+			notifications: { getFullList: vi.fn().mockRejectedValue(new Error('boom')), delete: vi.fn() },
+		});
+
+		await expect(deleteConversation(pb, 'conv1')).resolves.toBeUndefined();
+	});
+
+	it('propagates a conversation-deletion failure (it is outside the cleanup try/catch)', async () => {
+		const pb = makeMockPb({
+			conversations: { delete: vi.fn().mockRejectedValue(new Error('cannot delete')) },
+			notifications: { getFullList: vi.fn(), delete: vi.fn() },
+		});
+
+		await expect(deleteConversation(pb, 'conv1')).rejects.toThrow('cannot delete');
+	});
+});

--- a/src/routes/user/items/+page.server.ts
+++ b/src/routes/user/items/+page.server.ts
@@ -3,6 +3,7 @@ import type { ClientResponseError } from 'pocketbase';
 import { PUBLIC_PB_URL } from '../../../hooks.server';
 import { ITEM_CATEGORIES, texts, type ItemCategory } from '$lib/texts';
 import type { Item } from '$lib/types/models';
+import { deleteConversation } from '../../conversations/[conversationId]/conversation.server';
 
 export async function load({ locals, url }) {
 	const page = Math.max(1, parseInt(url.searchParams.get('page') ?? '1'));
@@ -155,8 +156,12 @@ export const actions = {
 					.collection('conversations')
 					.getFullList({ filter: locals.pb.filter('requestedItem = {:itemId}', { itemId }) });
 
+				// Use deleteConversation (not a bare conversations.delete) so the
+				// notifications referencing each conversation are cleaned up too —
+				// otherwise the other party is left with dead-link notifications
+				// pointing at a now-missing conversation.
 				for (const conversation of conversations) {
-					await locals.pb.collection('conversations').delete(conversation.id);
+					await deleteConversation(locals.pb, conversation.id);
 				}
 
 				await locals.pb.collection('items').delete(itemId);

--- a/src/routes/user/items/page.server.test.ts
+++ b/src/routes/user/items/page.server.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mocked dependency: assert the delete action routes conversation deletion through it.
+const { deleteConversationMock } = vi.hoisted(() => ({ deleteConversationMock: vi.fn() }));
+vi.mock('../../conversations/[conversationId]/conversation.server', () => ({
+	deleteConversation: deleteConversationMock,
+}));
+// hooks.server.ts (re-exported by +page.server) reads PUBLIC_PB_URL from here.
+vi.mock('$env/static/public', () => ({ PUBLIC_PB_URL: 'http://localhost', PUBLIC_VAPID_PUBLIC_KEY: 'x' }));
+
+import { actions } from './+page.server';
+
+function mockFilter(raw: string, params?: Record<string, unknown>): string {
+	if (!params) return raw;
+	let result = raw;
+	for (const [key, value] of Object.entries(params)) {
+		const escaped = typeof value === 'string' ? `'${value.replace(/'/g, "\\'")}'` : `${value}`;
+		result = result.replaceAll(`{:${key}}`, escaped);
+	}
+	return result;
+}
+
+type DeleteEvent = Parameters<typeof actions.delete>[0];
+
+function setup(conversations: { id: string }[]) {
+	const convGetFullList = vi.fn().mockResolvedValue(conversations);
+	const itemsDelete = vi.fn().mockResolvedValue(true);
+	const pb = {
+		collection: vi.fn((name: string) =>
+			name === 'conversations' ? { getFullList: convGetFullList } : { delete: itemsDelete }
+		),
+		filter: vi.fn(mockFilter),
+	};
+	return { pb, convGetFullList, itemsDelete };
+}
+
+function callDelete(pb: unknown, itemId?: string) {
+	const fd = new FormData();
+	if (itemId !== undefined) fd.set('itemId', itemId);
+	return actions.delete({
+		locals: { pb },
+		request: { formData: vi.fn().mockResolvedValue(fd) },
+	} as unknown as DeleteEvent);
+}
+
+describe('user items: delete action', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('routes each conversation deletion through deleteConversation, then deletes the item', async () => {
+		const { pb, itemsDelete } = setup([{ id: 'c1' }, { id: 'c2' }]);
+
+		await callDelete(pb, 'item1');
+
+		expect(deleteConversationMock).toHaveBeenCalledTimes(2);
+		expect(deleteConversationMock).toHaveBeenCalledWith(pb, 'c1');
+		expect(deleteConversationMock).toHaveBeenCalledWith(pb, 'c2');
+		expect(itemsDelete).toHaveBeenCalledWith('item1');
+	});
+
+	it('deletes the item even when it has no conversations', async () => {
+		const { pb, itemsDelete } = setup([]);
+
+		await callDelete(pb, 'item1');
+
+		expect(deleteConversationMock).not.toHaveBeenCalled();
+		expect(itemsDelete).toHaveBeenCalledWith('item1');
+	});
+
+	it('does nothing when no itemId is supplied', async () => {
+		const { pb, itemsDelete } = setup([]);
+
+		await callDelete(pb, undefined);
+
+		expect(deleteConversationMock).not.toHaveBeenCalled();
+		expect(itemsDelete).not.toHaveBeenCalled();
+	});
+
+	it('does not delete the item if a conversation deletion fails (error is swallowed)', async () => {
+		const { pb, itemsDelete } = setup([{ id: 'c1' }]);
+		deleteConversationMock.mockRejectedValueOnce(new Error('boom'));
+
+		await expect(callDelete(pb, 'item1')).resolves.toBeUndefined();
+		expect(itemsDelete).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## What & why
Closes #406. Deleting an item removed its conversations but left the other party's
notifications pointing at a now-missing conversation, so clicking one showed
"Unterhaltung wurde nicht gefunden" and an unread one never cleared from the badge.

## Changes
- The item delete action (`src/routes/user/items/+page.server.ts`) deleted each
  conversation with a bare `conversations.delete()`, skipping notification cleanup.
  It now routes deletion through the existing `deleteConversation()` helper
  (`src/routes/conversations/[conversationId]/conversation.server.ts`), which deletes
  the conversation **and** the notifications referencing it — the same cleanup the
  normal conversation-delete path already used.

## Tests
- New unit tests for `deleteConversation` (deletes the conversation and each
  referencing notification; deletes even with zero notifications; swallows a cleanup
  failure; propagates a conversation-delete failure) and for the item delete action
  (routes each conversation through `deleteConversation`, then deletes the item;
  no-ops without an itemId; does not delete the item if a conversation deletion fails).
- Suite green; `npm run check` clean.
- Verified end-to-end against a local PocketBase: deleting an item removes its
  conversations and the other party's referencing notifications — no dead links left.
