### PR TITLE
fix: load trustees-only item images via items_searchable (#419)

### DIFF
--- a/src/routes/items/[id]/+page.server.ts
+++ b/src/routes/items/[id]/+page.server.ts
@@ -42,12 +42,17 @@ export async function load({ params, locals }) {
 		item.trusteesOnly && isAuthenticated && !isOwnItem && !ownerTrustsViewer;
 
 	// items_public masks trustees-only items (name/image/description are NULL). The owner
-	// and trusted viewers may see full details, read here from the trust-gated base `items`.
+	// and trusted viewers may see full details, read here from the trust-filtered
+	// `items_searchable` view. We must take the image (and its `collectionId`) from that
+	// view too: the file URL is built from `collectionId`, and items_public masks the
+	// image to NULL, so a URL pointing at items_public 404s. items_searchable exposes the
+	// un-masked file (same view search uses), so its file URL resolves in the browser.
 	if (item.trusteesOnly && (isOwnItem || ownerTrustsViewer)) {
 		try {
-			const full = await locals.pb.collection('items').getOne(item.id, {
-				fields: 'id,name,image,externalImgUrl,externalUrl,description',
+			const full = await locals.pb.collection('items_searchable').getOne(item.id, {
+				fields: 'collectionId,name,image,externalImgUrl,externalUrl,description',
 			});
+			item.collectionId = full.collectionId;
 			item.name = full.name;
 			item.image = full.image;
 			item.externalImgUrl = full.externalImgUrl;

--- a/src/routes/users/[id]/+page.server.ts
+++ b/src/routes/users/[id]/+page.server.ts
@@ -51,17 +51,22 @@ export async function load({ params, locals }) {
 	const trustedItems = (profileTrustsViewer || isOwnProfile) ? trustedItemsAll : null;
 
 	// items_public masks trustees-only items (name/image/description are NULL). The owner
-	// and trusted viewers may see full details, read here from the trust-gated base `items`.
+	// and trusted viewers may see full details, read here from the trust-filtered
+	// `items_searchable` view. We must take the image (and its `collectionId`) from that
+	// view too: the file URL is built from `collectionId`, and items_public masks the
+	// image to NULL, so a URL pointing at items_public 404s. items_searchable exposes the
+	// un-masked file (same view search uses), so its file URL resolves in the browser.
 	if (trustedItems && trustedItems.length > 0) {
 		try {
-			const full = await locals.pb.collection('items').getFullList({
-				filter: locals.pb.filter('owner = {:ownerId} && trusteesOnly = true', { ownerId: profileUser.id }),
-				fields: 'id,name,image,externalImgUrl,externalUrl,description',
+			const full = await locals.pb.collection('items_searchable').getFullList({
+				filter: locals.pb.filter('userId = {:ownerId} && trusteesOnly = true', { ownerId: profileUser.id }),
+				fields: 'id,collectionId,name,image,externalImgUrl,externalUrl,description',
 			});
 			const byId = new Map(full.map((f) => [f.id, f] as const));
 			for (const item of trustedItems) {
 				const f = byId.get(item.id);
 				if (!f) continue;
+				item.collectionId = f.collectionId;
 				item.name = f.name;
 				item.image = f.image;
 				item.externalImgUrl = f.externalImgUrl;


### PR DESCRIPTION
## Problem

The item-detail and user-profile pages failed to load the image of **trustees-only** items for the owner and trusted viewers (HTTP 404), even though the same image loads fine in search. Reported in #419 (regression from #402).

## Cause

Both pages read the item from the content-masked `items_public` view, then un-mask `name`/`image`/`description` for the owner and trusted viewers from the base `items` collection — but leave `item.collectionId` pointing at `items_public`.

The image URL is built as `api/files/{collectionId}/{id}/{image}`. Since `items_public` masks the image file to `NULL` for trustees-only items, that URL resolves against a record where the file doesn't exist → **404** (the `pbc_2268005888` collection id in the issue is exactly the `items_public` view).

## Fix

Source the un-masked details — **including `collectionId`** — from the trust-filtered `items_searchable` view instead of the base `items` collection. That is the same view the search page already uses, and its file URLs resolve in the browser because the view exposes the un-masked file.

- `items/[id]/+page.server.ts` — read from `items_searchable`, copy `collectionId`.
- `users/[id]/+page.server.ts` — same; the filter switches from `owner` to `userId` to match the view's column.

The trust gating is unchanged: `items_searchable`'s row rule returns trustees-only rows only to the owner and trusted users — exactly the branch this code already guards with `isOwnItem || ownerTrustsViewer`.

## Testing

- Reproduced at the data layer: as a trusted viewer, the old `items_public` file URL returns **404**, the new `items_searchable` URL returns **200** for the same trustees-only item.
- Verified end-to-end in the browser: image now loads on item-detail and profile for a trusted viewer; the item stays correctly masked for a non-trusted viewer.
- `npx vitest run` → all green. No new typecheck errors.

Closes #419