### PR TITLE
fix(items): restore item images broken by items_public view masking

### DIFF
--- a/src/lib/utils/utils.test.ts
+++ b/src/lib/utils/utils.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { itemImageUrl } from './utils';
+
+const PB_URL = 'https://pb.example.com/';
+
+describe('itemImageUrl', () => {
+	it('serves an uploaded file via the items_searchable view, not the record collectionId', () => {
+		const url = itemImageUrl(PB_URL, { id: 'item123', image: 'photo_abc.jpg' });
+		expect(url).toBe('https://pb.example.com/api/files/items_searchable/item123/photo_abc.jpg');
+	});
+
+	it('ignores collectionId entirely (so items_public ids cannot produce 404 URLs)', () => {
+		const url = itemImageUrl(PB_URL, {
+			id: 'item123',
+			image: 'photo_abc.jpg',
+			// a collectionId on the record must not leak into the URL
+			...({ collectionId: 'pbc_items_public' } as Record<string, unknown>),
+		});
+		expect(url).not.toContain('pbc_items_public');
+		expect(url).toContain('/items_searchable/');
+	});
+
+	it('falls back to externalImgUrl when no file is uploaded', () => {
+		const url = itemImageUrl(PB_URL, {
+			id: 'item123',
+			image: null,
+			externalImgUrl: 'https://catalogue.example/cover.jpg',
+		});
+		expect(url).toBe('https://catalogue.example/cover.jpg');
+	});
+
+	it('prefers the uploaded file over externalImgUrl', () => {
+		const url = itemImageUrl(PB_URL, {
+			id: 'item123',
+			image: 'photo_abc.jpg',
+			externalImgUrl: 'https://catalogue.example/cover.jpg',
+		});
+		expect(url).toBe('https://pb.example.com/api/files/items_searchable/item123/photo_abc.jpg');
+	});
+
+	it('returns null when there is neither a file nor an external image', () => {
+		expect(itemImageUrl(PB_URL, { id: 'item123', image: null })).toBeNull();
+		expect(itemImageUrl(PB_URL, { id: 'item123', image: '', externalImgUrl: '' })).toBeNull();
+	});
+});

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -24,6 +24,27 @@ export function displayName(
 	return user.username ?? texts.account.deletedAccountName;
 }
 
+/**
+ * Build the display URL for an item's image, falling back to its external image URL.
+ *
+ * Item file fields are served via the `items_searchable` view, NOT the record's own
+ * `collectionId`. Records read from `items_public` carry that view's id, but its `image`
+ * column is a masking expression PocketBase does not serve as a file (→ 404). In
+ * `items_searchable`, `image` is a real, trust-filtered file column: it serves public items
+ * to everyone and trustees-only items only to authorized viewers. Use this for any item
+ * loaded from a public view; base-`items` records (their own `collectionId` already resolves)
+ * don't need it.
+ */
+export function itemImageUrl(
+	pbUrl: string,
+	item: { id: string; image?: string | null; externalImgUrl?: string | null }
+): string | null {
+	if (item.image) {
+		return `${pbUrl}api/files/items_searchable/${item.id}/${item.image}`;
+	}
+	return item.externalImgUrl || null;
+}
+
 export function formatTimestamp(
 	timestamp: string,
 	includeYear: boolean = false

--- a/src/routes/items/[id]/+page.svelte
+++ b/src/routes/items/[id]/+page.svelte
@@ -4,6 +4,7 @@
 	import { HeartSolid } from 'flowbite-svelte-icons';
 	import { texts } from '$lib/texts';
 	import { getCategoryPlaceholder } from '$lib/utils/categoryPlaceholder';
+	import { itemImageUrl } from '$lib/utils/utils';
 	import type { ItemPublic, UserPublic } from '$lib/types/models';
 	import ItemImage from './ItemImage.svelte';
 	import ItemTravelTime from './ItemTravelTime.svelte';
@@ -27,11 +28,7 @@
 	const categoryPlaceholder = $derived(getCategoryPlaceholder(item.categories));
 	const isArchived = $derived(item.description?.startsWith('[Nicht mehr im Bestand]') ?? false);
 
-	const imageUrl = $derived(
-		item.image
-			? `${data.PB_IMG_URL}api/files/${item.collectionId}/${item.id}/${item.image}`
-			: (item.externalImgUrl ?? null)
-	);
+	const imageUrl = $derived(itemImageUrl(data.PB_IMG_URL, item));
 
 	const ownerImageUrl = $derived(
 		owner.profileImage
@@ -49,9 +46,7 @@
 				)
 	);
 	const seoImage = $derived(
-		item.image
-			? `${data.PB_IMG_URL}api/files/${item.collectionId}/${item.id}/${item.image}`
-			: 'https://allerleih.org/og-invite.png'
+		itemImageUrl(data.PB_IMG_URL, item) ?? 'https://allerleih.org/og-invite.png'
 	);
 </script>
 

--- a/src/routes/search/ResultsList.svelte
+++ b/src/routes/search/ResultsList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Gallery } from 'flowbite-svelte';
+	import { itemImageUrl } from '$lib/utils/utils';
 	import ItemCard from './ItemCard.svelte';
 	import type { ItemPublic } from '$lib/types/models';
 
@@ -22,7 +23,7 @@
 	{#each filteredItemList as item (item.id)}
 		<ItemCard
 			{item}
-			imgUrl={item.image ? `${PB_IMG_URL}api/files/${item.collectionId}/${item.id}/${item.image}` : (item.externalImgUrl ?? '')}
+			imgUrl={itemImageUrl(PB_IMG_URL, item) ?? ''}
 			ownerImgUrl={item.profileImage
 				? `${PB_IMG_URL}api/files/users/${item.userId}/${item.profileImage}`
 				: undefined}

--- a/src/routes/users/[id]/ItemsSection.svelte
+++ b/src/routes/users/[id]/ItemsSection.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { texts } from '$lib/texts';
+	import { itemImageUrl } from '$lib/utils/utils';
 	import type { Item, ItemPublic } from '$lib/types/models';
 	import ItemCard from '../../search/ItemCard.svelte';
 	import LockedItemCard from './LockedItemCard.svelte';
@@ -101,7 +102,7 @@
 			{#each displayedItems as item (item.id)}
 				<ItemCard
 					item={item as unknown as ItemPublic}
-					imgUrl={item.image ? `${pbImgUrl}api/files/${item.collectionId}/${item.id}/${item.image}` : (item.externalImgUrl ?? '')}
+					imgUrl={itemImageUrl(pbImgUrl, item) ?? ''}
 					ownerImgUrl={profileImageUrl ?? undefined}
 					profileView={true}
 				/>


### PR DESCRIPTION
## Problem

All item images on the site returned **404** (e.g. `https://allerleih.org/items/ga22hdt2i5ikbhn`). Owner portraits and other assets loaded fine.

## Root cause

Item image URLs were built from the record's own `collectionId`:

```
${PB_IMG_URL}api/files/${item.collectionId}/${item.id}/${item.image}
```

For records read from the **`items_public`** view, `collectionId` is that view's collection id. Since `items_public` masks the `image` column to `NULL` for trustees-only items, `image` is a *computed* column there — PocketBase no longer recognises it as a file field, so every file URL built from an `items_public` row 404s (verified on prod: the same file served via `items` / `items_searchable` returns 200, via `items_public` returns 404). Owner portraits were unaffected because their URL hardcodes the `users` collection name.

This regressed when `items_public` started masking the `image` column.

## Fix

Add a central `itemImageUrl()` helper (`$lib/utils/utils.ts`) that serves item files from the **`items_searchable`** view instead of the record's `collectionId`. In `items_searchable`, `image` is a real, trust-filtered file column: it serves public items to everyone and trustees-only items only to authorized viewers (owner + trusted), so URLs resolve again without leaking restricted images.

Applied to the view-sourced sites:
- `items/[id]/+page.svelte` (detail image + OG/SEO image)
- `users/[id]/ItemsSection.svelte` (public profile)
- `search/ResultsList.svelte`

Deliberately **not** touched: `conversations/*` and `user/items/*`. These read the base `items` collection, whose `collectionId` already resolves; switching them to `items_searchable` would 404 thumbnails for e.g. conversations with deleted owners (that view excludes deleted owners' items).

## Verification

- Prod: `…/api/files/items_searchable/<id>/<file>` → **200** (the `items_public` variant → 404).
- `npm run check`: 0 errors · ESLint: clean · Vitest: **174 passed** (incl. 5 new tests for `itemImageUrl`).