### PR TITLE
Gate email-notification toggle on a verified email address (allerleih-backend#8)

### DIFF
--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -590,6 +590,8 @@ export const texts = {
 			denied: 'Benachrichtigungen sind in deinem Browser blockiert. Du kannst sie in deinen Browser-Einstellungen wieder aktivieren.',
 			emailToggleLabel: 'E-Mail-Benachrichtigungen',
 			emailToggleDescription: 'Erhalte eine E-Mail, wenn du neue Nachrichten oder Anfragen bekommst.',
+			emailToggleVerifyHint:
+				'Bestätige zuerst deine E-Mail-Adresse, um E-Mail-Benachrichtigungen zu erhalten.',
 		},
 		},
 		invite: {

--- a/src/routes/user/profile/+page.svelte
+++ b/src/routes/user/profile/+page.svelte
@@ -198,7 +198,7 @@
 		</div>
 	</div>
 
-	<NotificationSettings userId={data.currentUser.id} />
+	<NotificationSettings userId={data.currentUser.id} verified={data.currentUser.verified ?? false} />
 
 	<InviteLink inviteUrl={data.inviteUrl} />
 

--- a/src/routes/user/profile/NotificationSettings.svelte
+++ b/src/routes/user/profile/NotificationSettings.svelte
@@ -9,7 +9,7 @@
 	} from '$lib/utils/pushSubscription';
 	import { getClientPB } from '$lib/client-pb';
 
-	let { userId }: { userId: string } = $props();
+	let { userId, verified }: { userId: string; verified: boolean } = $props();
 
 	// null         → not yet read from browser; section stays hidden during SSR
 	//                and until onMount resolves the actual state.
@@ -92,6 +92,10 @@
 	}
 
 	async function toggleEmailNotifications() {
+		// Email notifications are only delivered to verified addresses (#8), so the toggle is
+		// inert until the user verifies. The Toggle is also rendered disabled in that state.
+		if (!verified) return;
+
 		const newValue = !emailNotificationsEnabled;
 		emailNotificationsEnabled = newValue;
 
@@ -165,11 +169,17 @@
 							</p>
 						</div>
 						<Toggle
-							checked={emailNotificationsEnabled}
+							checked={verified && emailNotificationsEnabled}
+							disabled={!verified}
 							onchange={toggleEmailNotifications}
 							classes={{ span: 'bg-primary-300 peer-checked:bg-safety' }}
 						/>
 					</div>
+					{#if !verified}
+						<p class="text-sm text-accent-600 dark:text-accent-400 mt-2">
+							{texts.pages.profile.notifications.emailToggleVerifyHint}
+						</p>
+					{/if}
 				</div>
 			{/if}
 		</div>


### PR DESCRIPTION
## Summary

Part of allerleih-backend#8. Now that notification emails are only delivered to **verified**
recipient addresses (backend change), this gates the email-notification toggle in the profile so
the setting can't be enabled while it would have no effect.

## What changed

- **`src/routes/user/profile/NotificationSettings.svelte`** — the "E-Mail-Benachrichtigungen"
  toggle is **disabled until the user's email is verified**, with a hint to verify first.
  `toggleEmailNotifications` also early-returns when not verified (defensive).
- **`src/routes/user/profile/+page.svelte`** — passes `verified` (from `data.currentUser.verified`)
  into `NotificationSettings`.
- **`src/lib/texts.ts`** — new string `…notifications.emailToggleVerifyHint`.

The existing email-verification status + "resend verification" UI (EmailSection) already covers
prompting the user; this PR only ties the email-notification setting to that state.

## Testing

- `npm run check` — 0 errors (pre-existing warnings unrelated to this change).
- ESLint clean on the changed files.
- `npx vitest run` — all 191 tests pass.
- Manually: unverified user sees the toggle disabled + hint; verified user can toggle it.

## Notes

- Pairs with the backend PR (allerleih-backend) that adds env-based SMTP + verified-only
  notification emails.
- Follow-up (separate): #447 — move verification / email-change confirmation onto the frontend.
