### PR TITLE
Self-service account deletion + GDPR data export (#248)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -31,6 +31,12 @@ npm run format     # Prettier
 npm run test       # Vitest in WATCH mode
 npx vitest run                       # run all tests once (CI-style)
 npx vitest run src/path/to/file.test.ts  # run a single test file
+
+# Seed a running PocketBase with deterministic test data. Scenarios live in
+# scripts/seed/scenarios/ (one file per feature); shared helpers in scripts/seed/lib.js.
+# Idempotent; only touches its own `@seed.test` records. Requires superuser creds.
+npm run seed                                   # lists available scenarios
+PB_SUPERUSER_EMAIL=you@example.com PB_SUPERUSER_PASSWORD=secret npm run seed -- account-deletion
 ```
 
 ## Environment variables
@@ -179,7 +185,7 @@ SQL, and ER/class diagrams):
 
 | Collection | Purpose / key fields |
 |---|---|
-| `users` | `username`, `email`, `city`, `trusts[]`, `geolocation` (GeoPoint), `preferredTransportMode`, telegram/signal contacts (+ `*VisibleToTrustedOnly`), `inviteCode`, `invitedBy`, `hasOnboarded`, `verified`, `isInstitution`, `profileImage`, `bio` |
+| `users` | `username`, `email`, `city`, `trusts[]`, `geolocation` (GeoPoint), `preferredTransportMode`, telegram/signal contacts (+ `*VisibleToTrustedOnly`), `inviteCode`, `invitedBy`, `hasOnboarded`, `verified`, `isInstitution`, `profileImage`, `bio`, `deleted` / `deletedAt` (account-deletion flag — see below) |
 | `items` | `name`, `description`, `image` (file), `place`, `owner` (FK), `trusteesOnly`, `status`, `categories[]`; institution-only `externalId` / `externalUrl` / `externalImgUrl` |
 | `conversations` | `requester`, `itemOwner`, `requestedItem`, `messages[]`, `readByRequester`, `readByOwner`, `lendingStatus`, `counterfactual` |
 | `messages` | `messageContent`, `from` (FK), `to` (FK) |
@@ -187,6 +193,7 @@ SQL, and ER/class diagrams):
 | `lending_terms` | versioned institutional terms of use: `owner`, `version`, `title`, `body`, `effectiveFrom`, `active`, `minAge` |
 | `term_acceptances` | acceptance audit trail: `user`, `terms` (FK), `acceptedAt`, `confirmedAdult`, plus snapshots of the terms text/version |
 | `push_subscriptions` | `user` (FK), `endpoint`, `p256dh`, `auth` |
+| `deleted_accounts` | restricted audit store written on account deletion: `user` (FK), `email`, `username`, `deletedAt` — **superuser-only access rules**, holds retained identifiers for the dispute-resolution window |
 | `outbound_clicks` | analytics for `/api/redirect`: `destination`, `source_page`, `item` |
 | `searches` | search-query analytics: `query`, `categories` |
 | `feedback` | `feedbackMessage`, `route`, `device`, `viewportSize`, `browser`, `browserVersion` |
@@ -205,8 +212,33 @@ SQL, and ER/class diagrams):
 
 Unprotected path prefixes (`unprotectedPrefix` in `hooks.server.ts`): `/auth/login`,
 `/auth/register`, `/auth/reset`, `/search`, `/items`, `/users`, `/misc`, `/invite`,
-`/sitemap.xml`, `/api/redirect`, `/api/diagnostics`. Everything else — including `/` (home)
-— requires authentication.
+`/sitemap.xml`, `/api/redirect`, `/api/diagnostics`, `/auth/account-deleted`. Everything else —
+including `/` (home) — requires authentication.
+
+## Account deletion & GDPR
+
+Self-service account deletion (Art. 17) and data export (Art. 15/20) live at `/user/account`
+(linked from the profile page). The heavy lifting runs in the **backend PocketBase hooks**
+(`allerleih-backend/pb_hooks/account.pb.js` + `services/account.js`), which have superuser
+`$app` access — required to edit other users' records during anonymization:
+
+- `DELETE /api/account` (body `{ password }`) — re-auth, refuses if a loan is still open
+  (`accepted`/`active`/`return_requested`), then in a transaction: copies `email`+`username`
+  into the restricted `deleted_accounts` collection, hard-deletes personal-only data
+  (contacts, geolocation, push subs, own notifications, and items nobody requested — items
+  referenced by a conversation are kept as `unavailable` since `requestedItem` is required),
+  removes the user from every other user's `trusts[]`, and anonymizes the live `users` row in
+  place (placeholder
+  `username`/`email`, `deleted=true`, random password). Shared/audit data (messages,
+  conversations, `term_acceptances`) is **retained** and resolves to "Gelöschtes Konto".
+- `GET /api/account/export` — machine-readable JSON of all the caller's data; proxied to the
+  browser as a download by `src/routes/user/account/export/+server.ts`.
+- `onRecordAuthRequest` (users) blocks login for `deleted=true` accounts; `hooks.server.ts`
+  enforces the same defensively.
+
+Deleted users' names are masked everywhere via `displayName()` in `$lib/utils/utils.ts` —
+**never render `user.username` directly** for a user that might be deleted. A future "phase 2"
+purge job (not yet built) uses `deletedAt` to finally remove the retained identifiers.
 
 ## Push notifications
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -189,6 +189,42 @@ Coordinates are **not** stored on `users` — they live in a separate `user_geol
 
 Messenger handles (`telegramUsername`, `signalLink`) and their per-handle "visible to trusted only" flags live here, **not** on `users`. All API rules are `@request.auth.id = user` (owner-only). They reach other users only through the `GET /api/contact/{userId}` hook, which returns a handle to a caller only if it's public (flag off), the caller is the owner, or the owner trusts the caller — so the "trusted only" toggle is enforced at the data layer, not just in the UI.
 
+## Account deletion (`deleted` / `deletedAt`, `deleted_accounts`)
+
+Self-service account deletion (GDPR Art. 17) is **two-phase, anonymize-in-place**:
+
+**Phase 1 — deactivate** (`DELETE /api/account`, backend hook with superuser access):
+- The live `users` row is kept but anonymized: `username` → `deleted-<id>`, `email` →
+  `deleted-<id>@deleted.invalid`, profile fields/`trusts[]`/`inviteCode` cleared, password
+  randomized, and `deleted = true` + `deletedAt` set. `deleted` is also exposed on the
+  `users_public` view so the public profile can mask the name.
+- Personal-only data is **hard-deleted**: `user_contacts`, `user_geolocations`,
+  `push_subscriptions`, and the user's own `notifications`. The user is removed from every
+  other user's `trusts[]`, and `invitedBy` referencing them is nulled.
+- `items`: those never requested are hard-deleted. An item still referenced by a conversation
+  **cannot** be deleted (`conversations.requestedItem` is a *required* relation) — it is kept
+  (set to `unavailable`) so the counterparty's loan history resolves. The `items_public` /
+  `items_searchable` views exclude rows whose owner is `deleted`, so a deleted account's
+  listings disappear from search/catalogue while existing conversations still show the item.
+- Shared/audit data is **retained**, de-identified to "Gelöschtes Konto": `messages`,
+  `conversations` (the counterparty keeps a coherent history; the lending paper trail stays
+  intact), and `term_acceptances` (legal-obligation exception, Art. 17(3)).
+- Before scrubbing, the original `email` + `username` are copied into **`deleted_accounts`**
+  (relation `user`, `email`, `username`, `deletedAt`). All its access rules are `null`
+  (superuser-only) so the retained identifiers never reach the client or any view. They exist
+  for dispute resolution (Art. 17(3)(e)) within the retention window documented in the privacy
+  statement.
+- Deletion is refused while any of the user's conversations is `accepted` / `active` /
+  `return_requested` (open loan).
+
+**Phase 2 — purge** (not yet implemented): a scheduled job uses `deletedAt` to finally remove
+`deleted_accounts` rows and the anonymized `users` rows after the retention window; the same
+routine will drive auto-deletion of long-inactive accounts.
+
+Login for a `deleted` account is blocked by an `onRecordAuthRequest` hook and, defensively, in
+`hooks.server.ts`. In the app, **never render `user.username` directly** — use `displayName()`
+(`$lib/utils/utils.ts`), which masks deleted accounts.
+
 ## items_public and items_searchable Views
 
 Two read-only PocketBase SQL views expose `items` joined with `users` (and `user_geolocations` for the location flag) as flat, privacy-safe rows. Neither exposes the owner's `trusts` list, and neither includes raw coordinates — they expose only `ownerHasLocation` (0 or 1); travel times are computed in the backend `/api/travel-times` hook, which returns only **bucketed minutes** so coordinates never reach the client.

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -120,3 +120,9 @@ Institutions (public libraries, lending shops, tool libraries) are regular `User
 - When active terms exist for an institution, borrowers are redirected to `/items/[id]/terms` and must accept before a conversation can be created
 - Acceptance is recorded in `TermAcceptance` with a full snapshot of the terms body, ensuring a legally robust audit trail even when terms are later updated
 - When an institution updates their terms, a new `LendingTerms` record is created with `active = true`; the old record remains for historical acceptances
+
+**Account deletion & anonymization**
+- A user can delete their own account (GDPR Art. 17) from `/user/account`; deletion is refused while a loan is still open (`accepted`/`active`/`return_requested`)
+- Deletion is *anonymize-in-place*: the `User` record is kept but its PII is scrubbed and `deleted` is set, so shared `Conversation`/`Message` history and `TermAcceptance` audit records stay referentially intact and render as "Gelöschtes Konto" to the counterparty
+- Personal-only data (contacts, geolocation, push subscriptions, owned `Item`s, own notifications) is hard-deleted; the user is removed from every other user's `trusts[]`
+- The original email + username are retained in a restricted `deleted_accounts` record for the dispute-resolution window, then purged by a future scheduled job (see [data-model.md](data-model.md))

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -91,6 +91,52 @@ describe('page name, e.g. Conversation Page', () => {
         });
 ```
 
+## Local test data (seeding)
+
+For manual testing and PR review you can populate a running PocketBase with deterministic
+data using the seed runner in [`scripts/seed.js`](/scripts/seed.js). Data is organised into
+named **scenarios** (one file per feature) under [`scripts/seed/scenarios/`](/scripts/seed/scenarios/),
+with shared connection/teardown/factory helpers in [`scripts/seed/lib.js`](/scripts/seed/lib.js).
+
+It is safe to run: it authenticates as a PocketBase **superuser** and only ever touches its
+own records — every seed user is created on the `@seed.test` email domain, and re-running
+first tears down the previous seed data (so it's idempotent). It never affects production.
+
+### Prerequisites
+- A running PocketBase instance (default `http://127.0.0.1:8090`).
+- A superuser. On a fresh DB create one with
+  `./pocketbase superuser create admin@example.com <password>` (in the `allerleih-backend` repo).
+
+### Usage
+
+```powershell
+# PowerShell — set credentials for the current session, then run a scenario
+$env:PB_SUPERUSER_EMAIL = "admin@example.com"
+$env:PB_SUPERUSER_PASSWORD = "<password>"
+npm run seed -- account-deletion
+```
+
+```bash
+# Git Bash / macOS / Linux
+PB_SUPERUSER_EMAIL=admin@example.com PB_SUPERUSER_PASSWORD=secret npm run seed -- account-deletion
+```
+
+- `npm run seed` with no argument **lists** the available scenarios.
+- Optional env var `PB_URL` overrides the PocketBase URL.
+- Seed users all share the password `password123` (the runner prints the logins + a
+  walkthrough on success).
+
+### Adding a scenario
+
+Create `scripts/seed/scenarios/<your-feature>.js` exporting:
+- `description` — a one-line summary (shown by the runner),
+- `async run(pb)` — builds the data via the factories from `../lib.js`
+  (`createUser`, `createItem`, `createMessage`, `createConversation`, `setTrust`) and
+  optionally returns a summary string to print.
+
+The runner discovers the file automatically; no registration needed. Run scenarios one at a
+time — `teardown()` clears all `@seed.test` data before the chosen scenario runs.
+
 ## CI Integration
 
 Tests run automatically on every pull request to `main` via GitHub Actions (`.github/workflows/vitest.yaml`). Coverage is reported as a PR comment via `davelosert/vitest-coverage-report-action` (json + lcov artifacts are also uploaded for download). The build step (`npm run build`) runs in the same workflow, catching TypeScript and Svelte compilation errors before merging.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 		"lint": "eslint . --ext .ts,.svelte,.js",
 		"lint:fix": "eslint . --ext .ts,.svelte,.js --fix",
 		"format": "prettier --write .",
-		"test": "vitest"
+		"test": "vitest",
+		"seed": "node scripts/seed.js"
 	},
 	"devDependencies": {
 		"@eslint/compat": "^2.0.1",

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -1,0 +1,61 @@
+/**
+ * Seed runner for local development and PR review.
+ *
+ * Seed data is organised into named *scenarios* under scripts/seed/scenarios/ — one
+ * file per feature/PR — so scenarios never collide and the next PR just adds its own
+ * file. Shared connection/teardown/factory helpers live in scripts/seed/lib.js.
+ *
+ * It is safe to ship: it talks to a running PocketBase as a superuser and only ever
+ * touches its own records (users on the `@seed.test` domain and what they own), so it
+ * never affects production data. Re-running first tears down the previous seed data.
+ *
+ * Usage (PocketBase must be running):
+ *   PB_SUPERUSER_EMAIL=you@example.com PB_SUPERUSER_PASSWORD=secret npm run seed -- <scenario>
+ * Examples:
+ *   npm run seed -- account-deletion
+ *   npm run seed                       # lists available scenarios
+ * Optional env: PB_URL (default http://127.0.0.1:8090)
+ */
+import { readdir } from 'node:fs/promises';
+import path, { dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { connect, teardown } from './seed/lib.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const scenariosDir = path.join(here, 'seed', 'scenarios');
+
+async function availableScenarios() {
+	const files = await readdir(scenariosDir);
+	return files.filter((f) => f.endsWith('.js')).map((f) => f.replace(/\.js$/, '')).sort();
+}
+
+async function main() {
+	const scenarios = await availableScenarios();
+	const name = process.argv[2] ?? process.env.SEED_SCENARIO;
+
+	if (!name || !scenarios.includes(name)) {
+		console.log(
+			`${name ? `Unknown scenario "${name}".\n\n` : ''}Available scenarios:\n` +
+				scenarios.map((s) => `  - ${s}`).join('\n') +
+				`\n\nRun:  npm run seed -- <scenario>`
+		);
+		process.exit(name ? 1 : 0);
+	}
+
+	const pb = await connect();
+	const cleared = await teardown(pb);
+	if (cleared) console.log(`Cleared ${cleared} previous seed user(s) and their data.`);
+
+	const scenario = await import(pathToFileURL(path.join(scenariosDir, `${name}.js`)).href);
+	console.log(`Seeding scenario "${name}": ${scenario.description ?? ''}\n`);
+	const summary = await scenario.run(pb);
+
+	console.log(`✓ Seed complete.\n\n${summary ?? ''}\n`);
+}
+
+main()
+	.then(() => process.exit(0))
+	.catch((err) => {
+		console.error('Seeding failed:', err?.response ?? err?.message ?? err);
+		process.exit(1);
+	});

--- a/scripts/seed/lib.js
+++ b/scripts/seed/lib.js
@@ -1,0 +1,92 @@
+/**
+ * Shared helpers for seed scenarios (see scripts/seed.js for the runner).
+ *
+ * Everything a scenario creates must use the `@seed.test` email domain for its users,
+ * so `teardown()` can reliably find and remove prior seed data without touching real
+ * records. Scenarios should build their data through the exported factories.
+ */
+import PocketBase from 'pocketbase';
+
+export const SEED_DOMAIN = '@seed.test';
+export const USER_PASSWORD = 'password123';
+
+/** Connect to PocketBase and authenticate as a superuser (creds from env). */
+export async function connect() {
+	const url = process.env.PB_URL ?? 'http://127.0.0.1:8090';
+	const email = process.env.PB_SUPERUSER_EMAIL;
+	const password = process.env.PB_SUPERUSER_PASSWORD;
+	if (!email || !password) {
+		throw new Error(
+			'Missing superuser credentials. Set PB_SUPERUSER_EMAIL and PB_SUPERUSER_PASSWORD.'
+		);
+	}
+	const pb = new PocketBase(url);
+	pb.autoCancellation(false);
+	await pb.collection('_superusers').authWithPassword(email, password);
+	return pb;
+}
+
+async function deleteWhere(pb, collection, filter) {
+	const rows = await pb.collection(collection).getFullList({ filter }).catch(() => []);
+	for (const row of rows) await pb.collection(collection).delete(row.id).catch(() => {});
+}
+
+/**
+ * Remove all data from any previous seed run (users on the `@seed.test` domain and
+ * everything they own), so scenarios are re-runnable. Deletes in FK-safe order.
+ */
+export async function teardown(pb) {
+	const seedUsers = await pb
+		.collection('users')
+		.getFullList({ filter: `email ~ "${SEED_DOMAIN}"` })
+		.catch(() => []);
+	if (seedUsers.length === 0) return 0;
+
+	const ids = seedUsers.map((u) => u.id);
+	const anyOf = (field) => '(' + ids.map((id) => `${field} = "${id}"`).join(' || ') + ')';
+
+	await deleteWhere(pb, 'messages', `${anyOf('from')} || ${anyOf('to')}`);
+	await deleteWhere(pb, 'conversations', `${anyOf('requester')} || ${anyOf('itemOwner')}`);
+	await deleteWhere(pb, 'items', anyOf('owner'));
+	for (const u of seedUsers) await pb.collection('users').delete(u.id).catch(() => {});
+	return seedUsers.length;
+}
+
+// --- Factories -------------------------------------------------------------
+
+export function createUser(pb, username, overrides = {}) {
+	return pb.collection('users').create({
+		username,
+		email: `${username}${SEED_DOMAIN}`,
+		password: USER_PASSWORD,
+		passwordConfirm: USER_PASSWORD,
+		verified: true,
+		hasOnboarded: true,
+		...overrides,
+	});
+}
+
+export function createItem(pb, ownerId, name, categories, opts = {}) {
+	return pb.collection('items').create({
+		name,
+		description: opts.description ?? `${name} (Testdaten)`,
+		place: opts.place ?? 'Kassel',
+		owner: ownerId,
+		status: opts.status ?? 'available',
+		trusteesOnly: opts.trusteesOnly ?? false,
+		categories,
+	});
+}
+
+export async function createMessage(pb, fromId, toId, content) {
+	const msg = await pb.collection('messages').create({ messageContent: content, from: fromId, to: toId });
+	return msg.id;
+}
+
+export function createConversation(pb, data) {
+	return pb.collection('conversations').create(data);
+}
+
+export function setTrust(pb, userId, trustedIds) {
+	return pb.collection('users').update(userId, { trusts: trustedIds });
+}

--- a/scripts/seed/scenarios/account-deletion.js
+++ b/scripts/seed/scenarios/account-deletion.js
@@ -1,0 +1,77 @@
+/**
+ * Scenario: account deletion / GDPR (PR #248).
+ *
+ *  - alice_seed has an ACTIVE loan (borrowing bob's "Kochbuch") → deleting alice is
+ *    blocked until that loan is completed.
+ *  - bob_seed has a COMPLETED loan (borrowed alice's "Bohrmaschine") with messages both
+ *    ways → after alice is deleted, bob still sees the conversation, anonymized to
+ *    "Gelöschtes Konto".
+ *  - alice ↔ bob trust each other; carla trusts alice; bob owns a trustees-only item.
+ */
+import {
+	createUser,
+	createItem,
+	createMessage,
+	createConversation,
+	setTrust,
+	USER_PASSWORD,
+	SEED_DOMAIN,
+} from '../lib.js';
+
+export const description =
+	'Account deletion: active loan blocks deletion; completed loan retained + anonymized.';
+
+export async function run(pb) {
+	const alice = await createUser(pb, 'alice_seed');
+	const bob = await createUser(pb, 'bob_seed');
+	const carla = await createUser(pb, 'carla_seed');
+
+	await setTrust(pb, alice.id, [bob.id]);
+	await setTrust(pb, bob.id, [alice.id]);
+	await setTrust(pb, carla.id, [alice.id]);
+
+	const drill = await createItem(pb, alice.id, 'Bohrmaschine', ['Werkzeug und Garten']);
+	await createItem(pb, alice.id, 'Campingzelt', ['Reisen und Outdoor']);
+	const cookbook = await createItem(pb, bob.id, 'Kochbuch', ['Bücher']);
+	await createItem(pb, bob.id, 'Beamer', ['Ton und Licht'], { trusteesOnly: true });
+	await createItem(pb, carla.id, 'Brettspiel', ['Spiele']);
+
+	// Completed loan: bob borrowed alice's drill (retained + anonymized after alice deletes).
+	await createConversation(pb, {
+		requester: bob.id,
+		itemOwner: alice.id,
+		requestedItem: drill.id,
+		messages: [
+			await createMessage(pb, bob.id, alice.id, 'Hi Alice, kann ich deine Bohrmaschine leihen?'),
+			await createMessage(pb, alice.id, bob.id, 'Klar, gerne! Wann passt es dir?'),
+			await createMessage(pb, bob.id, alice.id, 'Super, habe sie abgeholt – danke!'),
+			await createMessage(pb, bob.id, alice.id, 'Zurückgebracht, vielen Dank :)'),
+		],
+		readByRequester: true,
+		readByOwner: true,
+		lendingStatus: 'completed',
+	});
+
+	// Active loan: alice is borrowing bob's cookbook → this BLOCKS deleting alice.
+	await createConversation(pb, {
+		requester: alice.id,
+		itemOwner: bob.id,
+		requestedItem: cookbook.id,
+		messages: [
+			await createMessage(pb, alice.id, bob.id, 'Hallo Bob, darf ich dein Kochbuch ausleihen?'),
+			await createMessage(pb, bob.id, alice.id, 'Ja klar, ich bringe es dir morgen vorbei.'),
+		],
+		readByRequester: true,
+		readByOwner: false,
+		lendingStatus: 'active',
+	});
+
+	return `  Login (password for all: "${USER_PASSWORD}"):
+    alice_seed${SEED_DOMAIN} · bob_seed${SEED_DOMAIN} · carla_seed${SEED_DOMAIN}
+
+  Walkthrough:
+    1. Log in as alice → /user/account → delete is BLOCKED (active loan: borrowing bob's Kochbuch).
+    2. As bob, confirm the return of the Kochbuch (loan → completed), then delete alice's account.
+    3. Log in as bob → open the "Bohrmaschine" conversation → alice shows as "Gelöschtes Konto".
+    4. Search no longer lists alice's items; her data export is available before deletion at /user/account.`;
+}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -10,6 +10,7 @@ const unprotectedPrefix = [
 	'/auth/login',
 	'/auth/register',
 	'/auth/reset',
+	'/auth/account-deleted',
 	'/search',
 	'/items',
 	'/users',
@@ -30,7 +31,16 @@ export const authentication: Handle = async ({ event, resolve }) => {
 	try {
 		if (event.locals.pb.authStore.isValid) {
 			await event.locals.pb.collection('users').authRefresh();
-			event.locals.user = event.locals.pb.authStore.record;
+			const record = event.locals.pb.authStore.record;
+			// Defense-in-depth: a deleted (anonymized) account must never be treated as
+			// logged in, even if a stale cookie survives. The backend also rejects auth
+			// for these accounts (see allerleih-backend/pb_hooks/account.pb.js).
+			if (record?.deleted) {
+				event.locals.pb.authStore.clear();
+				event.locals.user = null;
+			} else {
+				event.locals.user = record;
+			}
 		} else {
 			event.locals.user = null;
 		}

--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -12,9 +12,12 @@ export const ITEM_CATEGORIES = [
 ] as const;
 export type ItemCategory = (typeof ITEM_CATEGORIES)[number];
 
+/** App name — referenced in interpolated strings below (object literals can't self-reference via `this`). */
+const APP_NAME = 'AllerLeih';
+
 export const texts = {
 	names: {
-		app: 'AllerLeih',
+		app: APP_NAME,
 		mainContactMail: 'kontakt@allerleih.org',
 	},
 
@@ -692,10 +695,15 @@ export const texts = {
 		},
 		// Goodbye page after successful deletion
 		deleted: {
-			title: 'Dein Konto wurde gelöscht',
-			body: 'Schade, dass du gehst. Deine persönlichen Daten wurden gelöscht. Danke, dass du Teil von AllerLeih warst.',
+			title: 'Auf Wiedersehen!',
+			body: `Dein Konto und deine persönlichen Daten wurden gelöscht. Danke, dass du Teil von ${APP_NAME} warst.`,
+			secondary: 'Du bist jederzeit willkommen, falls du irgendwann zurückkommen möchtest.',
 			backHome: 'Zur Startseite',
 		},
+		// Shown on the public profile of a deleted account
+		deletedProfileNotice: 'Dieses Konto wurde gelöscht. Die zugehörigen Daten sind nicht mehr verfügbar.',
+		// Guard when trying to trust a deleted account
+		cannotTrustDeleted: 'Dieses Konto wurde gelöscht und kann nicht als vertrauenswürdig markiert werden.',
 	},
 
 	// Notifications

--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -653,6 +653,51 @@ export const texts = {
 		}
 	},
 
+	// Account management, data export and deletion (GDPR)
+	account: {
+		/** Masked display name for deleted/anonymized accounts. */
+		deletedAccountName: 'Gelöschtes Konto',
+		pageTitle: 'Konto & Datenschutz',
+		pageIntro:
+			'Hier kannst du eine Kopie deiner Daten herunterladen oder dein Konto endgültig löschen.',
+		// Profile-page entry point
+		manageLink: 'Konto & Datenschutz',
+		// Data export (Art. 15 / 20)
+		export: {
+			title: 'Meine Daten exportieren',
+			description:
+				'Lade eine maschinenlesbare Kopie (JSON) aller Daten herunter, die wir über dich speichern – Profil, Gegenstände, Gespräche, Nachrichten und mehr.',
+			button: 'Daten herunterladen',
+			preparing: 'Daten werden vorbereitet …',
+			error: 'Export fehlgeschlagen. Bitte versuche es später erneut.',
+		},
+		// Account deletion (Art. 17)
+		delete: {
+			title: 'Konto löschen',
+			description:
+				'Dein Konto und deine persönlichen Daten werden gelöscht. Aus rechtlichen Gründen (z. B. zur Klärung von Streitfällen) bewahren wir deine E-Mail-Adresse und deinen Namen für eine begrenzte Zeit in geschützter Form auf, bevor auch diese endgültig entfernt werden. Bereits ausgetauschte Nachrichten bleiben bei deinem jeweiligen Gegenüber erhalten, dort jedoch anonymisiert als „Gelöschtes Konto".',
+			warning: 'Diese Aktion kann nicht rückgängig gemacht werden.',
+			confirmPhrase: 'LÖSCHEN',
+			confirmPhraseLabel: 'Tippe LÖSCHEN, um zu bestätigen',
+			passwordLabel: 'Passwort zur Bestätigung',
+			passwordPlaceholder: 'Dein aktuelles Passwort',
+			openButton: 'Konto löschen',
+			confirmButton: 'Mein Konto endgültig löschen',
+			cancelButton: 'Abbrechen',
+			// Error/blocked states
+			wrongPassword: 'Falsches Passwort.',
+			activeLoansBlocked:
+				'Du hast noch offene Ausleihen. Bitte schließe diese ab (Übergabe bzw. Rückgabe bestätigen), bevor du dein Konto löschst.',
+			genericError: 'Löschung fehlgeschlagen. Bitte versuche es später erneut.',
+		},
+		// Goodbye page after successful deletion
+		deleted: {
+			title: 'Dein Konto wurde gelöscht',
+			body: 'Schade, dass du gehst. Deine persönlichen Daten wurden gelöscht. Danke, dass du Teil von AllerLeih warst.',
+			backHome: 'Zur Startseite',
+		},
+	},
+
 	// Notifications
 	notifications: {
 		title: 'Benachrichtigungen',

--- a/src/lib/types/models.ts
+++ b/src/lib/types/models.ts
@@ -117,6 +117,15 @@ export interface User extends PocketBaseEntity {
 	 * Institutions: address, opening hours, website, lending modalities.
 	 */
 	bio?: string;
+
+	/**
+	 * Set when the user has deleted their account (phase 1 "deactivate"). The row is
+	 * anonymized in place; login is blocked and the UI shows "Gelöschtes Konto".
+	 */
+	deleted?: boolean;
+
+	/** ISO datetime the account was deleted/anonymized (drives the future purge job). */
+	deletedAt?: string;
 }
 
 export interface UserPublic extends PocketBaseEntity {
@@ -127,6 +136,8 @@ export interface UserPublic extends PocketBaseEntity {
 	profileImage: string | null;
 	telegramVisibleToTrustedOnly: boolean;
 	signalVisibleToTrustedOnly: boolean;
+	/** True if this account has been deleted/anonymized — used to mask the username. */
+	deleted?: boolean;
 }
 
 // --- ITEM ---

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -1,3 +1,29 @@
+import { texts } from '$lib/texts';
+
+/**
+ * The anonymized username a deleted account gets on the backend (`deleted-<15-char id>`).
+ * Keep in sync with anonymizeAccount() in allerleih-backend/pb_hooks/services/account.js.
+ */
+const DELETED_USERNAME_RE = /^deleted-[a-z0-9]{15}$/;
+
+/**
+ * Display name for a user, masking deleted/anonymized accounts to "Gelöschtes Konto".
+ * Never render `user.username` directly — always pass the user object through this helper.
+ *
+ * Masks when the `deleted` flag is set, OR when the username matches the backend's
+ * placeholder shape. The latter is a safety net for records loaded from a source that
+ * doesn't expose `deleted` (e.g. a view that omits the column), so the raw `deleted-<id>`
+ * placeholder can never leak to the UI even if the flag is missing.
+ */
+export function displayName(
+	user: { username?: string; deleted?: boolean } | null | undefined
+): string {
+	if (!user || user.deleted || (user.username && DELETED_USERNAME_RE.test(user.username))) {
+		return texts.account.deletedAccountName;
+	}
+	return user.username ?? texts.account.deletedAccountName;
+}
+
 export function formatTimestamp(
 	timestamp: string,
 	includeYear: boolean = false

--- a/src/routes/auth/account-deleted/+page.svelte
+++ b/src/routes/auth/account-deleted/+page.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { texts } from '$lib/texts';
+	import { resolve } from '$app/paths';
+</script>
+
+<svelte:head>
+	<title>{texts.account.deleted.title}</title>
+	<meta name="robots" content="noindex, nofollow" />
+</svelte:head>
+
+<main class="flex justify-center bg-secondary-100 dark:bg-tinte-900 px-4">
+	<div class="max-w-md w-full text-center bg-sand border border-tinte-200 rounded-lg shadow-sm dark:bg-tinte-800 dark:border-tinte-700 p-8 space-y-4">
+		<h1 class="text-2xl font-extrabold text-gray-900 dark:text-white">
+			{texts.account.deleted.title}
+		</h1>
+		<p class="text-tinte-700 dark:text-tinte-300">
+			{texts.account.deleted.body}
+		</p>
+		<a
+			href={resolve('/')}
+			class="inline-block mt-2 py-3 px-6 min-button bg-primary-200 hover:bg-primary text-white font-semibold rounded-xl transition-opacity"
+		>
+			{texts.account.deleted.backHome}
+		</a>
+	</div>
+</main>

--- a/src/routes/auth/account-deleted/+page.svelte
+++ b/src/routes/auth/account-deleted/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { texts } from '$lib/texts';
 	import { resolve } from '$app/paths';
+	import { HeartOutline } from 'flowbite-svelte-icons';
 </script>
 
 <svelte:head>
@@ -8,13 +9,19 @@
 	<meta name="robots" content="noindex, nofollow" />
 </svelte:head>
 
-<main class="flex justify-center bg-secondary-100 dark:bg-tinte-900 px-4">
-	<div class="max-w-md w-full text-center bg-sand border border-tinte-200 rounded-lg shadow-sm dark:bg-tinte-800 dark:border-tinte-700 p-8 space-y-4">
+<main class="flex justify-center bg-secondary-100 dark:bg-tinte-900 px-4 py-16 sm:py-24">
+	<div class="max-w-md w-full text-center bg-sand border border-tinte-200 rounded-2xl shadow-sm dark:bg-tinte-800 dark:border-tinte-700 p-8 sm:p-10 space-y-5">
+		<div class="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-primary-100 dark:bg-primary-900/30">
+			<HeartOutline class="h-8 w-8 text-primary" />
+		</div>
 		<h1 class="text-2xl font-extrabold text-gray-900 dark:text-white">
 			{texts.account.deleted.title}
 		</h1>
 		<p class="text-tinte-700 dark:text-tinte-300">
 			{texts.account.deleted.body}
+		</p>
+		<p class="text-sm text-tinte-500 dark:text-tinte-400">
+			{texts.account.deleted.secondary}
 		</p>
 		<a
 			href={resolve('/')}

--- a/src/routes/conversations/ConversationListItem.svelte
+++ b/src/routes/conversations/ConversationListItem.svelte
@@ -2,6 +2,7 @@
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { texts } from '$lib/texts';
+	import { displayName } from '$lib/utils/utils';
 
 	let { conversation, currentUser, PB_IMG_URL, activeTab } = $props();
 
@@ -70,7 +71,7 @@
 				{conversation.expand.requestedItem.name}
 			</p>
 			<p class="text-xs text-tinte-400 dark:text-tinte-500 truncate leading-tight mt-0.5">
-				{activeTab === 'borrowing' ? 'von' : 'an'} {otherUser.username}
+				{activeTab === 'borrowing' ? 'von' : 'an'} {displayName(otherUser)}
 			</p>
 			{#if lendingStatusLabel}
 				<span class="inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium mt-0.5

--- a/src/routes/conversations/[conversationId]/+page.svelte
+++ b/src/routes/conversations/[conversationId]/+page.svelte
@@ -9,7 +9,7 @@
 	// Other imports
 	import { Button, Modal, Input } from 'flowbite-svelte';
 	import MessageElement from './MessageElement.svelte';
-	import { setupPocketBaseSubscription } from '$lib/utils/utils';
+	import { setupPocketBaseSubscription, displayName } from '$lib/utils/utils';
 	import type { Conversation, Message } from '$lib/types/models';
 	import { texts } from '$lib/texts';
 	import ConversationHeader from './ConversationHeader.svelte';
@@ -148,14 +148,14 @@
 <LendingStatusBar
 	{lendingStatus}
 	isOwner={loggedInUserIsItemOwner}
-	itemOwnerUsername={data.conversation.itemOwner.username}
+	itemOwnerUsername={displayName(data.conversation.itemOwner)}
 />
 
 <!-- Messages list -->
 <div bind:this={chatWindow} class="flex flex-col flex-1 overflow-auto px-4 py-4 gap-0.5 bg-papier dark:bg-tinte-900">
 	{#if lendingStatus === 'pending' && messages.length === 0 && !loggedInUserIsItemOwner}
 		<p class="text-xl p-4 text-center max-w-100 mx-auto my-auto text-tinte-400 dark:text-tinte-500 italic">
-			{texts.lending.statusDescription.pending.requesterNudge(chatPartner.username, data.conversation.requestedItem.name)}
+			{texts.lending.statusDescription.pending.requesterNudge(displayName(chatPartner), data.conversation.requestedItem.name)}
 		</p>
 	{/if}
 	{#each messages as message (message.id)}

--- a/src/routes/conversations/[conversationId]/ConversationHeader.svelte
+++ b/src/routes/conversations/[conversationId]/ConversationHeader.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { texts } from '$lib/texts';
-	import { formatTimestamp } from '$lib/utils/utils';
+	import { formatTimestamp, displayName } from '$lib/utils/utils';
 	import { TrashBinSolid, ChevronLeftOutline } from 'flowbite-svelte-icons';
 	import { Tooltip } from 'flowbite-svelte';
 	import { enhance } from '$app/forms';
@@ -31,10 +31,12 @@
 
 	const showMessengerSection = $derived(telegramAvailable || telegramHidden || signalAvailable || signalHidden);
 
+	const chatPartnerName = $derived(displayName(chatPartner));
+
 	const chatPartnerAvatarUrl = $derived(
 		chatPartner.profileImage
 			? `${PB_URL}api/files/users/${chatPartner.id}/${chatPartner.profileImage}`
-			: `https://ui-avatars.com/api/?name=${encodeURIComponent(chatPartner.username)}&background=random`
+			: `https://ui-avatars.com/api/?name=${encodeURIComponent(chatPartnerName)}&background=random`
 	);
 </script>
 
@@ -124,7 +126,7 @@
 			class="flex items-center gap-2 hover:opacity-80 transition-opacity"
 		>
 			<div class="hidden md:flex flex-col items-end">
-				<span class="text-sm font-medium">{chatPartner.username}</span>
+				<span class="text-sm font-medium">{chatPartnerName}</span>
 				<span class="text-xs text-tinte-500 dark:text-tinte-400">
 					{texts.ui.activeSince(formatTimestamp(chatPartner.created, true))}
 				</span>

--- a/src/routes/items/[id]/OwnerCard.svelte
+++ b/src/routes/items/[id]/OwnerCard.svelte
@@ -2,6 +2,7 @@
 	import { UserCircleOutline, HomeOutline, CheckCircleOutline } from 'flowbite-svelte-icons';
 	import { resolve } from '$app/paths';
 	import { texts } from '$lib/texts';
+	import { displayName } from '$lib/utils/utils';
 	import type { UserPublic } from '$lib/types/models';
 
 	interface Props {
@@ -19,7 +20,6 @@
 	const cardTitle = $derived(
 		isInstitution ? texts.pages.itemDetail.institutionCardTitle : texts.pages.itemDetail.ownerCardTitle
 	);
-	console.log(owner.created);
 	const registeredSince = $derived(
 		new Date(owner.created).toLocaleDateString('de-DE', { month: 'long', year: 'numeric' })
 	);
@@ -54,7 +54,7 @@
 					href={resolve('/users/[id]', { id: owner.id })}
 					class="font-semibold text-tinte-900 dark:text-white hover:text-primary hover:underline"
 				>
-					{owner.username}
+					{displayName(owner)}
 				</a>
 				<!-- Email verification -->
 				{#if owner.verified}

--- a/src/routes/onboarding/+page.server.ts
+++ b/src/routes/onboarding/+page.server.ts
@@ -15,7 +15,10 @@ export async function load({ locals, url }) {
 		await locals.pb.collection('users').update(locals.user.id, { inviteCode });
 	}
 
-	const users = await locals.pb.collection('users').getFullList<User>();
+	// Exclude deleted (anonymized) accounts from the trustee picker.
+	const users = await locals.pb.collection('users').getFullList<User>({
+		filter: locals.pb.filter('deleted != true'),
+	});
 	const geolocation = await getUserGeolocation(locals.pb, locals.user.id);
 	const contact = await getOwnContact(locals.pb, locals.user.id);
 

--- a/src/routes/search/ItemCard.svelte
+++ b/src/routes/search/ItemCard.svelte
@@ -8,6 +8,7 @@
 	import VerifiedIcon from '$lib/components/VerifiedIcon.svelte';
 	import TransportModeIcon from '$lib/components/TransportModeIcon.svelte';
 	import { getCategoryPlaceholder } from '$lib/utils/categoryPlaceholder';
+	import { displayName } from '$lib/utils/utils';
 
 	type TransportMode = 'foot' | 'bicycle' | 'car';
 
@@ -101,7 +102,7 @@
 					{:else}
 						<UserCircleOutline class="h-6 w-6 inline" />
 					{/if}
-					<span class="font-medium text-xs max-w-20 truncate ml-1">{item.username ?? 'Unknown'}</span>
+					<span class="font-medium text-xs max-w-20 truncate ml-1">{displayName({ username: item.username })}</span>
 					<div class="absolute top-0 -right-1.5 flex flex-col gap-0.1 items-center">
 						{#if item.verified}
 							<VerifiedIcon class="h-3.5 w-3.5" />

--- a/src/routes/social/+page.server.ts
+++ b/src/routes/social/+page.server.ts
@@ -9,7 +9,10 @@ export async function load({ locals, url }) {
 	let users: User[] = [];
 
 	try {
-		users = await locals.pb.collection('users').getFullList();
+		// Exclude deleted (anonymized) accounts so they can't be found/added as trustees.
+		users = await locals.pb.collection('users').getFullList({
+			filter: locals.pb.filter('deleted != true'),
+		});
 	} catch (error: Error | any) {
 		console.error(error.message ? error.message : error);
 	}
@@ -53,6 +56,14 @@ export const actions = {
 		const formData = await request.formData();
 		const newTrusteeId = formData.get('trusteeId') as string;
 		const newTrusteeUsername = formData.get('trusteeUsername') as string | null;
+
+		// Cannot trust a deleted (anonymized) account.
+		try {
+			const target = await locals.pb.collection('users_public').getOne(newTrusteeId);
+			if (target.deleted) return fail(400, { fail: true, message: texts.account.cannotTrustDeleted });
+		} catch {
+			return fail(404, { fail: true, message: texts.errors.somethingWentWrong });
+		}
 
 		try {
 			await locals.pb.collection('users').update(locals.user.id, {

--- a/src/routes/user/account/+page.server.ts
+++ b/src/routes/user/account/+page.server.ts
@@ -1,0 +1,48 @@
+import { fail, redirect } from '@sveltejs/kit';
+import { texts } from '$lib/texts';
+import type { ClientResponseError } from 'pocketbase';
+
+export async function load({ locals }) {
+	return {
+		currentUser: locals.user,
+	};
+}
+
+export const actions = {
+	deleteAccount: async ({ locals, request }) => {
+		const formData = await request.formData();
+		const password = formData.get('password')?.toString() ?? '';
+
+		if (!password) {
+			return fail(400, { error: true, message: texts.account.delete.wrongPassword });
+		}
+
+		try {
+			// Delegated to the backend hook (DELETE /api/account), which runs the
+			// anonymization with superuser access and atomically. pb.send attaches the
+			// current auth token.
+			await locals.pb.send('/api/account', {
+				method: 'DELETE',
+				body: { password },
+			});
+		} catch (err) {
+			const e = err as ClientResponseError;
+			const code = (e.response as { code?: string })?.code;
+			if (e.status === 400 || code === 'invalid_password') {
+				return fail(400, { error: true, message: texts.account.delete.wrongPassword });
+			}
+			if (e.status === 409 || code === 'active_loans') {
+				return fail(409, { error: true, message: texts.account.delete.activeLoansBlocked });
+			}
+			console.error('Account deletion failed', err);
+			return fail(500, { error: true, message: texts.account.delete.genericError });
+		}
+
+		// Account is gone — drop the session so the cleared auth cookie is written by
+		// the authentication hook on this response.
+		locals.pb.authStore.clear();
+		locals.user = null;
+
+		redirect(303, '/auth/account-deleted');
+	},
+};

--- a/src/routes/user/account/+page.svelte
+++ b/src/routes/user/account/+page.svelte
@@ -37,10 +37,6 @@
 			<p class="mt-2 text-sm text-tinte-600 dark:text-tinte-400">{texts.account.pageIntro}</p>
 		</div>
 
-		{#if form?.error}
-			<CustomAlert type="error" message={form.message} />
-		{/if}
-
 		<!-- Data export (Art. 15 / 20) -->
 		<section class="bg-sand border border-tinte-200 rounded-lg shadow-sm dark:bg-tinte-800 dark:border-tinte-700 p-6">
 			<h2 class="text-lg font-semibold text-tinte-900 dark:text-white">{texts.account.export.title}</h2>
@@ -77,17 +73,24 @@
 		use:enhance={() => {
 			isDeleting = true;
 			return async ({ update }) => {
-				await update();
+				// keep the typed values on error so the user only fixes the password
+				await update({ reset: false });
 				isDeleting = false;
 			};
 		}}
 		class="space-y-4"
+		autocomplete="off"
 	>
+
 		<p class="text-sm text-tinte-700 dark:text-tinte-300">{texts.account.delete.description}</p>
+
+		{#if form?.error}
+			<CustomAlert type="error" message={form.message} />
+		{/if}
 
 		<div>
 			<Label for="confirmText" class="mb-1">{texts.account.delete.confirmPhraseLabel}</Label>
-			<Input id="confirmText" bind:value={confirmText} autocomplete="off" />
+			<Input id="confirmText" name="confirmPhrase" bind:value={confirmText} autocomplete="off" />
 		</div>
 
 		<div>
@@ -98,7 +101,7 @@
 				type="password"
 				bind:value={password}
 				placeholder={texts.account.delete.passwordPlaceholder}
-				autocomplete="current-password"
+				autocomplete="new-password"
 			/>
 		</div>
 

--- a/src/routes/user/account/+page.svelte
+++ b/src/routes/user/account/+page.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+	import { texts } from '$lib/texts';
+	import { Button, Modal, Input, Label } from 'flowbite-svelte';
+	import { enhance } from '$app/forms';
+	import { resolve } from '$app/paths';
+	import CustomAlert from '$lib/components/CustomAlert.svelte';
+
+	let { form } = $props();
+
+	let showDeleteModal = $state(false);
+	let confirmText = $state('');
+	let password = $state('');
+	let isDeleting = $state(false);
+
+	const canDelete = $derived(
+		confirmText.trim() === texts.account.delete.confirmPhrase && password.length > 0
+	);
+
+	function closeModal() {
+		showDeleteModal = false;
+		confirmText = '';
+		password = '';
+	}
+</script>
+
+<svelte:head>
+	<title>{texts.account.pageTitle}</title>
+	<meta name="robots" content="noindex, nofollow" />
+</svelte:head>
+
+<main class="bg-secondary-100 dark:bg-tinte-900 min-h-screen">
+	<div class="max-w-2xl mx-auto px-4 py-8 sm:py-12 space-y-6">
+		<div class="text-center">
+			<h1 class="text-2xl tracking-tight font-extrabold text-gray-900 dark:text-white">
+				{texts.account.pageTitle}
+			</h1>
+			<p class="mt-2 text-sm text-tinte-600 dark:text-tinte-400">{texts.account.pageIntro}</p>
+		</div>
+
+		{#if form?.error}
+			<CustomAlert type="error" message={form.message} />
+		{/if}
+
+		<!-- Data export (Art. 15 / 20) -->
+		<section class="bg-sand border border-tinte-200 rounded-lg shadow-sm dark:bg-tinte-800 dark:border-tinte-700 p-6">
+			<h2 class="text-lg font-semibold text-tinte-900 dark:text-white">{texts.account.export.title}</h2>
+			<p class="mt-1 text-sm text-tinte-600 dark:text-tinte-400">{texts.account.export.description}</p>
+			<a
+				href={resolve('/user/account/export')}
+				download
+				class="mt-4 inline-flex items-center justify-center py-2.5 px-5 min-button bg-primary-200 hover:bg-primary text-white font-semibold rounded-xl transition-opacity"
+			>
+				{texts.account.export.button}
+			</a>
+		</section>
+
+		<!-- Danger zone — account deletion (Art. 17) -->
+		<section class="border border-accent-300 dark:border-accent-700 rounded-lg shadow-sm bg-accent-50 dark:bg-accent-900/20 p-6">
+			<h2 class="text-lg font-semibold text-accent-800 dark:text-accent-300">{texts.account.delete.title}</h2>
+			<p class="mt-1 text-sm text-tinte-700 dark:text-tinte-300">{texts.account.delete.description}</p>
+			<p class="mt-2 text-sm font-semibold text-accent-700 dark:text-accent-400">{texts.account.delete.warning}</p>
+			<Button
+				color="red"
+				class="mt-4"
+				onclick={() => (showDeleteModal = true)}
+			>
+				{texts.account.delete.openButton}
+			</Button>
+		</section>
+	</div>
+</main>
+
+<Modal title={texts.account.delete.title} bind:open={showDeleteModal} dismissable={false} onclose={closeModal}>
+	<form
+		method="POST"
+		action="?/deleteAccount"
+		use:enhance={() => {
+			isDeleting = true;
+			return async ({ update }) => {
+				await update();
+				isDeleting = false;
+			};
+		}}
+		class="space-y-4"
+	>
+		<p class="text-sm text-tinte-700 dark:text-tinte-300">{texts.account.delete.description}</p>
+
+		<div>
+			<Label for="confirmText" class="mb-1">{texts.account.delete.confirmPhraseLabel}</Label>
+			<Input id="confirmText" bind:value={confirmText} autocomplete="off" />
+		</div>
+
+		<div>
+			<Label for="password" class="mb-1">{texts.account.delete.passwordLabel}</Label>
+			<Input
+				id="password"
+				name="password"
+				type="password"
+				bind:value={password}
+				placeholder={texts.account.delete.passwordPlaceholder}
+				autocomplete="current-password"
+			/>
+		</div>
+
+		<div class="flex justify-end gap-3 pt-2">
+			<Button color="alternative" type="button" onclick={closeModal}>
+				{texts.account.delete.cancelButton}
+			</Button>
+			<Button color="red" type="submit" disabled={!canDelete || isDeleting}>
+				{texts.account.delete.confirmButton}
+			</Button>
+		</div>
+	</form>
+</Modal>

--- a/src/routes/user/account/export/+server.ts
+++ b/src/routes/user/account/export/+server.ts
@@ -1,0 +1,24 @@
+import { error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+// Proxy the pocketbase backend export (GET /api/account/export) and stream it back as a file
+// download. Keeps the auth token server-side; the client just hits this route.
+export const GET: RequestHandler = async ({ locals }) => {
+	if (!locals.user) error(401);
+
+	let payload: unknown;
+	try {
+		payload = await locals.pb.send('/api/account/export', { method: 'GET' });
+	} catch (err) {
+		console.error('Data export failed', err);
+		error(500, 'export_failed');
+	}
+
+	return new Response(JSON.stringify(payload, null, 2), {
+		headers: {
+			'Content-Type': 'application/json; charset=utf-8',
+			'Content-Disposition': 'attachment; filename="allerleih-meine-daten.json"',
+			'Cache-Control': 'no-store',
+		},
+	});
+};

--- a/src/routes/user/account/page.server.test.ts
+++ b/src/routes/user/account/page.server.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { actions } from './+page.server';
+
+type DeleteEvent = Parameters<typeof actions.deleteAccount>[0];
+
+function setup(sendImpl: () => Promise<unknown> = () => Promise.resolve({ ok: true })) {
+	const send = vi.fn(sendImpl);
+	const clear = vi.fn();
+	const locals = {
+		user: { id: 'u1' },
+		pb: { send, authStore: { clear } },
+	};
+	return { locals, send, clear };
+}
+
+function callDelete(locals: unknown, password: string | undefined) {
+	const fd = new FormData();
+	if (password !== undefined) fd.set('password', password);
+	return actions.deleteAccount({
+		locals,
+		request: { formData: vi.fn().mockResolvedValue(fd) },
+	} as unknown as DeleteEvent);
+}
+
+describe('account: deleteAccount action', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('calls the backend DELETE endpoint, clears the session and redirects to the goodbye page', async () => {
+		const { locals, send, clear } = setup();
+
+		// redirect() throws — capture it.
+		const result = await callDelete(locals, 'secret').catch((e) => e);
+
+		expect(send).toHaveBeenCalledWith('/api/account', {
+			method: 'DELETE',
+			body: { password: 'secret' },
+		});
+		expect(clear).toHaveBeenCalledOnce();
+		expect(result).toMatchObject({ status: 303, location: '/auth/account-deleted' });
+	});
+
+	it('fails with 400 when no password is supplied (no backend call)', async () => {
+		const { locals, send } = setup();
+
+		const result = await callDelete(locals, '');
+
+		expect(send).not.toHaveBeenCalled();
+		expect(result).toMatchObject({ status: 400, data: { error: true } });
+	});
+
+	it('maps a 400 from the backend to a wrong-password failure', async () => {
+		const { locals, clear } = setup(() =>
+			Promise.reject(Object.assign(new Error('bad'), { status: 400, response: { code: 'invalid_password' } }))
+		);
+
+		const result = await callDelete(locals, 'wrong');
+
+		expect(clear).not.toHaveBeenCalled();
+		expect(result).toMatchObject({ status: 400, data: { error: true } });
+	});
+
+	it('maps a 409 from the backend to an active-loans failure', async () => {
+		const { locals, clear } = setup(() =>
+			Promise.reject(Object.assign(new Error('blocked'), { status: 409, response: { code: 'active_loans' } }))
+		);
+
+		const result = await callDelete(locals, 'secret');
+
+		expect(clear).not.toHaveBeenCalled();
+		expect(result).toMatchObject({ status: 409, data: { error: true } });
+	});
+});

--- a/src/routes/user/profile/+page.svelte
+++ b/src/routes/user/profile/+page.svelte
@@ -201,4 +201,13 @@
 	<NotificationSettings />
 
 	<InviteLink inviteUrl={data.inviteUrl} />
+
+	<div class="max-w-2xl mx-auto px-4 pb-8">
+		<a
+			href={resolve('/user/account')}
+			class="block text-center text-sm font-medium text-tinte-600 dark:text-tinte-400 underline hover:text-primary"
+		>
+			{texts.account.manageLink}
+		</a>
+	</div>
 </main>

--- a/src/routes/user/profile/+page.svelte
+++ b/src/routes/user/profile/+page.svelte
@@ -203,11 +203,21 @@
 	<InviteLink inviteUrl={data.inviteUrl} />
 
 	<div class="max-w-2xl mx-auto px-4 pb-8">
-		<a
-			href={resolve('/user/account')}
-			class="block text-center text-sm font-medium text-tinte-600 dark:text-tinte-400 underline hover:text-primary"
-		>
-			{texts.account.manageLink}
-		</a>
+		<div class="bg-sand border border-tinte-200 rounded-lg shadow-sm dark:bg-tinte-800 dark:border-tinte-700 p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+			<div>
+				<h2 class="text-lg font-semibold text-tinte-900 dark:text-white">
+					{texts.account.manageLink}
+				</h2>
+				<p class="mt-1 text-sm text-tinte-600 dark:text-tinte-400">
+					{texts.account.pageIntro}
+				</p>
+			</div>
+			<a
+				href={resolve('/user/account')}
+				class="shrink-0 inline-flex items-center justify-center py-2.5 px-5 min-button bg-primary-200 hover:bg-primary text-white font-semibold rounded-xl transition-opacity"
+			>
+				{texts.account.manageLink}
+			</a>
+		</div>
 	</div>
 </main>

--- a/src/routes/users/[id]/+page.server.ts
+++ b/src/routes/users/[id]/+page.server.ts
@@ -15,6 +15,26 @@ export async function load({ params, locals }) {
 		error(e.status === 404 ? 404 : 500, 'User not found');
 	}
 
+	// Deleted (anonymized) account: render a minimal tombstone. Skip all item and
+	// trust-graph queries — there is nothing left to show.
+	if (profileUser.deleted) {
+		// The row is already anonymized (empty bio/profileImage, placeholder username),
+		// so it's safe to pass through; the page renders only a tombstone.
+		return {
+			profileUser,
+			isDeleted: true,
+			publicItems: [],
+			trustedItems: null,
+			hiddenItemsCount: 0,
+			hiddenCategories: [],
+			isOwnProfile: false,
+			loggedIn: !!locals.user,
+			viewerTrustsProfile: false,
+			profileTrustsViewer: false,
+			PB_IMG_URL: PUBLIC_PB_URL,
+		};
+	}
+
 	let allItems: Item[] = [];
 	try {
 		allItems = await locals.pb.collection('items_public').getFullList({
@@ -106,6 +126,14 @@ export const actions = {
 	addTrust: async ({ params, locals }) => {
 		if (!locals.user) return fail(401, { message: texts.errors.noPermission });
 		if (params.id === locals.user.id) return fail(400, { message: texts.errors.noPermission });
+
+		// Cannot trust a deleted (anonymized) account.
+		try {
+			const target = await locals.pb.collection('users_public').getOne(params.id);
+			if (target.deleted) return fail(400, { message: texts.account.cannotTrustDeleted });
+		} catch {
+			return fail(404, { message: texts.errors.noPermission });
+		}
 
 		const profileUserId = params.id;
 		const updatedTrusts = [...(locals.user.trusts || []), profileUserId];

--- a/src/routes/users/[id]/+page.svelte
+++ b/src/routes/users/[id]/+page.svelte
@@ -20,8 +20,10 @@
 	);
 
 	const activeSinceDate = $derived(
-		new Intl.DateTimeFormat('de-DE', { month: 'long', year: 'numeric' })
-			.format(new Date(data.profileUser.created))
+		data.profileUser.created
+			? new Intl.DateTimeFormat('de-DE', { month: 'long', year: 'numeric' })
+					.format(new Date(data.profileUser.created))
+			: ''
 	);
 </script>
 
@@ -34,36 +36,46 @@
 </svelte:head>
 
 <div class="mx-auto max-w-3xl px-4 py-6 space-y-8">
-	<ProfileHeader
-		username={profileName}
-		{profileImageUrl}
-		verified={data.profileUser.verified}
-		isInstitution={data.profileUser.isInstitution}
-		{activeSinceDate}
-	/>
-
-	{#if data.profileUser.bio}
-		<div class="space-y-1">
-			<h2 class="text-sm font-semibold text-tinte-500 dark:text-tinte-400 uppercase tracking-wide">
-				{data.profileUser.isInstitution ? texts.pages.profile.bioLabelInstitution : texts.pages.profile.bioLabel}
-			</h2>
-			<p class="text-tinte-700 dark:text-tinte-300 whitespace-pre-wrap">
-				{data.profileUser.bio}
+	{#if data.isDeleted}
+		<!-- Tombstone for a deleted (anonymized) account -->
+		<div class="text-center py-16 space-y-3">
+			<h1 class="text-2xl font-bold text-tinte-700 dark:text-tinte-200">{profileName}</h1>
+			<p class="text-tinte-500 dark:text-tinte-400 max-w-md mx-auto">
+				{texts.account.deletedProfileNotice}
 			</p>
 		</div>
-	{/if}
+	{:else}
+		<ProfileHeader
+			username={profileName}
+			{profileImageUrl}
+			verified={data.profileUser.verified}
+			isInstitution={data.profileUser.isInstitution}
+			{activeSinceDate}
+		/>
 
-	{#if !isOwnProfile && data.loggedIn}
-		<TrustSection {profileTrustsViewer} {viewerTrustsProfile} />
-	{/if}
+		{#if data.profileUser.bio}
+			<div class="space-y-1">
+				<h2 class="text-sm font-semibold text-tinte-500 dark:text-tinte-400 uppercase tracking-wide">
+					{data.profileUser.isInstitution ? texts.pages.profile.bioLabelInstitution : texts.pages.profile.bioLabel}
+				</h2>
+				<p class="text-tinte-700 dark:text-tinte-300 whitespace-pre-wrap">
+					{data.profileUser.bio}
+				</p>
+			</div>
+		{/if}
 
-	<ItemsSection
-		publicItems={data.publicItems}
-		trustedItems={data.trustedItems}
-		hiddenItemsCount={data.hiddenItemsCount}
-		hiddenCategories={data.hiddenCategories}
-		{profileImageUrl}
-		pbImgUrl={data.PB_IMG_URL}
-		loggedIn={data.loggedIn}
-	/>
+		{#if !isOwnProfile && data.loggedIn}
+			<TrustSection {profileTrustsViewer} {viewerTrustsProfile} />
+		{/if}
+
+		<ItemsSection
+			publicItems={data.publicItems}
+			trustedItems={data.trustedItems}
+			hiddenItemsCount={data.hiddenItemsCount}
+			hiddenCategories={data.hiddenCategories}
+			{profileImageUrl}
+			pbImgUrl={data.PB_IMG_URL}
+			loggedIn={data.loggedIn}
+		/>
+	{/if}
 </div>

--- a/src/routes/users/[id]/+page.svelte
+++ b/src/routes/users/[id]/+page.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
 	import { texts } from '$lib/texts';
+	import { displayName } from '$lib/utils/utils';
 	import ProfileHeader from './ProfileHeader.svelte';
 	import TrustSection from './TrustSection.svelte';
 	import ItemsSection from './ItemsSection.svelte';
 
 	const { data } = $props();
+
+	const profileName = $derived(displayName(data.profileUser));
 
 	const isOwnProfile = $derived(data.isOwnProfile);
 	const viewerTrustsProfile = $derived(data.viewerTrustsProfile);
@@ -23,16 +26,16 @@
 </script>
 
 <svelte:head>
-	<title>{texts.seo.userProfile(data.profileUser.username)}</title>
-	<meta name="description" content={texts.seo.userProfileDescription(data.profileUser.username)} />
-	<meta property="og:title" content={texts.seo.userProfile(data.profileUser.username)} />
-	<meta property="og:description" content={texts.seo.userProfileDescription(data.profileUser.username)} />
+	<title>{texts.seo.userProfile(profileName)}</title>
+	<meta name="description" content={texts.seo.userProfileDescription(profileName)} />
+	<meta property="og:title" content={texts.seo.userProfile(profileName)} />
+	<meta property="og:description" content={texts.seo.userProfileDescription(profileName)} />
 	<meta property="og:type" content="website" />
 </svelte:head>
 
 <div class="mx-auto max-w-3xl px-4 py-6 space-y-8">
 	<ProfileHeader
-		username={data.profileUser.username}
+		username={profileName}
 		{profileImageUrl}
 		verified={data.profileUser.verified}
 		isInstitution={data.profileUser.isInstitution}


### PR DESCRIPTION
# Self-service account deletion + GDPR data export (#248)

## Why
Users had no way to delete their own account, and GDPR data-subject requests were handled entirely by hand. This adds self-service **account deletion (Art. 17)** and a **data export (Art. 15/20)**, and resolves the tricky part: deleting one person must not erase the other party's conversation history or break the lending paper trail.

## What changed (key decisions)

**Deletion is "anonymize-in-place", not a hard delete.** When a user deletes their account:
- Their **personal data is removed** — profile, contacts, location, push subscriptions, and items nobody ever requested.
- **Shared/legal records are kept but de-identified**: conversations, messages, completed loans, and terms-of-use acceptances remain so the *other* party keeps a coherent history and disputes stay traceable. The deleted user shows everywhere as **"Gelöschtes Konto"**.
- **Email + username are retained** in a restricted, admin-only store for a limited window (dispute resolution under Art. 17(3)(e)); the live record is scrubbed so the email frees up for re-registration immediately. A future scheduled job purges these (also the basis for the planned 6-month auto-deletion of inactive accounts).
- We deliberately **did not use DB cascade deletes** — cascade would destroy exactly the counterparty/audit data we must retain.

**Guard rails & UX**
- Deletion is **blocked while a loan is open** (active/return-pending), so nobody is left with an unresolved borrow.
- Requires **password re-entry + typing a confirmation word**; lands on a farewell page.
- Deleted accounts: **can't log in**, **don't appear** in trust search or onboarding, their **profile shows a tombstone**, and they **can't be trusted**.

**Data export** — one-click download of everything we store about the user as machine-readable JSON (internal DB metadata stripped).

> Note: this spans two repos — the SvelteKit app **and** `allerleih-backend` (the deletion/export logic runs as a PocketBase hook with elevated rights, plus migrations adding the `deleted` flag and the audit store). Both need to be deployed together.

## How to test
1. **Backend**: from `allerleih-backend`, run a fresh PocketBase (`./pocketbase serve`) so the new migrations apply, and create a superuser.
2. **Seed test data** (see [docs/testing-strategy.md](docs/testing-strategy.md) for details):
env:PB_SUPERUSER_EMAIL="…"; $env:PB_SUPERUSER_PASSWORD="…"
npm run seed -- account-deletion


This creates `alice_seed` / `bob_seed` / `carla_seed` (password `password123`) with trust links, a completed loan, and an **active** loan. Then `npm run dev`.
3. **Walkthrough**:
- As **alice** → *Profil → Konto & Datenschutz*: try to delete → **blocked** (active loan). Also click "Meine Daten exportieren" and check the JSON.
- As **bob**: confirm the Kochbuch return so that loan completes.
- As **alice**: delete (wrong password → error shows *inside* the modal; correct password → farewell page).
- As **bob**: open the Bohrmaschine conversation → alice shows as **"Gelöschtes Konto"**, history intact. Search & trust no longer surface alice; her profile is a tombstone.
- Try logging in as alice → rejected. Re-register with alice's old email → works.
4. **Admin check**: a `deleted_accounts` row holds alice's original email/username; her live record is scrubbed (`deleted=true`).

`npm run check`, `npm run lint`, and `npx vitest run` all pass.