### PR TITLE
Add shared .claude team skills (+ reviewer & CLAUDE.md updates)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -94,11 +94,27 @@ These prevent the most common bugs/security issues here — follow them without 
 
 ## Project tooling (this repo's `.claude/`)
 
+Skills auto-trigger from their own `description`; this list is the human index of what exists —
+run one explicitly with `/<name>`. Build / change work:
+
+- `/new-route` — scaffold a route (`+page.server.ts`/`.svelte` + co-located test) with the
+  pb.filter / trust-visibility / runes / form-action guardrails baked in.
+- `/add-notification-type` — wire a new notification type end-to-end (union → texts → trigger site →
+  in-app routing), keeping `relatedId` / push url / href consistent.
+- `/schema-change` — coordinate a schema change across both repos: migration (delegates to the
+  backend `new-migration`) → `models.ts` → `docs/data-model.md` → public-view leak check.
+- `/write-tests` — author tests to the repo's conventions (Vitest with mocked PocketBase).
+- `/seed-scenario` — add a deterministic local seed scenario (items get generated placeholder images).
+
+Maintenance & review:
+
+- `/refresh-skills` — audit & fix the `.claude/skills` when code they cite drifts (paths, signatures,
+  texts keys, commands). Run after a change that touches code a skill references.
 - `/create-pr` — preflight (lint/check/test/build), draft, and open a PR to `main`.
 - `/accessibility-review` — audit changed Svelte files against the project's a11y patterns.
-- `sveltekit-pb-reviewer` agent — delegated AllerLeih-specific code/security review
-  (pb.filter, trust visibility, public-view leakage, runes, texts.ts). Complements the
-  built-in `/code-review` and `/security-review`.
+- `sveltekit-pb-reviewer` agent — delegated AllerLeih-specific code/security review (pb.filter,
+  trust/group visibility, public-view & `items_searchable` leakage, deleted-account masking, runes,
+  texts.ts). Complements the built-in `/code-review` and `/security-review`.
 
 ## Keep in sync
 

--- a/.claude/agents/sveltekit-pb-reviewer.md
+++ b/.claude/agents/sveltekit-pb-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: sveltekit-pb-reviewer
-description: AllerLeih-specific code & security reviewer for SvelteKit + PocketBase changes. Use to review a diff or set of files for PocketBase filter injection, trust-visibility / public-view leakage, auth, Svelte 5 runes correctness, German-string placement, and test conventions. Complements the generic built-in /code-review and /security-review — invoke when you want a project-aware review of the current branch.
+description: AllerLeih-specific code & security reviewer for SvelteKit + PocketBase changes. Use to review a diff or set of files for PocketBase filter injection, trust- & group-visibility and public-view / items_searchable leakage, auth, Svelte 5 runes correctness, deleted-account masking, realtime subscriptions, German-string placement, and test conventions. Complements the generic built-in /code-review and /security-review — invoke when you want a project-aware review of the current branch.
 tools: Read, Grep, Glob, Bash
 ---
 
@@ -21,11 +21,14 @@ user names files, review those. Read enough surrounding context to judge correct
    `pb.filter(raw, {params})` / `locals.pb.filter(...)`. Flag ANY template-literal or string
    concatenation in a filter — including values that look "safe" like `locals.user.id` or route
    params. `grep` for `filter:` and backtick filter strings.
-2. **Trust visibility & data leakage.** After fetching items, `filterTrustedItems()`
-   (`$lib/server/itemFilters`) must be applied so `trusteesOnly` items don't reach non-trusted
-   users. Unauthenticated paths must read the `*_public` views — verify no email, raw
-   coordinates, contact fields, or trust-graph (`trusts[]`) data leaks through any response or
-   public view usage.
+2. **Item visibility & data leakage.** After fetching items, `filterTrustedItems(items, userId, loggedIn)`
+   (`$lib/server/itemFilters`, synchronous) must be applied so `trusteesOnly` items don't reach
+   non-trusted users — and the fetch must `expand: 'owner'`, or it can't read the owner's `trusts[]`
+   and silently mis-filters. Items can also be shared with **groups** (`groups[]` + `group_members`),
+   an audience independent of trust; a visibility change must hold for *both* the trust and group
+   audiences. Check the **`items_searchable`** view (search/profile) as well as the `*_public` views:
+   verify no email, raw coordinates, contact data, `trusts[]`, or a group-only item leaks to anyone
+   outside its audience — and that `items_searchable`'s `groups` column isn't surfaced to clients.
 3. **Auth / route protection.** New routes outside the `unprotectedPrefix` set in
    `src/hooks.server.ts` must require auth; confirm anything newly made public is intentional and
    leaks nothing sensitive. Mutations belong in form actions, not unauthenticated `/api/*`.
@@ -36,8 +39,12 @@ user names files, review those. Read enough surrounding context to judge correct
    (+ `ITEM_CATEGORIES`), not be hardcoded inline in components.
 6. **Tests.** New/changed server logic should have co-located `*.test.ts` mocking PocketBase per
    `docs/testing-strategy.md` (a `mockLocals` with `pb.collection()` returning `vi.fn()` stubs).
-7. **Correctness & footguns.** Obvious bugs, unhandled errors, missing `$effect` cleanup for
-   `setupPocketBaseSubscription()`, and image handling that ignores `externalImgUrl` fallback.
+7. **Deleted accounts & realtime.** Never render `user.username` directly for a user that might be
+   deleted — it must go through `displayName()` (`$lib/utils/utils.ts`). Client realtime goes through
+   `subscribeRealtime()` (`$lib/client-pb`) with `$effect`/`onMount` cleanup — flag any direct
+   `pb.collection(...).subscribe()` (it loses the reconnect/retry from issue #435).
+8. **Correctness & footguns.** Obvious bugs, unhandled errors, and image handling that ignores the
+   `externalImgUrl` fallback.
 
 ## Output
 

--- a/.claude/skills/add-notification-type/SKILL.md
+++ b/.claude/skills/add-notification-type/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: add-notification-type
+description: Wire up a new notification type end-to-end in AllerLeih (the NotificationType union, the German body string, the trigger site that creates + pushes it, and the in-app list routing/icon). Use whenever the user wants to add, send, or notify about a new event — e.g. "notify the owner when X happens", "add a notification for Y", "send a push when Z" — so the notification isn't half-wired (a created record with no push, or a push that links to a dead page).
+---
+
+# add-notification-type
+
+Notifications span four places, and the classic failure is wiring only some of them — a record
+with no push, a push with no in-app entry, or (worst) a link that 404s because `relatedId` and the
+target URL disagree. This skill keeps all four in sync. A notification has two faces: an **in-app**
+list entry (`notifications` collection) and a **web-push** message; most flows create both together.
+
+The whole pipeline (see `src/lib/server/notifications.ts`, `src/routes/notifications/+page.svelte`,
+`src/service-worker.ts`) is driven by two values you choose at the trigger site:
+- **`relatedId`** — the id the notification points at (a conversation id, or a user id, …).
+- **the target `url`** — the page a click should open, built from `relatedId`.
+
+Get those two consistent with the in-app `notificationHref()` and everything else falls out.
+
+## The four places to change
+
+1. **Type union** — `src/lib/types/models.ts`, the `NotificationType` union (~line 358). Add your
+   string literal (snake_case, like the existing `new_request`, `return_confirmed`).
+2. **German body** — `src/lib/texts.ts`, the **`notifications` body block** (~line 824). Add a
+   generator, e.g. `groupInvite: (from: string, group: string) => \`${from} hat dich zu „${group}" eingeladen\``.
+   The body is **stored pre-formatted** on the record and rendered verbatim — never inline a string.
+   Heads-up: there are **two** `notifications:` keys in `texts.ts` — a settings/permission sub-block
+   (~line 592) and the message-body generators (~line 824, the top-level `texts.notifications`). A
+   naive grep for `notifications:` lands on the settings one first; you want the body block.
+3. **Trigger site** — wherever the event happens (a form action or a `$lib/server` helper). Create
+   the record **and** push, together:
+   ```ts
+   import { createNotification, sendPushToUser } from '$lib/server/notifications';
+   import { texts } from '$lib/texts';
+
+   const body = texts.notifications.groupInvite(inviterName, groupName);
+   const url = `/groups/${groupId}`;                 // where a click should land
+   await createNotification(pb, recipientId, senderId, 'group_invite', groupId, body);
+   await sendPushToUser(pb, recipientId, texts.notifications.pushTitle, body, url);
+   ```
+   `createNotification(pb, recipient, sender?, type, relatedId, body)` writes the in-app record
+   (`read:false`, fails silently). `sendPushToUser(pb, userId, title, body, url)` pushes to every
+   registered device and prunes stale subscriptions (HTTP 410/404). Always pass
+   `texts.notifications.pushTitle` as the title. **`relatedId` here must match the `url`** (here both
+   derive from `groupId`).
+4. **In-app routing + icon** — `src/routes/notifications/+page.svelte`. `notificationHref()` maps a
+   notification to its link. Either add your type to the `conversationNotificationTypes` set (if it
+   points to a conversation → `/conversations/{relatedId}`), or add a branch (e.g.
+   `n.type === 'group_invite'` → `/groups/{relatedId}`). Add a matching arm to the icon `{#if}` block
+   too — a type with no arm silently renders **no icon** (it doesn't error, so it's easy to miss).
+   **This href must produce the same destination as the push `url`** — otherwise the in-app link and
+   the push go to different places, and a wrong `relatedId` dead-links.
+
+## The consistency rule (the actual footgun)
+
+`relatedId` → push `url` (trigger site) → `notificationHref()` (in-app list) must all agree. The
+**service worker needs no change** — `notificationclick` just navigates to the `url` you passed at
+push time (`src/service-worker.ts`), and it already suppresses a push if the user has that page
+open. So the routing decision lives entirely in the `url` you build and the matching
+`notificationHref()` branch. If they diverge, clicks 404.
+
+## Email (backend) — only if you want it
+
+In-app + push are frontend-only and need **no backend change**. The backend hook
+(`allerleih-backend/pb_hooks/notification.pb.js`) sends *email* and currently fires only for
+`new_message` (with throttling + an `emailNotifications` opt-out). If your new type should also email,
+that's a separate change in the backend repo (a hook on the relevant collection + an HTML template in
+`pb_hooks/views/mail/`) — call it out rather than assuming it happens automatically.
+
+## Verify
+
+- Add a Vitest test at the trigger site asserting `createNotification`/`sendPushToUser` are called
+  with the right `type`, `relatedId`, and `url` (mock them; see the `write-tests` skill).
+- Manually: trigger the event, confirm the entry appears at `/notifications` with the right text and
+  that clicking it (and the push) lands on the intended page — not `/notifications` fallback or a 404.

--- a/.claude/skills/new-route/SKILL.md
+++ b/.claude/skills/new-route/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: new-route
+description: Scaffold a new SvelteKit route in AllerLeih the way this repo does it — +page.server.ts (load + form actions), +page.svelte (Svelte 5 runes, no data destructuring), a co-located test, and German strings in texts.ts — with the project's PocketBase guardrails baked in. Use whenever the user wants to add a new page, screen, or route, build a CRUD/form page, or "make a page for X", so the route lands consistent and isn't missing pb.filter, trust filtering, or server-side permission checks.
+---
+
+# new-route
+
+Scaffold a route that matches the repo's conventions and avoids its recurring footguns. A route is a
+folder under `src/routes/<path>/` with up to four files:
+
+```
+src/routes/<path>/
+├── +page.server.ts        # load() + actions (all data + mutations)
+├── +page.svelte           # UI: Svelte 5 runes, use:enhance forms
+├── +page.server.test.ts   # co-located Vitest (see the write-tests skill)
+└── *.svelte               # optional sub-components
+```
+
+There is **no REST layer for app data** — every read goes through `load()`, every mutation through a
+**form action**. Read `docs/best-practices.md` for the canonical CRUD-form pattern before starting.
+
+## 1. `load()` — reading data
+
+```ts
+import type { PageServerLoad } from './$types';
+import { filterTrustedItems } from '$lib/server/itemFilters';
+import { PUBLIC_PB_URL } from '$env/static/public';
+
+export const load: PageServerLoad = async ({ locals }) => {
+  const items = await locals.pb.collection('items').getFullList({
+    filter: locals.pb.filter('owner = {:ownerId}', { ownerId: locals.user.id }),
+    sort: '-updated',
+    expand: 'owner', // required: filterTrustedItems reads item.expand.owner.trusts
+  });
+  return { items: filterTrustedItems(items, locals.user.id, true), PB_URL: PUBLIC_PB_URL };
+};
+```
+
+Guardrails (these prevent the bugs we actually hit):
+- **Every interpolated value goes through `locals.pb.filter('… = {:x}', { x })`** — never a template
+  literal, even for `locals.user.id` or a route param. A raw `"` in a value is filter injection.
+- **Call `filterTrustedItems(items, locals.user?.id ?? null, !!locals.user)`** (synchronous; from
+  `$lib/server/itemFilters`) after fetching items that aren't exclusively the current user's own —
+  skipping it **leaks** `trusteesOnly` items to non-trusted viewers. It checks
+  `item.expand?.owner?.trusts`, so the same fetch **must** `expand: 'owner'`, or trusted viewers are
+  wrongly denied (it fails closed).
+- `locals.pb` is the server client; `locals.user` is the auth record (null if unauthenticated).
+- Pass `PUBLIC_PB_URL` (from `$env/static/public`) down as `PB_URL` so the client can build file URLs.
+
+## 2. `actions` — mutations
+
+```ts
+import { fail } from '@sveltejs/kit'; // + redirect when an action navigates
+import { texts } from '$lib/texts';
+
+export const actions = {
+  create: async ({ locals, request }) => {
+    const form = await request.formData();
+    const name = form.get('name')?.toString().trim();
+    if (!name) return fail(400, { fail: true, message: texts.errors.changesNotSaved });
+
+    await locals.pb.collection('items').create({ name, owner: locals.user.id });
+    // return nothing on success → SvelteKit re-runs load() and the page refreshes
+  },
+
+  remove: async ({ locals, request }) => {
+    const id = (await request.formData()).get('id')?.toString();
+    if (!id) return fail(400, { fail: true, message: texts.errors.missingId });
+
+    // ALWAYS re-fetch and check ownership server-side — never trust the form for authorization.
+    const item = await locals.pb.collection('items').getOne(id).catch(() => null);
+    if (!item) return fail(404, { fail: true, message: texts.errors.itemNotFound });
+    if (item.owner !== locals.user.id) return fail(403, { fail: true, message: texts.errors.noPermission });
+
+    await locals.pb.collection('items').delete(id);
+  },
+};
+```
+
+- Name actions to match the form's `action="?/create"`. Read `request.formData()`.
+- **Validation/permission failure → `return fail(status, { fail: true, message })`** (re-renders the
+  page with `form`); **navigation on success → `throw redirect(303, '/path')`** (import `redirect`
+  alongside `fail` from `@sveltejs/kit`); a plain successful action returns nothing and SvelteKit
+  re-runs `load()`. Reference real `texts.errors.*` keys (or add one) — don't invent key names.
+- **Re-fetch the record and verify `owner === locals.user.id` before mutating.** Form fields are
+  attacker-controlled — the id in the form is not proof of permission.
+- Use `locals.pb.filter(...)` for any id you interpolate into a query.
+
+## 3. `+page.svelte` — UI
+
+```svelte
+<script lang="ts">
+  import { enhance } from '$app/forms';
+  import { texts } from '$lib/texts';
+
+  let { data, form } = $props();          // declare props; do NOT copy fields out of `data`
+  let q = $state('');
+  const visible = $derived(data.items.filter((i) => i.name.includes(q)));
+</script>
+
+<form method="POST" action="?/create" use:enhance>
+  <input name="name" />
+  <button type="submit">{texts.buttons.save}</button>
+</form>
+
+{#each data.items as item (item.id)}
+  <p>{item.name}</p>
+{/each}
+```
+
+- **Never destructure `data` into locals** (`let items = data.items` detaches `use:enhance`
+  reactivity — the #1 footgun). Read `data.items` directly in markup; derive with `$derived`.
+- Svelte 5 runes only: `$props`, `$state`, `$derived`, `$effect`, `$bindable`. No `export let`.
+- Wire forms with `method="POST" action="?/name" use:enhance`.
+
+## 4. Strings, tests, auth
+
+- **All user-facing German strings live in `src/lib/texts.ts`** (organised by feature) — import
+  `texts` and reference them; never inline a German string in the component or the action.
+- **Co-locate a test** `+page.server.test.ts` covering `load` + each action — invoke the
+  **`write-tests`** skill; it knows the PocketBase-mock pattern and how to capture thrown redirects.
+- **Auth is on by default.** `src/hooks.server.ts` protects every path except the `unprotectedPrefix`
+  list. A new route requires login automatically. To make it public, add its prefix to
+  `unprotectedPrefix` (and remember the `*_public` views + `filterTrustedItems` for unauthenticated
+  reads). Authenticated users who haven't accepted the current legal docs are gated to `/legal/accept`.

--- a/.claude/skills/refresh-skills/SKILL.md
+++ b/.claude/skills/refresh-skills/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: refresh-skills
+description: Audit and update this repo's own .claude/skills against the current codebase, fixing drifted file paths, function signatures, texts.ts keys, route paths, and command names so the skills don't rot. Use whenever the user asks to refresh, audit, update, or check the skills, after a change that touches code the skills reference (a renamed helper, a changed signature, a moved route), or when a skill turns out to be inaccurate. Run it before relying on a skill you haven't used in a while.
+---
+
+# refresh-skills
+
+Skills encode real file paths, function signatures, `texts.ts` keys and commands — and the code
+moves underneath them. A stale skill is worse than none: it leads confidently to code that doesn't
+compile or, worse, silently breaks a guardrail (we have already shipped a skill with a wrong
+`filterTrustedItems` signature). This skill treats the skills like code: extract their checkable
+claims, verify each against the current repo, and fix what drifted — without changing what a skill
+is *for*.
+
+## 1. Scope
+
+Operate on every `SKILL.md` under `.claude/skills/*/` in **this** repo (and, for a skill that
+explicitly references the other repo — e.g. `schema-change` citing `allerleih-backend` — verify those
+claims against that repo too). Don't touch skills in other repos otherwise.
+
+## 2. Extract the checkable claims
+
+For each `SKILL.md`, pull out every statement that can rot — these are facts, not prose:
+
+- **File/dir paths** (`src/lib/server/itemFilters.ts`, `scripts/seed/scenarios/`).
+- **Imported symbols + signatures** (`filterTrustedItems(items, userId, loggedIn)`,
+  `createNotification(pb, recipient, sender?, type, relatedId, body)`).
+- **`texts.ts` keys** (`texts.errors.changesNotSaved`, `texts.notifications.pushTitle`).
+- **Route paths / endpoints** (`/legal/accept`, `/api/contact/{id}`).
+- **Commands & scripts** (`npx vitest run`, `npm test`, `npm run seed`).
+- **Collection / field names** and any **line-number hints** (`~line 824`).
+
+## 3. Verify each against the code
+
+Use Grep/Glob/Read — don't trust memory:
+
+- **Path** → confirm it exists (`Glob`). If moved, find the new location.
+- **Signature** → grep the `export function`/`export const`/`export async function` and Read it.
+  Confirm arg names, order, count, and `async`/sync. This is the highest-value check — a wrong
+  signature is the failure that bites hardest.
+- **`texts.*` key** → grep the dotted path in `src/lib/texts.ts`; confirm it resolves to a real entry
+  (watch for duplicate parent keys — e.g. two `notifications:` blocks).
+- **Command** → confirm the script exists in `package.json`.
+- **Line-number hint** → it's approximate; if the thing has moved far, update the "~line N".
+- **Embedded code snippet** that's meant to compile → reconcile it against the real signatures it
+  uses. Where cheap, sanity-check by type-checking (`npm run check`) a throwaway use of it.
+
+## 4. Fix the drift — facts only
+
+Edit each `SKILL.md` to match reality, **preserving the skill's wording, structure, and intent**:
+
+- Correct the path / signature / key / command / line hint to the current truth.
+- Keep the description's *meaning* and trigger boundary intact — fix a stale path inside it, but don't
+  re-scope what the skill triggers on.
+- A referenced symbol that was **renamed** → update to the new name. **Removed with no replacement**,
+  or a behavioural change you can't confidently map → **don't guess; flag it for the human** in your
+  report and leave a clear note rather than inventing an API.
+
+## 5. Report
+
+Output a compact drift table and the fixes you made:
+
+```
+skill            claim                                   status     action
+new-route        filterTrustedItems(pb, items, user)     DRIFTED    → fixed to (items, userId, loggedIn)
+seed-scenario    npm run seed                             ok         —
+add-notification texts.notifications.pushTitle            ok         —
+schema-change    allerleih-backend/pb_migrations/         ok         —
+```
+
+Use four statuses: **ok** (matches reality), **DRIFTED** (wrong value that would mislead or break —
+fix it), **IMPRECISE** (points at the right thing but mis-describes it — e.g. an inline union called a
+named "type", or a paraphrased command/line-hint — fix the wording), **GONE** (API removed with no
+replacement — flag for the human, don't invent one).
+
+End with anything you flagged for human judgement (GONE items, ambiguous renames). If nothing
+drifted, say so plainly — a clean audit is a valid result.
+
+## When to run
+
+After merging changes that touch code a skill references, before leaning on a skill you haven't used
+recently, or periodically. This is the operational half of the `CLAUDE.md` "keep in sync" rule:
+that rule keeps docs aligned with code; this keeps the skills aligned too.

--- a/.claude/skills/schema-change/SKILL.md
+++ b/.claude/skills/schema-change/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: schema-change
+description: Coordinate a PocketBase schema change across both AllerLeih repos so nothing drifts — the backend migration (delegated to new-migration), the frontend TypeScript types, the data-model docs, and a public-view leak check. Use whenever the user adds/changes/removes a field on a collection, adds a collection, or changes a `*_public` view — anything that touches the schema. The point is to stop the frontend types, docs, and the privacy views from falling out of sync with the database.
+---
+
+# schema-change
+
+The schema lives in the **backend** repo (migrations + views), but its shadow is everywhere: frontend
+types, docs, seed factories, search. A change that only lands the migration leaves the frontend
+type-checking against a stale shape and — the dangerous case — can quietly expose a new field through
+a public view. This skill drives the change end-to-end and keeps the pieces in lockstep.
+
+Work through these in order; skip a step only when you can say *why* it doesn't apply.
+
+## 1. Backend migration — delegate to `new-migration`
+
+The migration itself is the backend repo's job. Invoke the **`new-migration`** skill in
+`allerleih-backend` (`.claude/skills/new-migration/`) — it has the templates for adding a field,
+changing access rules, and updating views, plus the `down()` revert and the `npm test` check (fresh
+DB, all migrations + hooks). Don't hand-roll the migration here.
+
+Two things to decide *during* the migration, because they ripple into every later step:
+- **Is the field user-settable?** If not (a server/hook-maintained field like the legal-consent
+  fields on `users`), stop clients writing it by **appending `&& @request.body.<field>:isset = false`
+  to the collection's existing `updateRule`** — don't replace the list/view rules, add this body-guard
+  (the pattern in `allerleih-backend/pb_migrations/1781900051_added_legal_fields_to_users.js`). The
+  field still goes in the TS type, marked as hook-maintained.
+- **Should it be visible to unauthenticated/other users?** That decides whether any `*_public` /
+  `items_searchable` view changes — and drives the leak check in step 4.
+
+## 2. Frontend types — `src/lib/types/models.ts`
+
+Update the type to match the new shape:
+- The **full collection interface** (e.g. `User`, `Item`) — add/change the field with its TS type;
+  mark server-only fields optional and note they're hook-maintained.
+- The **`*_public` view interface** (e.g. `UserPublic`, `ItemPublic`) — add the field **only if it
+  appears in that view's SQL `SELECT`**. These interfaces must match the view column-for-column;
+  a field in the interface that the view doesn't select is a lie the compiler can't catch, and a
+  selected column missing from the interface makes frontend code access `undefined`.
+
+## 3. Docs — `docs/data-model.md`
+
+- Add the field to the collection's block in the **Mermaid ER diagram** (type + a short comment,
+  e.g. `string tosAcceptedVersion "legal-consent cache — server-only"`) — this is the main doc touch
+  for most fields.
+- If the field changes a view's exposure or has special handling, add a note to the **views section**
+  — which currently documents the `items_public` / `items_searchable` columns + masking. There is no
+  `users_public` SQL block there, so a private `users` field needs only the ER-diagram entry. Docs
+  publish to GitHub Pages and are part of the "keep in sync" contract.
+
+## 4. Public-view leak check (the security-critical step)
+
+A new field on `users` or `items` is **not** in the `*_public` / `items_searchable` views unless a
+migration adds it — and it usually shouldn't be. Confirm, don't assume:
+- Inspect what each view actually selects (in a `pb_migrations/*` `viewQuery`, or live:
+  `app.findCollectionByNameOrId('users_public').viewQuery`).
+- These are **deliberately excluded** and must stay out: `users.email`, `users.password`,
+  `users.trusts`, `users.inviteCode`, raw coordinates (geolocation lives in an owner-only collection),
+  and the raw `owner` relation (exposed only as `userId`). Note the two views protect differently:
+  `users_public` works by **column omission** (a field that isn't in its `SELECT` is simply absent),
+  while `items_public` keeps the row but **NULL-masks** content fields (`name`, `image`,
+  `description`, …) for `trusteesOnly`/group-shared items — check the mechanism for the view you touched.
+- If the new field genuinely should be public, add it to the view's `SELECT` in the migration **and**
+  to the matching `*Public` interface (step 2) **and** the docs (step 3). If it shouldn't, verify no
+  `SELECT *`-style query sweeps it in. When unsure whether something leaks, get a project-aware
+  review (the `sveltekit-pb-reviewer` agent, or `/security-review`).
+
+## 5. The usual ripple — touch what applies
+
+- **Seed factories** `scripts/seed/lib.js` — set the field in `createUser`/`createItem`/… (required
+  fields must be set; optional ones get a sensible test default). See the `seed-scenario` skill.
+- **Search** `src/routes/search/searchFilter.ts` — if the field is searchable/filterable, add it to
+  `buildSearchFilter()` / `buildItemFilter()` (these are typed against `ItemPublic`).
+- **Texts** `src/lib/texts.ts` — German label for any user-visible field (and `ITEM_CATEGORIES` if
+  it's a category enum). Never inline strings.
+- **Create/edit route** (e.g. `src/routes/items/[id]/`) — add the field to the form + the action's
+  validate/save logic if it's user-editable.
+- **Lending requirements** — if the field is a borrower gate, register it in both
+  `src/lib/server/lendingRequirements.ts` and the backend `pb_hooks/lending_requirements.pb.js`.
+
+## Verify
+
+Run `npm test` in the backend (migrations + hooks apply on a fresh DB) and `npm run check` in the
+frontend (the types must compile against the new shape). Add/extend tests for any new server logic
+(the `write-tests` skill). For a visibility-affecting change, confirm the leak check with a quick
+read of the view `SELECT` — a wrong view is a privacy bug, not just a type error.

--- a/.claude/skills/seed-scenario/SKILL.md
+++ b/.claude/skills/seed-scenario/SKILL.md
@@ -51,7 +51,7 @@ see **"When there's no factory"** below.
 
 `createUser`/`createItem`/`createConversation` return the **record** (use `.id`); `createMessage`
 returns just the **id**. A conversation's `lendingStatus` is one of `pending`, `accepted`, `rejected`,
-`active`, `return_requested`, `completed` (the `LendingStatus` type in `src/lib/types/models.ts`; a
+`active`, `return_requested`, `completed` (the inline `lendingStatus` union on the conversation interface in `src/lib/types/models.ts` (~line 352); a
 fresh request starts `pending`) — see `docs/domain-model.md` for the lifecycle.
 
 ### When there's no factory

--- a/.claude/skills/seed-scenario/SKILL.md
+++ b/.claude/skills/seed-scenario/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: seed-scenario
+description: Create a new deterministic seed scenario for AllerLeih's local PocketBase (a file under scripts/seed/scenarios/) so reviewers and you can populate a running instance with realistic test data for a feature. Use whenever the user asks to add seed data, create a seed scenario, set up test data for a PR/feature, or "make some data to click through" — anything about populating the local DB to exercise a flow, not about Vitest unit tests.
+---
+
+# seed-scenario
+
+Add a named seed scenario so anyone can spin up realistic, deterministic data for a feature with
+one command — invaluable for PR review and manual walkthroughs. Scenarios are **safe to ship**:
+they only ever create users on the `@seed.test` domain and records those users own, and the runner
+tears that data down before each run, so production is never touched and re-running is idempotent.
+
+Model your scenario on the existing one: `scripts/seed/scenarios/account-deletion.js`. The factories
+and constants live in `scripts/seed/lib.js`; the runner is `scripts/seed.js`.
+
+## 1. Where it goes
+
+One file per feature/PR: `scripts/seed/scenarios/<feature>.js` (kebab-case, e.g. `groups.js`,
+`lending-lifecycle.js`). The runner **auto-discovers** it — no registration anywhere. The file name
+(without `.js`) is the scenario name you pass on the command line.
+
+## 2. Required exports
+
+```js
+import { createUser, createItem, createMessage, createConversation, setTrust, USER_PASSWORD, SEED_DOMAIN } from '../lib.js';
+
+// One-line summary, printed by the runner.
+export const description = 'Trust visibility: a trustees-only item is visible to a trusted user but hidden from everyone else.';
+
+// Builds the data. `pb` is an authenticated superuser client. Optionally return a
+// walkthrough string (logins + click-through steps) — the runner prints it on success.
+export async function run(pb) {
+  // …build data through the factories…
+  return `  Login (password for all: "${USER_PASSWORD}"):\n    owner_seed${SEED_DOMAIN} · trusted_seed${SEED_DOMAIN}\n\n  Walkthrough:\n    1. …`;
+}
+```
+
+## 3. Build everything through the factories
+
+Use the helpers for users/items/messages/conversations so users land on the `@seed.test` domain
+(the thing teardown keys off) and items get sane defaults. For collections the factories don't cover,
+see **"When there's no factory"** below.
+
+| Factory | Signature → returns | Notes |
+|---|---|---|
+| `createUser` | `(pb, username, overrides?)` → **record** | Makes `username@seed.test`, verified + onboarded, password `USER_PASSWORD`. Use a `_seed` suffix (`alice_seed`) to signal seed data and avoid clashing real usernames. `overrides` for extra fields (`isInstitution`, `city`, `bio`, …). |
+| `createItem` | `(pb, ownerId, name, categories, opts?)` → **record** | `categories` is an **array of valid `ITEM_CATEGORIES`** strings from `src/lib/texts.ts` (e.g. `['Werkzeug und Garten']`). `opts`: `description`, `place`, `status`, `trusteesOnly`. **Images:** each item gets a generated colour placeholder PNG by default — pass `withImage: false` to skip it, or `image: <File/Blob>` to upload your own. |
+| `createMessage` | `(pb, fromId, toId, content)` → **message id** (string, not a record) | Pass these ids into a conversation's `messages` array. |
+| `createConversation` | `(pb, data)` → **record** | `data` is the full object: `requester`, `itemOwner`, `requestedItem`, `messages: [ids]`, `readByRequester`, `readByOwner`, `lendingStatus`. |
+| `setTrust` | `(pb, userId, trustedIds[])` | Sets the user's `trusts[]`. Trust is directional — set both sides if you want mutual trust. |
+
+`createUser`/`createItem`/`createConversation` return the **record** (use `.id`); `createMessage`
+returns just the **id**. A conversation's `lendingStatus` is one of `pending`, `accepted`, `rejected`,
+`active`, `return_requested`, `completed` (the `LendingStatus` type in `src/lib/types/models.ts`; a
+fresh request starts `pending`) — see `docs/domain-model.md` for the lifecycle.
+
+### When there's no factory
+
+The factories only cover users, items, messages, conversations, and trust. Many features
+(`groups`/`group_members`, `lending_terms`, `notifications`, `user_contacts`, …) have none — and for
+those you **may** create records directly with `pb.collection(name).create(...)`. Two rules keep that
+safe:
+
+- **Reachable from a seed user.** `teardown()` only deletes `users`, `items`, `conversations`, and
+  `messages` (plus whatever the backend `cascadeDelete`s when a seed user is removed). A record you
+  create in any other collection survives re-runs and leaks **unless** deleting one of your
+  `@seed.test` users cascades to it (e.g. a `group` owned by a seed user takes its `group_members`
+  with it). If nothing cascades to it, it's orphaned — don't create it, or it'll pollute the next run.
+- **Respect the real rules and hooks.** Your direct `create` runs against the live collection rules
+  and `pb_hooks` — read the relevant backend hook first. They auto-create rows and enforce unique
+  indexes: e.g. creating a `groups` record fires a hook that inserts the owner as an `admin`
+  `group_member`, so adding the owner's membership yourself violates the unique `(group, user)` index
+  and the seed crashes. Set only the rows the hook doesn't.
+
+## 4. Idempotency: tie everything to seed users, run one at a time
+
+Before any scenario runs, `teardown()` deletes **every** `@seed.test` user and their
+messages/conversations/items. Two consequences:
+- **Everything you create must belong to a seed user** (made via `createUser`). A record owned by a
+  real user won't be cleaned up and will leak across runs.
+- **Scenarios are independent and run one at a time** — never assume data from another scenario is
+  present; build the full world your scenario needs.
+
+## 5. Write a walkthrough
+
+The most useful scenarios return a summary string with the logins and the exact click-through that
+demonstrates the feature (see `account-deletion.js` for the shape). This is what a reviewer reads to
+verify the PR, so make the steps concrete and ordered.
+
+## 6. Run it
+
+PocketBase must be running, and you need superuser credentials in the environment:
+
+```bash
+npm run seed                 # lists available scenarios
+PB_SUPERUSER_EMAIL=you@example.com PB_SUPERUSER_PASSWORD=secret npm run seed -- <feature>
+```
+
+All seed users share the password `password123`; the runner prints the logins + your walkthrough on
+success. `PB_URL` overrides the instance (default `http://127.0.0.1:8090`). Run your new scenario
+once to confirm it seeds cleanly before committing.

--- a/.claude/skills/write-tests/SKILL.md
+++ b/.claude/skills/write-tests/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: write-tests
+description: Write Vitest unit tests for the AllerLeih SvelteKit frontend, following this repo's conventions (co-located *.test.ts, mocked PocketBase, testing server functions and +page.server.ts load/actions). Use whenever the user asks to write, add, or improve tests, increase coverage, or "test this" for any server-side function, form action, or load function — even if they don't say "Vitest". Reach for it before merging logic that isn't covered.
+---
+
+# write-tests (frontend)
+
+Add tests that match how this repo already tests, so they read like the surrounding suite
+and pass in CI. We test **server-side logic** — pure helpers in `$lib/server/*.ts` and a route's
+`+page.server.ts` `load`/`actions` — by mocking PocketBase. UI-component rendering isn't tested
+here yet; don't introduce a new harness for it without asking.
+
+Before writing, skim a nearby test to copy the local style. Good models:
+`src/lib/server/items.test.ts` (helper functions), `src/routes/legal/accept/page.server.test.ts`
+(load + actions, redirects), and `docs/testing-strategy.md` (the canonical mock shape).
+
+## 1. Where the file goes
+
+Co-locate the test with its target, same basename + `.test.ts`:
+- `src/lib/server/items.ts` → `src/lib/server/items.test.ts`
+- `src/routes/legal/accept/+page.server.ts` → `src/routes/legal/accept/page.server.test.ts`
+
+## 2. Mock PocketBase with a small factory
+
+There's no real DB in unit tests. Build a `pb` whose `collection(name)` returns an object of
+`vi.fn()` stubs for only the methods the code under test calls — e.g. `getOne`, `getFirstListItem`,
+`getFullList`, `create`, `update`, `delete`. Distinguish multiple calls to the same collection by
+inspecting the args (e.g. the `filter` string), and expose the stubs so you can assert on them
+afterwards.
+
+Many helpers signal "not found" by **rejecting** rather than returning null — `getOne` and
+`getFirstListItem` throw when nothing matches, and the code wraps them in `try/catch`. Drive that
+branch with `vi.fn().mockRejectedValue(new Error('not found'))` so you actually exercise the catch.
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { deleteItem } from './items';
+
+function makePb({ item, openConversations = [] }) {
+  const getOne = vi.fn().mockResolvedValue(item);
+  const deleteRecord = vi.fn().mockResolvedValue(undefined);
+  const getFullList = vi.fn(({ filter } = {}) =>
+    Promise.resolve(filter?.includes('lendingStatus') ? openConversations : [])
+  );
+  const pb = {
+    collection: vi.fn((name: string) =>
+      name === 'items' ? { getOne, delete: deleteRecord } : { getFullList }
+    ),
+    // Mirror the real pb.filter() so the code under test can interpolate params.
+    filter: (raw: string, params?: Record<string, unknown>) =>
+      params ? Object.entries(params).reduce((a, [k, v]) => a.replace(`{:${k}}`, String(v)), raw) : raw,
+    _deleteRecord: deleteRecord, // handles surfaced for assertions
+  };
+  return pb as unknown as Parameters<typeof deleteItem>[0] & typeof pb;
+}
+```
+
+Always provide `pb.filter` — production code builds every filter through it (never with template
+literals), so a missing mock throws. Reset state between tests with `beforeEach(() => vi.clearAllMocks())`.
+
+**Not everything routes through `collection()`.** Some `$lib/server/*` helpers reach a privileged
+backend hook via the root-level `pb.send('/api/…')`, and a few read `pb.authStore`. Stub those as
+siblings of `pb.filter` on the `pb` object — `send: vi.fn().mockResolvedValue({ … })` — not inside
+`collection()`, otherwise the call is `undefined` and the test throws before it asserts anything.
+
+## 3. Testing `load` and `actions`
+
+These take a SvelteKit request event. Build a `makeEvent({ user, form, params, … })` helper that
+returns `{ locals: { pb, user }, request, url, params, … }` cast to the function's parameter type.
+Put form fields into a real `FormData` and expose it via `request.formData`.
+
+SvelteKit's `redirect()` and `error()` **throw**, so a successful redirect never returns — capture
+the thrown value and assert on it:
+
+```ts
+async function capture(fn: () => unknown) {
+  try { await fn(); } catch (e) { return e as { status: number; location?: string }; }
+  throw new Error('expected a thrown redirect, but none was thrown');
+}
+
+const r = await capture(() => actions.accept(event));
+expect(r).toMatchObject({ status: 303, location: '/items/abc' });
+```
+
+A form action that returns a `fail()` (e.g. validation error) does *not* throw — assert on the
+returned object instead.
+
+## 4. Assert behaviour, not implementation
+
+Prefer asserting the function's return value and the PocketBase calls it made
+(`expect(pb._deleteRecord).toHaveBeenCalledWith('item1')`) over internal details. Cover every branch
+the function can take — owner vs. non-owner, found vs. not-found, empty input, the open-loan guard,
+the security edge cases (e.g. open-redirect targets in `legal/accept`). One `it()` per branch, named
+for the behaviour it pins down.
+
+For user-facing error/success messages, assert against the constant from `$lib/texts`
+(`texts.legal.accept.errors.mustAcceptAll`) rather than hard-coding the German string — strings live
+in `texts.ts` and may change.
+
+## 5. Run it
+
+```bash
+npx vitest run src/path/to/file.test.ts   # the file you just wrote, fast feedback
+npx vitest run                            # full suite, the CI gate
+```
+
+`npm run test` starts Vitest in **watch** mode (handy while iterating); use `npx vitest run` for a
+one-shot pass. CI runs `npx vitest run --coverage` + `npm run build` on every PR
+(`.github/workflows/vitest.yaml`) and posts a coverage comment, so a new test that fails to compile
+or run will block the merge — confirm it's green locally first.

--- a/scripts/seed/lib.js
+++ b/scripts/seed/lib.js
@@ -6,6 +6,7 @@
  * records. Scenarios should build their data through the exported factories.
  */
 import PocketBase from 'pocketbase';
+import zlib from 'node:zlib';
 
 export const SEED_DOMAIN = '@seed.test';
 export const USER_PASSWORD = 'password123';
@@ -66,8 +67,65 @@ export function createUser(pb, username, overrides = {}) {
 	});
 }
 
+// Tiny dependency-free PNG encoder so seeded items carry a real (offline, deterministic)
+// image instead of just the category placeholder. Each item gets a solid card whose colour
+// is derived from its name, so the seeded items look distinct when clicking through.
+const CRC_TABLE = (() => {
+	const t = new Uint32Array(256);
+	for (let n = 0; n < 256; n++) {
+		let c = n;
+		for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+		t[n] = c >>> 0;
+	}
+	return t;
+})();
+function crc32(buf) {
+	let c = 0xffffffff;
+	for (let i = 0; i < buf.length; i++) c = CRC_TABLE[(c ^ buf[i]) & 0xff] ^ (c >>> 8);
+	return (c ^ 0xffffffff) >>> 0;
+}
+function pngChunk(type, data) {
+	const len = Buffer.alloc(4);
+	len.writeUInt32BE(data.length, 0);
+	const typeBuf = Buffer.from(type, 'ascii');
+	const crc = Buffer.alloc(4);
+	crc.writeUInt32BE(crc32(Buffer.concat([typeBuf, data])), 0);
+	return Buffer.concat([len, typeBuf, data, crc]);
+}
+function solidPng(w, h, [r, g, b]) {
+	const ihdr = Buffer.alloc(13);
+	ihdr.writeUInt32BE(w, 0);
+	ihdr.writeUInt32BE(h, 4);
+	ihdr[8] = 8; // bit depth
+	ihdr[9] = 2; // colour type: truecolour RGB
+	const row = Buffer.alloc(1 + w * 3); // leading filter byte (0) + RGB pixels
+	for (let x = 0; x < w; x++) [row[1 + x * 3], row[1 + x * 3 + 1], row[1 + x * 3 + 2]] = [r, g, b];
+	const raw = Buffer.concat(Array.from({ length: h }, () => row));
+	const sig = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+	return Buffer.concat([sig, pngChunk('IHDR', ihdr), pngChunk('IDAT', zlib.deflateSync(raw)), pngChunk('IEND', Buffer.alloc(0))]);
+}
+function hsvToRgb(h, s, v) {
+	const c = v * s,
+		x = c * (1 - Math.abs(((h / 60) % 2) - 1)),
+		m = v - c;
+	const [r, g, b] =
+		h < 60 ? [c, x, 0] : h < 120 ? [x, c, 0] : h < 180 ? [0, c, x] : h < 240 ? [0, x, c] : h < 300 ? [x, 0, c] : [c, 0, x];
+	return [Math.round((r + m) * 255), Math.round((g + m) * 255), Math.round((b + m) * 255)];
+}
+
+/** A deterministic solid-colour PNG (640×420) as an upload, coloured from the name. */
+export function placeholderImage(name) {
+	let hash = 0;
+	for (const ch of name) hash = (hash * 31 + ch.charCodeAt(0)) >>> 0;
+	const png = solidPng(640, 420, hsvToRgb(hash % 360, 0.5, 0.8));
+	const file = `${name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'item'}.png`;
+	return typeof File !== 'undefined'
+		? new File([png], file, { type: 'image/png' })
+		: new Blob([png], { type: 'image/png' });
+}
+
 export function createItem(pb, ownerId, name, categories, opts = {}) {
-	return pb.collection('items').create({
+	const data = {
 		name,
 		description: opts.description ?? `${name} (Testdaten)`,
 		place: opts.place ?? 'Kassel',
@@ -75,7 +133,13 @@ export function createItem(pb, ownerId, name, categories, opts = {}) {
 		status: opts.status ?? 'available',
 		trusteesOnly: opts.trusteesOnly ?? false,
 		categories,
-	});
+	};
+	// Items get a generated placeholder image by default. Opt out with `withImage: false`,
+	// or supply your own File/Blob via `image`. The PocketBase SDK detects the File and
+	// uploads it as multipart.
+	const image = opts.image ?? (opts.withImage === false ? null : placeholderImage(name));
+	if (image) data.image = image;
+	return pb.collection('items').create(data);
 }
 
 export async function createMessage(pb, fromId, toId, content) {


### PR DESCRIPTION
## What

Adds shared project skills under `.claude/skills/` so the team uses the same workflows, plus a refresh of the reviewer agent and the CLAUDE.md tooling index.

**New skills**
- `write-tests` — author Vitest tests to repo conventions (co-located `*.test.ts`, mocked PocketBase).
- `seed-scenario` — create a deterministic local seed scenario. Also adds optional **image support** to the `createItem` seed factory (`scripts/seed/lib.js`): items get a generated solid-colour placeholder PNG by default (opt out with `withImage:false`, or supply your own via `image`), via a tiny dependency-free PNG encoder.
- `new-route` — scaffold a SvelteKit route with the project guardrails baked in (`pb.filter`, `filterTrustedItems` + `expand:'owner'`, runes / no `data` destructuring, server-side ownership checks, co-located test).
- `add-notification-type` — wire a new notification type end-to-end (union → `texts` → trigger site → in-app routing), keeping `relatedId` / push url / `notificationHref` consistent.
- `schema-change` — coordinate a schema change across both repos: migration (delegates to backend `new-migration`) → `models.ts` → `docs/data-model.md` → public-view leak check.
- `refresh-skills` — audit & fix the `.claude/skills` when code they cite drifts (paths, signatures, `texts` keys, commands).

**Also**
- Extends the `sveltekit-pb-reviewer` agent for the current codebase (group visibility + `items_searchable`, the verified `filterTrustedItems(items, userId, loggedIn)` signature, deleted-account `displayName()` masking, `subscribeRealtime()`).
- Lists all skills in the CLAUDE.md "Project tooling" index (skills still auto-trigger from their own `description`; the list is for human discoverability).

Each skill was validated against the real code (authoring/review pass); `seed-scenario`'s image support was verified end-to-end against a throwaway PocketBase (uploaded + served as `image/png`).

## Test notes

Preflight on this branch:
- `eslint scripts/seed/lib.js` (the only code change) — clean
- `npm run check` — 0 errors
- `npm run build` — ok

**Pre-existing red on `main` (not from this PR):** `npx vitest run` reports 2 failing tests in `src/routes/user/items/page.server.test.ts`, and `npm run lint` reports 26 errors — all in the `user/items` area. Verified they fail on `origin/main` as well, so they are unrelated to this change (which is markdown + one self-contained seed helper). The 2 stale delete-action tests are addressed separately on `fix/user-items-delete-tests`.

No app routes, `/api/*` endpoints, or PocketBase collections/views were changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
