### PR TITLE
Allow deleting multiple items, guard against open conversations

### DIFF
--- a/src/lib/server/items.test.ts
+++ b/src/lib/server/items.test.ts
@@ -10,17 +10,37 @@ import { deleteConversation } from '../../routes/conversations/[conversationId]/
 const OWNER_ID = 'user123';
 const OTHER_ID = 'user999';
 
+/**
+ * Builds a mock PocketBase.
+ *
+ * Conversations getFullList is called twice per deleteItem:
+ *   1. open-guard query  — filter contains "lendingStatus"
+ *   2. cascade query     — filter contains only the item ID
+ *
+ * We distinguish them via the filter string so each collection() call
+ * can return the right data regardless of how many times the factory is invoked.
+ */
 function makePb({
 	item,
-	conversations = [],
+	openConversations = [],
+	allConversations = [],
 }: {
 	item?: { id: string; owner: string } | null;
-	conversations?: { id: string }[];
+	openConversations?: { id: string }[];
+	allConversations?: { id: string }[];
 }) {
-	const getOne = item === null ? vi.fn().mockRejectedValue(new Error('not found')) : vi.fn().mockResolvedValue(item);
+	const getOne =
+		item === null
+			? vi.fn().mockRejectedValue(new Error('not found'))
+			: vi.fn().mockResolvedValue(item);
 	const deleteRecord = vi.fn().mockResolvedValue(undefined);
 	const update = vi.fn().mockResolvedValue(undefined);
-	const getFullList = vi.fn().mockResolvedValue(conversations);
+
+	const getFullList = vi.fn(({ filter }: { filter?: string } = {}) =>
+		typeof filter === 'string' && filter.includes('lendingStatus')
+			? Promise.resolve(openConversations)
+			: Promise.resolve(allConversations)
+	);
 
 	const pb = {
 		collection: vi.fn((name: string) => {
@@ -46,37 +66,51 @@ function makePb({
 describe('deleteItem', () => {
 	beforeEach(() => vi.clearAllMocks());
 
-	it('deletes conversations and item when caller is owner', async () => {
+	it('deletes conversations and item when caller is owner and no open conversations exist', async () => {
 		const pb = makePb({
 			item: { id: 'item1', owner: OWNER_ID },
-			conversations: [{ id: 'conv1' }, { id: 'conv2' }],
+			openConversations: [],
+			allConversations: [{ id: 'conv1' }, { id: 'conv2' }],
 		});
 
 		const result = await deleteItem(pb, 'item1', OWNER_ID);
 
-		expect(result).toBe(true);
+		expect(result).toEqual({ status: 'deleted' });
 		expect(deleteConversation).toHaveBeenCalledTimes(2);
 		expect(deleteConversation).toHaveBeenCalledWith(pb, 'conv1');
 		expect(deleteConversation).toHaveBeenCalledWith(pb, 'conv2');
 		expect(pb._deleteRecord).toHaveBeenCalledWith('item1');
 	});
 
-	it('returns false and deletes nothing when caller is not the owner', async () => {
-		const pb = makePb({ item: { id: 'item1', owner: OWNER_ID } });
+	it('returns has_open_conversations and deletes nothing when open conversations exist', async () => {
+		const pb = makePb({
+			item: { id: 'item1', owner: OWNER_ID },
+			openConversations: [{ id: 'conv-active' }],
+		});
 
-		const result = await deleteItem(pb, 'item1', OTHER_ID);
+		const result = await deleteItem(pb, 'item1', OWNER_ID);
 
-		expect(result).toBe(false);
+		expect(result).toEqual({ status: 'has_open_conversations', conversationIds: ['conv-active'] });
 		expect(deleteConversation).not.toHaveBeenCalled();
 		expect(pb._deleteRecord).not.toHaveBeenCalled();
 	});
 
-	it('returns false when item is not found', async () => {
+	it('returns not_owner and deletes nothing when caller is not the owner', async () => {
+		const pb = makePb({ item: { id: 'item1', owner: OWNER_ID } });
+
+		const result = await deleteItem(pb, 'item1', OTHER_ID);
+
+		expect(result).toEqual({ status: 'not_owner' });
+		expect(deleteConversation).not.toHaveBeenCalled();
+		expect(pb._deleteRecord).not.toHaveBeenCalled();
+	});
+
+	it('returns not_found when item does not exist', async () => {
 		const pb = makePb({ item: null });
 
 		const result = await deleteItem(pb, 'nonexistent', OWNER_ID);
 
-		expect(result).toBe(false);
+		expect(result).toEqual({ status: 'not_found' });
 		expect(pb._deleteRecord).not.toHaveBeenCalled();
 	});
 });
@@ -84,36 +118,63 @@ describe('deleteItem', () => {
 describe('deleteMultipleItems', () => {
 	beforeEach(() => vi.clearAllMocks());
 
-	it('deletes owned items and skips non-owned, returns correct count', async () => {
-		let callCount = 0;
+	it('deletes items without open conversations and collects blocked ones', async () => {
+		// item1: owned, no open convs → deleted
+		// item2: owned, has open conv → blocked
+		const itemMap: Record<string, { id: string; owner: string }> = {
+			item1: { id: 'item1', owner: OWNER_ID },
+			item2: { id: 'item2', owner: OWNER_ID },
+		};
+		const openConvsByItemId: Record<string, { id: string }[]> = {
+			item1: [],
+			item2: [{ id: 'conv-open' }],
+		};
+
 		const pb = {
 			collection: vi.fn((name: string) => {
 				if (name === 'items') {
 					return {
-						getOne: vi.fn(() => {
-							callCount++;
-							// item1 owned, item2 not owned, item3 owned
-							const owners = [OWNER_ID, OTHER_ID, OWNER_ID];
-							return Promise.resolve({ id: `item${callCount}`, owner: owners[callCount - 1] });
-						}),
+						getOne: vi.fn((id: string) => Promise.resolve(itemMap[id])),
 						delete: vi.fn().mockResolvedValue(undefined),
 					};
 				}
-				if (name === 'conversations') return { getFullList: vi.fn().mockResolvedValue([]) };
+				if (name === 'conversations') {
+					return {
+						getFullList: vi.fn(({ filter }: { filter?: string } = {}) => {
+							if (typeof filter === 'string' && filter.includes('lendingStatus')) {
+								// Open guard — derive item ID from the filter string
+								for (const [itemId, convs] of Object.entries(openConvsByItemId)) {
+									if (filter.includes(itemId)) return Promise.resolve(convs);
+								}
+								return Promise.resolve([]);
+							}
+							return Promise.resolve([]); // cascade — no remaining convs
+						}),
+					};
+				}
 				return {};
 			}),
-			filter: (raw: string) => raw,
+			filter: (raw: string, params?: Record<string, unknown>) => {
+				if (!params) return raw;
+				return Object.entries(params).reduce(
+					(acc, [k, v]) => acc.replace(`{:${k}}`, String(v)),
+					raw
+				);
+			},
 		} as unknown as Parameters<typeof deleteMultipleItems>[0];
 
-		const count = await deleteMultipleItems(pb, ['item1', 'item2', 'item3'], OWNER_ID);
+		const { deleted, blocked } = await deleteMultipleItems(pb, ['item1', 'item2'], OWNER_ID);
 
-		expect(count).toBe(2);
+		expect(deleted).toBe(1);
+		expect(blocked).toHaveLength(1);
+		expect(blocked[0].itemId).toBe('item2');
+		expect(blocked[0].conversationIds).toEqual(['conv-open']);
 	});
 
-	it('returns 0 when itemIds is empty', async () => {
+	it('returns deleted=0, blocked=[] when itemIds is empty', async () => {
 		const pb = makePb({ item: { id: 'x', owner: OWNER_ID } });
-		const count = await deleteMultipleItems(pb, [], OWNER_ID);
-		expect(count).toBe(0);
+		const result = await deleteMultipleItems(pb, [], OWNER_ID);
+		expect(result).toEqual({ deleted: 0, blocked: [] });
 	});
 });
 

--- a/src/lib/server/items.test.ts
+++ b/src/lib/server/items.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { deleteItem, deleteMultipleItems, setItemStatus } from './items';
+
+vi.mock('../../routes/conversations/[conversationId]/conversation.server', () => ({
+	deleteConversation: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { deleteConversation } from '../../routes/conversations/[conversationId]/conversation.server';
+
+const OWNER_ID = 'user123';
+const OTHER_ID = 'user999';
+
+function makePb({
+	item,
+	conversations = [],
+}: {
+	item?: { id: string; owner: string } | null;
+	conversations?: { id: string }[];
+}) {
+	const getOne = item === null ? vi.fn().mockRejectedValue(new Error('not found')) : vi.fn().mockResolvedValue(item);
+	const deleteRecord = vi.fn().mockResolvedValue(undefined);
+	const update = vi.fn().mockResolvedValue(undefined);
+	const getFullList = vi.fn().mockResolvedValue(conversations);
+
+	const pb = {
+		collection: vi.fn((name: string) => {
+			if (name === 'items') return { getOne, delete: deleteRecord, update };
+			if (name === 'conversations') return { getFullList };
+			return {};
+		}),
+		filter: (raw: string, params?: Record<string, unknown>) => {
+			if (!params) return raw;
+			return Object.entries(params).reduce(
+				(acc, [k, v]) => acc.replace(`{:${k}}`, String(v)),
+				raw
+			);
+		},
+		_deleteRecord: deleteRecord,
+		_update: update,
+		_getOne: getOne,
+		_getFullList: getFullList,
+	};
+	return pb as unknown as Parameters<typeof deleteItem>[0] & typeof pb;
+}
+
+describe('deleteItem', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('deletes conversations and item when caller is owner', async () => {
+		const pb = makePb({
+			item: { id: 'item1', owner: OWNER_ID },
+			conversations: [{ id: 'conv1' }, { id: 'conv2' }],
+		});
+
+		const result = await deleteItem(pb, 'item1', OWNER_ID);
+
+		expect(result).toBe(true);
+		expect(deleteConversation).toHaveBeenCalledTimes(2);
+		expect(deleteConversation).toHaveBeenCalledWith(pb, 'conv1');
+		expect(deleteConversation).toHaveBeenCalledWith(pb, 'conv2');
+		expect(pb._deleteRecord).toHaveBeenCalledWith('item1');
+	});
+
+	it('returns false and deletes nothing when caller is not the owner', async () => {
+		const pb = makePb({ item: { id: 'item1', owner: OWNER_ID } });
+
+		const result = await deleteItem(pb, 'item1', OTHER_ID);
+
+		expect(result).toBe(false);
+		expect(deleteConversation).not.toHaveBeenCalled();
+		expect(pb._deleteRecord).not.toHaveBeenCalled();
+	});
+
+	it('returns false when item is not found', async () => {
+		const pb = makePb({ item: null });
+
+		const result = await deleteItem(pb, 'nonexistent', OWNER_ID);
+
+		expect(result).toBe(false);
+		expect(pb._deleteRecord).not.toHaveBeenCalled();
+	});
+});
+
+describe('deleteMultipleItems', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('deletes owned items and skips non-owned, returns correct count', async () => {
+		let callCount = 0;
+		const pb = {
+			collection: vi.fn((name: string) => {
+				if (name === 'items') {
+					return {
+						getOne: vi.fn(() => {
+							callCount++;
+							// item1 owned, item2 not owned, item3 owned
+							const owners = [OWNER_ID, OTHER_ID, OWNER_ID];
+							return Promise.resolve({ id: `item${callCount}`, owner: owners[callCount - 1] });
+						}),
+						delete: vi.fn().mockResolvedValue(undefined),
+					};
+				}
+				if (name === 'conversations') return { getFullList: vi.fn().mockResolvedValue([]) };
+				return {};
+			}),
+			filter: (raw: string) => raw,
+		} as unknown as Parameters<typeof deleteMultipleItems>[0];
+
+		const count = await deleteMultipleItems(pb, ['item1', 'item2', 'item3'], OWNER_ID);
+
+		expect(count).toBe(2);
+	});
+
+	it('returns 0 when itemIds is empty', async () => {
+		const pb = makePb({ item: { id: 'x', owner: OWNER_ID } });
+		const count = await deleteMultipleItems(pb, [], OWNER_ID);
+		expect(count).toBe(0);
+	});
+});
+
+describe('setItemStatus', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('updates status when caller is owner', async () => {
+		const pb = makePb({ item: { id: 'item1', owner: OWNER_ID } });
+
+		const result = await setItemStatus(pb, 'item1', OWNER_ID, 'unavailable');
+
+		expect(result).toBe(true);
+		expect(pb._update).toHaveBeenCalledWith('item1', { status: 'unavailable' });
+	});
+
+	it('returns false and does not update when caller is not the owner', async () => {
+		const pb = makePb({ item: { id: 'item1', owner: OWNER_ID } });
+
+		const result = await setItemStatus(pb, 'item1', OTHER_ID, 'available');
+
+		expect(result).toBe(false);
+		expect(pb._update).not.toHaveBeenCalled();
+	});
+
+	it('returns false when item is not found', async () => {
+		const pb = makePb({ item: null });
+
+		const result = await setItemStatus(pb, 'nonexistent', OWNER_ID, 'available');
+
+		expect(result).toBe(false);
+	});
+});

--- a/src/lib/server/items.ts
+++ b/src/lib/server/items.ts
@@ -1,24 +1,41 @@
 import type PocketBase from 'pocketbase';
 import { deleteConversation } from '../../routes/conversations/[conversationId]/conversation.server';
 
+export type DeleteItemResult =
+	| { status: 'deleted' }
+	| { status: 'not_found' }
+	| { status: 'not_owner' }
+	| { status: 'has_open_conversations'; conversationIds: string[] };
+
 /**
- * Deletes an item and all related conversations (with their notifications).
- * Checks ownership before deleting. Returns false if the item is not found or
- * the caller is not the owner; true on success.
+ * Deletes an item and all related closed conversations (with their notifications).
+ * Refuses if any conversation is still open (pending/accepted/active/return_requested).
+ * Checks ownership before acting.
  */
 export async function deleteItem(
 	pb: PocketBase,
 	itemId: string,
 	ownerUserId: string
-): Promise<boolean> {
+): Promise<DeleteItemResult> {
 	let item;
 	try {
 		item = await pb.collection('items').getOne(itemId);
 	} catch {
-		return false;
+		return { status: 'not_found' };
 	}
 
-	if (item.owner !== ownerUserId) return false;
+	if (item.owner !== ownerUserId) return { status: 'not_owner' };
+
+	const open = await pb.collection('conversations').getFullList({
+		filter: pb.filter(
+			'requestedItem = {:itemId} && (lendingStatus = "pending" || lendingStatus = "accepted" || lendingStatus = "active" || lendingStatus = "return_requested")',
+			{ itemId }
+		),
+	});
+
+	if (open.length > 0) {
+		return { status: 'has_open_conversations', conversationIds: open.map((c) => c.id) };
+	}
 
 	const conversations = await pb
 		.collection('conversations')
@@ -29,29 +46,36 @@ export async function deleteItem(
 	}
 
 	await pb.collection('items').delete(itemId);
-	return true;
+	return { status: 'deleted' };
 }
 
 /**
  * Deletes multiple items by calling deleteItem() for each.
- * Skips items that are not found or not owned by ownerUserId.
- * Returns the count of items actually deleted.
+ * Skips items not owned by ownerUserId or not found.
+ * Collects items blocked by open conversations separately.
  */
 export async function deleteMultipleItems(
 	pb: PocketBase,
 	itemIds: string[],
 	ownerUserId: string
-): Promise<number> {
-	let count = 0;
+): Promise<{ deleted: number; blocked: Array<{ itemId: string; conversationIds: string[] }> }> {
+	let deleted = 0;
+	const blocked: Array<{ itemId: string; conversationIds: string[] }> = [];
+
 	for (const itemId of itemIds) {
 		try {
-			const deleted = await deleteItem(pb, itemId, ownerUserId);
-			if (deleted) count++;
+			const result = await deleteItem(pb, itemId, ownerUserId);
+			if (result.status === 'deleted') {
+				deleted++;
+			} else if (result.status === 'has_open_conversations') {
+				blocked.push({ itemId, conversationIds: result.conversationIds });
+			}
 		} catch (err: unknown) {
 			console.error('Failed to delete item', itemId, err instanceof Error ? err.message : err);
 		}
 	}
-	return count;
+
+	return { deleted, blocked };
 }
 
 /**

--- a/src/lib/server/items.ts
+++ b/src/lib/server/items.ts
@@ -1,0 +1,78 @@
+import type PocketBase from 'pocketbase';
+import { deleteConversation } from '../../routes/conversations/[conversationId]/conversation.server';
+
+/**
+ * Deletes an item and all related conversations (with their notifications).
+ * Checks ownership before deleting. Returns false if the item is not found or
+ * the caller is not the owner; true on success.
+ */
+export async function deleteItem(
+	pb: PocketBase,
+	itemId: string,
+	ownerUserId: string
+): Promise<boolean> {
+	let item;
+	try {
+		item = await pb.collection('items').getOne(itemId);
+	} catch {
+		return false;
+	}
+
+	if (item.owner !== ownerUserId) return false;
+
+	const conversations = await pb
+		.collection('conversations')
+		.getFullList({ filter: pb.filter('requestedItem = {:itemId}', { itemId }) });
+
+	for (const conversation of conversations) {
+		await deleteConversation(pb, conversation.id);
+	}
+
+	await pb.collection('items').delete(itemId);
+	return true;
+}
+
+/**
+ * Deletes multiple items by calling deleteItem() for each.
+ * Skips items that are not found or not owned by ownerUserId.
+ * Returns the count of items actually deleted.
+ */
+export async function deleteMultipleItems(
+	pb: PocketBase,
+	itemIds: string[],
+	ownerUserId: string
+): Promise<number> {
+	let count = 0;
+	for (const itemId of itemIds) {
+		try {
+			const deleted = await deleteItem(pb, itemId, ownerUserId);
+			if (deleted) count++;
+		} catch (err: unknown) {
+			console.error('Failed to delete item', itemId, err instanceof Error ? err.message : err);
+		}
+	}
+	return count;
+}
+
+/**
+ * Updates the status of an item after verifying ownership.
+ * Returns false if the item is not found or the caller is not the owner.
+ */
+export async function setItemStatus(
+	pb: PocketBase,
+	itemId: string,
+	ownerUserId: string,
+	newStatus: 'available' | 'unavailable'
+): Promise<boolean> {
+	let item;
+	try {
+		item = await pb.collection('items').getOne(itemId);
+	} catch {
+		return false;
+	}
+
+	if (item.owner !== ownerUserId) return false;
+
+	await pb.collection('items').update(itemId, { status: newStatus });
+	return true;
+}

--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -567,6 +567,12 @@ export const texts = {
 			bulkDelete: 'Löschen',
 			bulkDeleteConfirm: (n: number) =>
 				`${n} Ding(e) wirklich löschen? Verbundene Gespräche werden ebenfalls gelöscht.`,
+			deleteBlockedByConversation:
+				'Dieses Ding kann nicht gelöscht werden, da noch ein offenes Gespräch besteht.',
+			bulkDeletePartialBlock: (deleted: number, blocked: number) =>
+				`${deleted} Ding(e) gelöscht. ${blocked} Ding(e) konnten nicht gelöscht werden, da noch offene Gespräche bestehen.`,
+			linkToConversation: 'Zum Gespräch',
+			linkToConversations: 'Zu den Gesprächen',
 		},
 		profile: {
 			title: 'Mein Profil',

--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -564,6 +564,9 @@ export const texts = {
 			setUnavailable: 'Nicht verfügbar setzen',
 			deselectAll: 'Alle abwählen',
 			selectAll: 'Alle auf dieser Seite',
+			bulkDelete: 'Löschen',
+			bulkDeleteConfirm: (n: number) =>
+				`${n} Ding(e) wirklich löschen? Verbundene Gespräche werden ebenfalls gelöscht.`,
 		},
 		profile: {
 			title: 'Mein Profil',

--- a/src/routes/user/items/+page.server.ts
+++ b/src/routes/user/items/+page.server.ts
@@ -228,6 +228,7 @@ export const actions = {
 		if (blocked.length > 0) {
 			return fail(409, {
 				fail: true,
+				bulkBlocked: true,
 				message: texts.pages.items.bulkDeletePartialBlock(deleted, blocked.length),
 				conversationIds: blocked.flatMap((b) => b.conversationIds),
 			});

--- a/src/routes/user/items/+page.server.ts
+++ b/src/routes/user/items/+page.server.ts
@@ -187,7 +187,14 @@ export const actions = {
 		const itemId = (await request.formData()).get('itemId')?.toString();
 		if (itemId) {
 			try {
-				await deleteItem(locals.pb, itemId, locals.user.id);
+				const result = await deleteItem(locals.pb, itemId, locals.user.id);
+				if (result.status === 'has_open_conversations') {
+					return fail(409, {
+						fail: true,
+						message: texts.pages.items.deleteBlockedByConversation,
+						conversationIds: result.conversationIds,
+					});
+				}
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			} catch (err: Error | any) {
 				console.error(err ? err.message : err);
@@ -217,7 +224,14 @@ export const actions = {
 	bulkDelete: async ({ locals, request }) => {
 		const itemIds = (await request.formData()).getAll('itemId').map(String);
 		if (!itemIds.length) return fail(400, { fail: true, message: 'Ungültige Anfrage.' });
-		await deleteMultipleItems(locals.pb, itemIds, locals.user.id);
+		const { deleted, blocked } = await deleteMultipleItems(locals.pb, itemIds, locals.user.id);
+		if (blocked.length > 0) {
+			return fail(409, {
+				fail: true,
+				message: texts.pages.items.bulkDeletePartialBlock(deleted, blocked.length),
+				conversationIds: blocked.flatMap((b) => b.conversationIds),
+			});
+		}
 	},
 
 	toggleTrusteesOnly: async ({ locals, request }) => {

--- a/src/routes/user/items/+page.server.ts
+++ b/src/routes/user/items/+page.server.ts
@@ -3,8 +3,8 @@ import type { ClientResponseError } from 'pocketbase';
 import { PUBLIC_PB_URL } from '../../../hooks.server';
 import { ITEM_CATEGORIES, texts, type ItemCategory } from '$lib/texts';
 import type { Item } from '$lib/types/models';
-import { deleteConversation } from '../../conversations/[conversationId]/conversation.server';
 import { getAttachableGroups } from '$lib/server/groups';
+import { deleteItem, deleteMultipleItems, setItemStatus } from '$lib/server/items';
 
 /**
  * Keep only the submitted group ids the user is actually allowed to attach
@@ -187,19 +187,7 @@ export const actions = {
 		const itemId = (await request.formData()).get('itemId')?.toString();
 		if (itemId) {
 			try {
-				const conversations = await locals.pb
-					.collection('conversations')
-					.getFullList({ filter: locals.pb.filter('requestedItem = {:itemId}', { itemId }) });
-
-				// Use deleteConversation (not a bare conversations.delete) so the
-				// notifications referencing each conversation are cleaned up too —
-				// otherwise the other party is left with dead-link notifications
-				// pointing at a now-missing conversation.
-				for (const conversation of conversations) {
-					await deleteConversation(locals.pb, conversation.id);
-				}
-
-				await locals.pb.collection('items').delete(itemId);
+				await deleteItem(locals.pb, itemId, locals.user.id);
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			} catch (err: Error | any) {
 				console.error(err ? err.message : err);
@@ -218,14 +206,18 @@ export const actions = {
 
 		for (const itemId of itemIds) {
 			try {
-				const item = await locals.pb.collection('items').getOne(itemId);
-				if (item.owner !== locals.user.id) continue;
-				await locals.pb.collection('items').update(itemId, { status: newStatus });
+				await setItemStatus(locals.pb, itemId, locals.user.id, newStatus);
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			} catch (err: Error | any) {
 				console.error(err?.message ?? err);
 			}
 		}
+	},
+
+	bulkDelete: async ({ locals, request }) => {
+		const itemIds = (await request.formData()).getAll('itemId').map(String);
+		if (!itemIds.length) return fail(400, { fail: true, message: 'Ungültige Anfrage.' });
+		await deleteMultipleItems(locals.pb, itemIds, locals.user.id);
 	},
 
 	toggleTrusteesOnly: async ({ locals, request }) => {
@@ -267,7 +259,7 @@ export const actions = {
 
 		const newStatus = item.status === 'available' ? 'unavailable' : 'available';
 		try {
-			await locals.pb.collection('items').update(itemId, { status: newStatus });
+			await setItemStatus(locals.pb, itemId, locals.user.id, newStatus);
 		} catch (err) {
 			const e = err as Partial<ClientResponseError>;
 			return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });

--- a/src/routes/user/items/+page.svelte
+++ b/src/routes/user/items/+page.svelte
@@ -117,6 +117,16 @@
 			</select>
 		</div>
 
+		<!-- Bulk delete error -->
+		{#if form?.fail && form?.conversationIds?.length}
+			<div class="mb-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200">
+				<p>{form.message}</p>
+				<a href="/conversations" class="mt-1 inline-block font-semibold underline">
+					{texts.pages.items.linkToConversations}
+				</a>
+			</div>
+		{/if}
+
 		<!-- Bulk action bar -->
 		{#if selectedIds.size > 0}
 			<div class="flex flex-wrap items-center gap-3 mb-3 px-4 py-2 rounded-lg bg-primary-50 border border-primary-200 dark:bg-primary-900/30 dark:border-primary-700">

--- a/src/routes/user/items/+page.svelte
+++ b/src/routes/user/items/+page.svelte
@@ -155,6 +155,27 @@
 						{texts.pages.items.setUnavailable}
 					</button>
 				</form>
+				<form
+					method="POST"
+					action="?/bulkDelete"
+					use:enhance={({ cancel }) => {
+						if (!confirm(texts.pages.items.bulkDeleteConfirm(selectedIds.size))) {
+							cancel();
+							return;
+						}
+						return async ({ update }) => update({ reset: false });
+					}}
+				>
+					{#each [...selectedIds] as id}
+						<input type="hidden" name="itemId" value={id} />
+					{/each}
+					<button
+						type="submit"
+						class="text-xs font-semibold px-3 py-1 rounded-full bg-red-100 text-red-800 border border-red-300 hover:bg-red-200 cursor-pointer transition-colors"
+					>
+						{texts.pages.items.bulkDelete}
+					</button>
+				</form>
 				<button
 					type="button"
 					onclick={() => { selectedIds = new Set(); }}

--- a/src/routes/user/items/+page.svelte
+++ b/src/routes/user/items/+page.svelte
@@ -118,7 +118,7 @@
 		</div>
 
 		<!-- Bulk delete error -->
-		{#if form?.fail && form?.conversationIds?.length}
+		{#if form && 'bulkBlocked' in form && form.conversationIds?.length}
 			<div class="mb-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200">
 				<p>{form.message}</p>
 				<a href="/conversations" class="mt-1 inline-block font-semibold underline">
@@ -138,7 +138,7 @@
 					action="?/bulkSetStatus"
 					use:enhance={() => async ({ update }) => update({ reset: false })}
 				>
-					{#each [...selectedIds] as id}
+					{#each [...selectedIds] as id(id)}
 						<input type="hidden" name="itemId" value={id} />
 					{/each}
 					<input type="hidden" name="newStatus" value="available" />
@@ -154,7 +154,7 @@
 					action="?/bulkSetStatus"
 					use:enhance={() => async ({ update }) => update({ reset: false })}
 				>
-					{#each [...selectedIds] as id}
+					{#each [...selectedIds] as id(id)}
 						<input type="hidden" name="itemId" value={id} />
 					{/each}
 					<input type="hidden" name="newStatus" value="unavailable" />
@@ -168,15 +168,20 @@
 				<form
 					method="POST"
 					action="?/bulkDelete"
-					use:enhance={({ cancel }) => {
+					use:enhance={({ cancel, formData }) => {
 						if (!confirm(texts.pages.items.bulkDeleteConfirm(selectedIds.size))) {
 							cancel();
 							return;
 						}
-						return async ({ update }) => update({ reset: false });
+						const submitted = new Set(formData.getAll('itemId') as string[]);
+						return async ({ update }) => {
+							await update({ reset: false });
+							for (const id of submitted) selectedIds.delete(id);
+							selectedIds = new Set(selectedIds);
+						};
 					}}
 				>
-					{#each [...selectedIds] as id}
+					{#each [...selectedIds] as id(id)}
 						<input type="hidden" name="itemId" value={id} />
 					{/each}
 					<button

--- a/src/routes/user/items/ItemModal.svelte
+++ b/src/routes/user/items/ItemModal.svelte
@@ -21,7 +21,6 @@
 	import { resolve } from '$app/paths';
 	import { texts, ITEM_CATEGORIES } from '$lib/texts';
 	import { compressImage } from '$lib/utils/imageUtils';
-	import CustomAlert from '$lib/components/CustomAlert.svelte';
 	import type { ActionData } from './$types';
 
 	interface Props {

--- a/src/routes/user/items/ItemModal.svelte
+++ b/src/routes/user/items/ItemModal.svelte
@@ -132,8 +132,14 @@
 
 <Modal bind:open={isVisible} size="xs">
 	{#if form?.fail}
-		<div class="variant-soft-error rounded-token mb-2 px-4 py-2">
-			<CustomAlert type="error" message={form?.message} />
+		<div class="mb-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200">
+			<p>{form.message}</p>
+			{#if form?.conversationIds?.length}
+				<a
+					href="/conversations/{form.conversationIds[0]}"
+					class="mt-1 inline-block font-semibold underline"
+				>{texts.pages.items.linkToConversation}</a>
+			{/if}
 		</div>
 	{/if}
 	<form


### PR DESCRIPTION
## Summary

- Adds a **bulk delete** button to the item list's existing multi-select bar (alongside the existing bulk status-change buttons)
- Extracts item mutation logic into a new **`$lib/server/items.ts`** helper (`deleteItem`, `deleteMultipleItems`, `setItemStatus`) so the cascade logic lives in one tested place rather than inline in form actions
- Guards deletion at the helper level: if an item has any open conversation (`pending`, `accepted`, `active`, `return_requested`) the delete is refused and the user is shown a persistent error with a direct link to the relevant conversation

## Design decisions

**`$lib/server/items.ts` as the single source of truth**
The `delete` action previously inlined the conversation-cascade logic (find conversations → `deleteConversation` each → delete item). This is now in `deleteItem()`, which both the single-delete and bulk-delete actions call. `deleteMultipleItems()` loops over `deleteItem()`, so all deletion goes through the same guard and cascade. `setItemStatus()` likewise centralises the ownership-check + update that `bulkSetStatus` and `toggleStatus` shared.

**`DeleteItemResult` union type instead of boolean**
`deleteItem` previously returned `boolean`. Returning a discriminated union (`'deleted' | 'not_found' | 'not_owner' | { status: 'has_open_conversations', conversationIds }`) lets callers distinguish _why_ deletion was refused without exceptions-as-control-flow, and threads the conversation IDs through to the UI.

**Open-conversation guard filter**
Only the four non-terminal statuses are blocked: `pending`, `accepted`, `active`, `return_requested`. Conversations with status `rejected` or `completed` are terminal and do not block deletion.

**Persistent inline error block instead of `CustomAlert`**
`CustomAlert` auto-dismisses after 3 s — not suitable when the user needs to click a link. The blocked-deletion error is rendered as a persistent `div` that stays until the next navigation or successful action.

**Confirmation dialog**
Bulk delete uses a native `confirm()` dialog (consistent with how group deletion is confirmed elsewhere in the app) before submitting the form.

**`conversationIds` passed through `fail()`**
The server actions return `conversationIds` alongside the error message so the UI can link directly to the specific conversation (single delete) or to the conversations list (bulk delete, where multiple conversations across multiple items may be involved).

## How to test

**Bulk delete — happy path**
1. Go to `/user/items` and create two or three items with no open conversations.
2. Check the checkboxes next to them and click **Löschen**.
3. Confirm the dialog — items disappear and the selection clears.

**Bulk delete — partial block**
1. Create item A and item B. As another user, start a conversation on item A (do not reject/complete it).
2. Select both items and click **Löschen** → confirm.
3. Item B is deleted; item A remains. A persistent red banner appears with the count and a "Zu den Gesprächen" link that goes to `/conversations`.

**Single delete — blocked by open conversation**
1. Open the edit modal for an item that has an open conversation.
2. Click **Löschen** (the delete button at the bottom of the modal).
3. A persistent red error appears inside the modal with a "Zum Gespräch" link pointing directly at that conversation. The item is not deleted.

**Single delete — no open conversations**
1. Open the edit modal for an item where all conversations are closed or there are none.
2. Click **Löschen** → item is deleted and the modal closes.

**Unit tests**
```
npx vitest run src/lib/server/items.test.ts
```
9 tests covering: `deleteItem` (deleted / not\_found / not\_owner / has\_open\_conversations / only terminal convs present), `deleteMultipleItems` (mixed blocked+deleted, empty input), `setItemStatus` (owner / not owner / not found).

🤖 Generated with [Claude Code](https://claude.com/claude-code)