### PR TITLE
Fix travel time 400 error when preferredTransportMode is empty

### DIFF
--- a/src/routes/items/[id]/+page.server.ts
+++ b/src/routes/items/[id]/+page.server.ts
@@ -112,7 +112,7 @@ export async function load({ params, locals }) {
 		viewerTrustsOwner,
 		ownerTrustsViewer,
 		ownerItemCount,
-		preferredTransportMode: locals.user?.preferredTransportMode ?? 'bicycle',
+		preferredTransportMode: locals.user?.preferredTransportMode || 'bicycle',
 		existingConversation,
 		requiresTermsAcceptance,
 		ownerHasLocation: !!item.ownerHasLocation,

--- a/src/routes/items/[id]/ItemTravelTime.svelte
+++ b/src/routes/items/[id]/ItemTravelTime.svelte
@@ -16,7 +16,7 @@
 	const { itemId, preferredTransportMode }: Props = $props();
 
 	let transportMode = $state<TransportMode>(
-		untrack(() => preferredTransportMode ?? 'bicycle')
+		untrack(() => preferredTransportMode || 'bicycle')
 	);
 	let travelMinutes = $state<number | null | undefined>(undefined);
 	let dropdownOpen = $state(false);


### PR DESCRIPTION
## Summary

- Fixes a 400 "Invalid transport mode" error when calculating travel times on item detail pages
- Users without a preferred transport mode set have `""` stored in PocketBase, which the nullish coalescing operator (`??`) does not catch — changed to `||` to properly fall back to `'bicycle'`

## Root Cause

`preferredTransportMode ?? 'bicycle'` only triggers the fallback for `null`/`undefined`, not for empty string `""`. Since PocketBase stores unset select fields as empty strings, the empty value was passed through to the `/api/travel-times/item` endpoint which correctly rejects it with a 400.

## Changes

- `src/routes/items/[id]/+page.server.ts`: Use `||` instead of `??` when passing `preferredTransportMode` to the page
- `src/routes/items/[id]/ItemTravelTime.svelte`: Use `||` instead of `??` when initializing the transport mode state