### PR TITLE
docs: refresh CLAUDE.md to match the current codebase

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,17 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project overview
 
-**AllerLeih** is an item-sharing platform. Users list items they are willing to share or lend, and browse and request items from others. The trust system lets owners restrict certain items to trusted users only. The UI is entirely in German.
-
-## User interaction
-
-- Claude always asks the user relevant questions before developing an implementation plan.
+**AllerLeih** is an item-sharing platform. Users list items they are willing to share or lend, and browse and request items from others. A trust system lets owners restrict certain items to trusted users only; institutional accounts can bulk-import items and link out to external catalogues. The UI is entirely in German.
 
 ## Tech stack
 
 | Layer | Technology |
 |---|---|
-| Frontend framework | SvelteKit 2 + Svelte 5 |
+| Frontend framework | SvelteKit 2 + Svelte 5 (runes) |
 | Language | TypeScript (strict mode) |
 | CSS | Tailwind CSS v4 + Flowbite Svelte components |
 | Backend / DB | PocketBase (hosted SQLite, no migration files in repo) |
@@ -28,11 +24,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 npm run dev        # start dev server
 npm run build      # production build
 npm run preview    # preview production build
-npm run check      # svelte-check + tsc type checking
+npm run check      # svelte-kit sync + svelte-check (type checking)
 npm run lint       # ESLint
 npm run lint:fix   # ESLint with auto-fix
 npm run format     # Prettier
-npm run test       # Vitest (all tests)
+npm run test       # Vitest in WATCH mode
+npx vitest run                       # run all tests once (CI-style)
 npx vitest run src/path/to/file.test.ts  # run a single test file
 ```
 
@@ -46,35 +43,45 @@ PUBLIC_VAPID_PUBLIC_KEY= # VAPID public key for push notifications
 VAPID_PRIVATE_KEY=       # VAPID private key
 VAPID_SUBJECT=           # VAPID subject (mailto: or https: URI)
 ORS_API_KEY=             # OpenRouteService API key (geocoding + travel times)
+MISTRAL_API_KEY=         # Mistral API key — AI item image analysis (production only)
 ```
 
 ## Project structure
 
 ```
 src/
-├── app.d.ts                    # Global TypeScript types (locals, PageData)
-├── hooks.server.ts             # Auth hooks — runs on every request
+├── app.d.ts                    # Global types (locals, PageData)
+├── hooks.server.ts             # Auth hooks (authentication + authorization) — every request
 ├── service-worker.ts           # PWA: asset caching + push notification handling
 ├── lib/
 │   ├── components/             # Reusable Svelte components
-│   ├── server/                 # Server-only helpers (itemFilters, notifications)
-│   ├── types/models.ts         # TypeScript interfaces for all PocketBase collections
-│   ├── utils/utils.ts          # formatTimestamp(), setupPocketBaseSubscription()
-│   └── texts.ts                # ALL German UI strings
+│   ├── server/                 # Server-only helpers: itemFilters, notifications, registration,
+│   │                           #   lendingTerms, pushSubscriptions, travelTimes
+│   ├── types/models.ts         # TS interfaces for all PocketBase collections + public views
+│   ├── utils/                  # utils.ts (formatTimestamp, setupPocketBaseSubscription),
+│   │                           #   imageUtils (compressImage), categoryPlaceholder, pushSubscription (client)
+│   └── texts.ts                # ALL German UI strings + ITEM_CATEGORIES
 └── routes/
-    ├── api/geocode/            # GET — ORS address autocomplete
-    ├── api/travel-times/       # POST — ORS travel time matrix
-    ├── api/push-subscribe/     # POST — register/unregister push subscriptions
+    ├── api/
+    │   ├── geocode/            # GET  — ORS address autocomplete (Germany only)
+    │   ├── travel-times/       # POST — ORS travel time matrix
+    │   ├── push-subscribe/     # POST — register/unregister push subscriptions
+    │   ├── analyze-item/       # POST — Mistral image → name/description/categories (prod only)
+    │   ├── diagnostics/        # POST — fire-and-forget client diagnostics logging
+    │   └── redirect/           # GET  — safe outbound redirect (https only) + click logging
     ├── auth/                   # login, register, reset, logout
-    ├── conversations/[conversationId]/  # messaging between users
+    ├── onboarding/             # multi-step first-run onboarding flow
+    ├── invite/[slug]/          # invite-link landing (sets invitedBy on register)
+    ├── conversations/[conversationId]/  # messaging + lending lifecycle
     ├── items/[id]/             # item detail view
     ├── notifications/          # in-app notification list
-    ├── search/                 # browse/search items
+    ├── search/                 # browse/search items (logs queries to `searches`)
     ├── social/                 # trust network management
-    ├── user/                   # current user's profile and items
+    ├── user/                   # current user's profile, items, bulk import
     ├── users/[id]/             # other users' public profiles
-    └── misc/                   # static pages (about, contact, imprint)
-docs/                           # Architecture docs — read before making structural changes
+    ├── misc/                   # static pages (about, contact, imprint)
+    └── sitemap.xml/            # generated sitemap
+docs/                           # Architecture docs — read before structural changes (see below)
 ```
 
 ## Architecture patterns
@@ -85,13 +92,11 @@ SvelteKit file-based routing. Each route uses:
 - `+page.svelte` — UI component
 - `+page.server.ts` — `load()` for data fetching, `actions` for form submissions
 - `+layout.server.ts` — provides `currentUser` to all pages
-- `+server.ts` — explicit HTTP endpoints
+- `+server.ts` — explicit HTTP endpoints (the `/api/*` routes above)
 
-All mutations go through **form actions** (`action="?/actionName"`). There is no REST API layer.
+All mutations go through **form actions** (`action="?/actionName"`). There is no REST API layer for app data; the `/api/*` endpoints exist only for external integrations and client-side helpers.
 
-### Svelte 5 runes
-
-Use the new runes API throughout: `$state()`, `$derived()`, `$props()`, `$effect()`, `$bindable()`.
+Use the Svelte 5 runes API throughout: `$state()`, `$derived()`, `$props()`, `$effect()`, `$bindable()`.
 
 ### CRITICAL: do not destructure the `data` prop
 
@@ -108,9 +113,29 @@ Breaking `use:enhance` reactivity is the #1 footgun. Always access page data dir
 </script>
 ```
 
+### CRITICAL: always build PocketBase filters with `pb.filter()`
+
+Never interpolate values directly into a filter string with template literals
+(`` `owner = "${id}"` ``) — a value containing `"` can break out of the filter
+expression and change which records match (filter injection). Always use the
+SDK's `pb.filter(raw, params)` helper, which escapes each placeholder:
+
+```typescript
+// CORRECT
+pb.filter('inviteCode = {:code}', { code: inviteCode })
+// WRONG — filter injection if `code` contains a `"`
+`inviteCode = "${code}"`
+```
+
+This applies to **every** interpolated value — including IDs from `locals.user.id`
+or route params, not just obviously "user-supplied" fields. Use `locals.pb.filter(...)`
+in routes and `pb.filter(...)` in `$lib/server/*` helpers that take `pb: PocketBase`.
+
 ### PocketBase access pattern
 
-`locals.pb` is the PocketBase client (server-side only). `locals.user` is the authenticated user record (null if unauthenticated).
+`locals.pb` is the PocketBase client (server-side only). `locals.user` is the
+authenticated user record (null if unauthenticated). Schema changes are made in
+the PocketBase admin dashboard — there are no migration files in this repo.
 
 ```typescript
 // +page.server.ts
@@ -124,93 +149,112 @@ export async function load({ locals }) {
 }
 ```
 
-Schema changes are made in the PocketBase admin dashboard — no migration files in this repo.
+### Trust-based item visibility
 
-### CRITICAL: always build PocketBase filters with `pb.filter()`
+`filterTrustedItems()` in `$lib/server/itemFilters` hides items with `trusteesOnly=true`
+from users not in the owner's `trusts[]` list. Always call it after fetching items in
+server load functions. Unauthenticated browsing reads the **public views** (`items_public`,
+`users_public`) rather than the base collections — these deliberately omit sensitive
+fields (email, raw coordinates). Be careful not to leak trusted items or trust-graph data
+through them.
 
-Never interpolate values directly into a filter string with template literals
-(`` `owner = "${id}"` ``) — a value containing `"` can break out of the filter
-expression and change which records are matched (filter injection). Always use
-the SDK's `pb.filter(raw, params)` helper, which escapes each placeholder:
+### Item images
 
-```typescript
-// CORRECT
-pb.filter('inviteCode = {:code}', { code: inviteCode })
-
-// WRONG — filter injection if `code` contains a `"`
-`inviteCode = "${code}"`
-```
-
-This applies to every interpolated value, including IDs from `locals.user.id`
-or route params, not just obviously "user-supplied" fields — be consistent.
-Use `locals.pb.filter(...)` in routes and `pb.filter(...)` in `$lib/server/*`
-helpers that take `pb: PocketBase` as a parameter.
-
-### Item image URLs
-
-Item images are PocketBase file fields. To display them, pass `PUBLIC_PB_URL` from the server and construct the URL client-side using the PocketBase SDK:
-
-```typescript
-// server: return { PB_IMG_URL: PUBLIC_PB_URL }
-// client: pb.getFileUrl(item, item.image)
-// or directly: `${PB_IMG_URL}/api/files/items/${item.id}/${item.image}`
-```
+Item images are PocketBase file fields. Pass `PUBLIC_PB_URL` from the server and build the
+URL client-side: `pb.getFileUrl(item, item.image)` or
+`` `${PB_IMG_URL}/api/files/items/${item.id}/${item.image}` ``. Compress uploads client-side
+with `compressImage()` from `$lib/utils/imageUtils`. Items may instead carry an
+`externalImgUrl` (institution catalogue cover) shown when no file is uploaded.
 
 ### Real-time subscriptions
 
-Use `setupPocketBaseSubscription()` from `$lib/utils/utils` for client-side PocketBase realtime (e.g. live chat). It returns an unsubscribe function suitable for use in `$effect` cleanup.
-
-### Trust-based item visibility
-
-`filterTrustedItems()` in `$lib/server/itemFilters` filters items where `trusteesOnly=true` to only show them to users in the owner's `trusts[]` list. Always call this after fetching items in server load functions.
+Use `setupPocketBaseSubscription()` from `$lib/utils/utils` for client-side PocketBase
+realtime (e.g. live chat). It returns an unsubscribe function suitable for `$effect` cleanup.
 
 ## Data model
 
-PocketBase collections:
+PocketBase collections (see [docs/data-model.md](../docs/data-model.md) and
+[docs/domain-model.md](../docs/domain-model.md) for full schemas, the `*_public` view
+SQL, and ER/class diagrams):
 
-| Collection | Key fields |
+| Collection | Purpose / key fields |
 |---|---|
-| `users` | `username`, `email`, `city`, `trusts[]` (user IDs), `telegramUsername`, `signalLink`, `geolocation` (GeoPoint), `preferredTransportMode` |
-| `items` | `name`, `description`, `image` (file), `place`, `owner` (FK user), `trusteesOnly` (bool) |
-| `conversations` | `requester` (FK user), `itemOwner` (FK user), `requestedItem` (FK item), `messages[]`, `readByRequester`, `readByOwner` |
-| `messages` | `messageContent`, `from` (FK user), `to` (FK user) |
-| `notifications` | `recipient` (FK user), `type` (`new_message`\|`new_request`\|`trust_added`), `relatedId`, `body` (German text), `read` (bool) |
-| `push_subscriptions` | `user` (FK user), `endpoint`, `p256dh`, `auth` |
+| `users` | `username`, `email`, `city`, `trusts[]`, `geolocation` (GeoPoint), `preferredTransportMode`, telegram/signal contacts (+ `*VisibleToTrustedOnly`), `inviteCode`, `invitedBy`, `hasOnboarded`, `verified`, `isInstitution`, `profileImage`, `bio` |
+| `items` | `name`, `description`, `image` (file), `place`, `owner` (FK), `trusteesOnly`, `status`, `categories[]`; institution-only `externalId` / `externalUrl` / `externalImgUrl` |
+| `conversations` | `requester`, `itemOwner`, `requestedItem`, `messages[]`, `readByRequester`, `readByOwner`, `lendingStatus`, `counterfactual` |
+| `messages` | `messageContent`, `from` (FK), `to` (FK) |
+| `notifications` | `recipient`, `sender`, `type`, `relatedId`, `body` (German text), `read` |
+| `lending_terms` | versioned institutional terms of use: `owner`, `version`, `title`, `body`, `effectiveFrom`, `active`, `minAge` |
+| `term_acceptances` | acceptance audit trail: `user`, `terms` (FK), `acceptedAt`, `confirmedAdult`, plus snapshots of the terms text/version |
+| `push_subscriptions` | `user` (FK), `endpoint`, `p256dh`, `auth` |
+| `outbound_clicks` | analytics for `/api/redirect`: `destination`, `source_page`, `item` |
+| `searches` | search-query analytics: `query`, `categories` |
 | `feedback` | `feedbackMessage`, `route`, `device`, `viewportSize`, `browser`, `browserVersion` |
+| `items_public` / `users_public` | read-only views for unauthenticated browsing (no email, no raw coordinates) |
 
-See [docs/data-model.md](docs/data-model.md) for ER diagrams.
+`NotificationType`: `new_message`, `new_request`, `trust_added`, `invite_accepted`,
+`request_accepted`, `request_rejected`, `handover_confirmed`, `return_requested`,
+`return_confirmed`.
 
 ## Auth and authorization
 
 `src/hooks.server.ts` runs `sequence(authentication, authorization)` on every request:
 
-- **Authentication** — loads PocketBase auth from cookies, refreshes token, sets `locals.user`
-- **Authorization** — redirects unauthenticated users to `/auth/login`
+- **Authentication** — loads PocketBase auth from cookies, refreshes the token, sets `locals.user`
+- **Authorization** — redirects unauthenticated users to `/auth/login` (preserving `redirectTo`)
 
-Unprotected routes: `/auth/login`, `/auth/register`, `/auth/reset`, `/search`, `/items`, `/users`, `/` (home)
+Unprotected path prefixes (`unprotectedPrefix` in `hooks.server.ts`): `/auth/login`,
+`/auth/register`, `/auth/reset`, `/search`, `/items`, `/users`, `/misc`, `/invite`,
+`/sitemap.xml`, `/api/redirect`, `/api/diagnostics`. Everything else — including `/` (home)
+— requires authentication.
 
 ## Push notifications
 
-Uses Web Push (VAPID) via the `web-push` npm package. Two server helpers in `$lib/server/notifications.ts`:
+Web Push (VAPID) via the `web-push` package. Server helpers in `$lib/server/notifications.ts`:
 - `createNotification()` — writes a record to the `notifications` collection
-- `sendPushToUser()` — sends a push to all registered devices; auto-removes stale subscriptions (HTTP 410/404)
+- `sendPushToUser()` — pushes to all registered devices; auto-removes stale subscriptions (HTTP 410/404)
 
-The service worker (`src/service-worker.ts`) handles `push` and `notificationclick` events. Notifications are suppressed if the user already has the target page open.
+Subscription CRUD lives in `$lib/server/pushSubscriptions.ts` (server) and
+`$lib/utils/pushSubscription.ts` (client). The service worker (`src/service-worker.ts`)
+handles `push` and `notificationclick`; notifications are suppressed if the user already has
+the target page open.
 
 ## External APIs
 
-**OpenRouteService (ORS)** — requires `ORS_API_KEY`:
-- `GET /api/geocode` — address autocomplete (restricted to Germany)
-- `POST /api/travel-times` — travel time matrix between user location and item owners; supports `foot`, `bicycle`, `car` transport modes
+- **OpenRouteService (ORS)** — `ORS_API_KEY`. `GET /api/geocode` (address autocomplete,
+  Germany only) and `POST /api/travel-times` (travel-time matrix; `foot`, `bicycle`, `car`).
+  Server logic in `$lib/server/travelTimes.ts`.
+- **Mistral** — `MISTRAL_API_KEY` (production only). `POST /api/analyze-item` runs item-photo
+  recognition (`pixtral-12b-2409`) to pre-fill name/description/categories. Rate-limited per user.
 
 ## Testing
 
-Test files live co-located with their target (e.g. `+page.server.test.ts` next to `+page.server.ts`). Mock PocketBase by constructing a `mockLocals` object with `pb.collection(name)` returning vi.fn() stubs. See [docs/testing-strategy.md](docs/testing-strategy.md) for a full example.
+Test files live co-located with their target (e.g. `+page.server.test.ts` next to
+`+page.server.ts`). Mock PocketBase by constructing a `mockLocals` object with
+`pb.collection(name)` returning `vi.fn()` stubs. See
+[docs/testing-strategy.md](../docs/testing-strategy.md) for a full example.
 
 ## Text management
 
-All German UI strings live in `src/lib/texts.ts`, organized by feature (`auth`, `nav`, `forms`, `errors`, `buttons`, etc.). Always add new user-facing strings there rather than inline in components.
+All German UI strings live in `src/lib/texts.ts`, organized by feature (`auth`, `nav`,
+`forms`, `errors`, `buttons`, etc.); `ITEM_CATEGORIES` (the fixed 9-category list) lives there
+too. Always add new user-facing strings there rather than inline in components. See
+[docs/text-management.md](../docs/text-management.md).
 
 ## Documentation
 
-Docs live in ./docs and are published on a static GitHub page via a GitHub Action. If Claude makes any changes to the data- or domain-model, it should update them there.
+Docs live in `./docs` and are published to a static GitHub Pages site via a GitHub Action.
+**Read the relevant doc before making structural changes**, and update it whenever you change
+the data or domain model.
+
+**Keep this CLAUDE.md in sync.** Whenever you add, remove, or rename a route, an `/api/*`
+endpoint, a PocketBase collection/view, a server helper or util, or an environment variable,
+update the corresponding section here in the same change so the file never drifts from the code.
+
+- [docs/architecture.md](../docs/architecture.md) — system architecture, auth flow, tech stack
+- [docs/best-practices.md](../docs/best-practices.md) — CRUD form patterns and conventions
+- [docs/data-model.md](../docs/data-model.md) — collection schemas + public-view SQL
+- [docs/domain-model.md](../docs/domain-model.md) — class diagrams and domain relationships
+- [docs/testing-strategy.md](../docs/testing-strategy.md) — testing approach + mock examples
+- [docs/text-management.md](../docs/text-management.md) — UI string organization
+- [docs/operations/](../docs/operations/) — operational runbooks (e.g. institutional onboarding)


### PR DESCRIPTION
## What
Refresh `.claude/CLAUDE.md` so it matches the code currently on `main`.
The guide had drifted as the project grew.

## Changes
- **Routes:** add `onboarding`, `invite/[slug]`, `sitemap.xml`
- **API endpoints:** document `analyze-item` (Mistral, prod only), `diagnostics`, `redirect`
- **Server helpers / utils:** add `registration`, `lendingTerms`, `pushSubscriptions`,
  `travelTimes`; `imageUtils`, `categoryPlaceholder`, `pushSubscription`
- **Env vars:** add `MISTRAL_API_KEY` (production only)
- **Data model:** add `lending_terms`, `term_acceptances`, `outbound_clicks`, `searches`
  and the `items_public` / `users_public` views; new user/item/conversation fields;
  full `NotificationType` union
- **Auth:** correct the unprotected-routes list (`/` is now protected) to match `hooks.server.ts`
- Fix relative doc links (`../docs/...`) and add a docs index
- Add a "keep this file in sync" maintenance note
