### PR TITLE
Fix stale user/items delete-action tests (red on main)

### DIFF
--- a/src/routes/user/items/page.server.test.ts
+++ b/src/routes/user/items/page.server.test.ts
@@ -1,44 +1,33 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Mocked dependency: assert the delete action routes conversation deletion through it.
-const { deleteConversationMock } = vi.hoisted(() => ({ deleteConversationMock: vi.fn() }));
-vi.mock('../../conversations/[conversationId]/conversation.server', () => ({
-	deleteConversation: deleteConversationMock,
+// The delete action delegates the cascade + open-loan guard to deleteItem();
+// that helper is unit-tested in src/lib/server/items.test.ts, so here we only
+// assert the action delegates correctly and maps the result.
+const { deleteItemMock, deleteMultipleItemsMock, setItemStatusMock } = vi.hoisted(() => ({
+	deleteItemMock: vi.fn(),
+	deleteMultipleItemsMock: vi.fn(),
+	setItemStatusMock: vi.fn(),
+}));
+vi.mock('$lib/server/items', () => ({
+	deleteItem: deleteItemMock,
+	deleteMultipleItems: deleteMultipleItemsMock,
+	setItemStatus: setItemStatusMock,
 }));
 // hooks.server.ts (re-exported by +page.server) reads PUBLIC_PB_URL from here.
 vi.mock('$env/static/public', () => ({ PUBLIC_PB_URL: 'http://localhost', PUBLIC_VAPID_PUBLIC_KEY: 'x' }));
 
 import { actions } from './+page.server';
-
-function mockFilter(raw: string, params?: Record<string, unknown>): string {
-	if (!params) return raw;
-	let result = raw;
-	for (const [key, value] of Object.entries(params)) {
-		const escaped = typeof value === 'string' ? `'${value.replace(/'/g, "\\'")}'` : `${value}`;
-		result = result.replaceAll(`{:${key}}`, escaped);
-	}
-	return result;
-}
+import { texts } from '$lib/texts';
 
 type DeleteEvent = Parameters<typeof actions.delete>[0];
 
-function setup(conversations: { id: string }[]) {
-	const convGetFullList = vi.fn().mockResolvedValue(conversations);
-	const itemsDelete = vi.fn().mockResolvedValue(true);
-	const pb = {
-		collection: vi.fn((name: string) =>
-			name === 'conversations' ? { getFullList: convGetFullList } : { delete: itemsDelete }
-		),
-		filter: vi.fn(mockFilter),
-	};
-	return { pb, convGetFullList, itemsDelete };
-}
+const pb = {} as unknown;
 
-function callDelete(pb: unknown, itemId?: string) {
+function callDelete(itemId?: string) {
 	const fd = new FormData();
 	if (itemId !== undefined) fd.set('itemId', itemId);
 	return actions.delete({
-		locals: { pb },
+		locals: { pb, user: { id: 'u1' } },
 		request: { formData: vi.fn().mockResolvedValue(fd) },
 	} as unknown as DeleteEvent);
 }
@@ -46,40 +35,41 @@ function callDelete(pb: unknown, itemId?: string) {
 describe('user items: delete action', () => {
 	beforeEach(() => vi.clearAllMocks());
 
-	it('routes each conversation deletion through deleteConversation, then deletes the item', async () => {
-		const { pb, itemsDelete } = setup([{ id: 'c1' }, { id: 'c2' }]);
+	it('delegates to deleteItem with the pb client, item id, and current user id', async () => {
+		deleteItemMock.mockResolvedValue({ status: 'deleted' });
 
-		await callDelete(pb, 'item1');
+		const result = await callDelete('item1');
 
-		expect(deleteConversationMock).toHaveBeenCalledTimes(2);
-		expect(deleteConversationMock).toHaveBeenCalledWith(pb, 'c1');
-		expect(deleteConversationMock).toHaveBeenCalledWith(pb, 'c2');
-		expect(itemsDelete).toHaveBeenCalledWith('item1');
+		expect(deleteItemMock).toHaveBeenCalledWith(pb, 'item1', 'u1');
+		expect(result).toBeUndefined();
 	});
 
-	it('deletes the item even when it has no conversations', async () => {
-		const { pb, itemsDelete } = setup([]);
+	it('returns a 409 (with conversation ids) when the item has open conversations', async () => {
+		deleteItemMock.mockResolvedValue({
+			status: 'has_open_conversations',
+			conversationIds: ['c1', 'c2'],
+		});
 
-		await callDelete(pb, 'item1');
+		const result = await callDelete('item1');
 
-		expect(deleteConversationMock).not.toHaveBeenCalled();
-		expect(itemsDelete).toHaveBeenCalledWith('item1');
+		expect(result?.status).toBe(409);
+		expect(result?.data).toMatchObject({
+			fail: true,
+			message: texts.pages.items.deleteBlockedByConversation,
+			conversationIds: ['c1', 'c2'],
+		});
 	});
 
 	it('does nothing when no itemId is supplied', async () => {
-		const { pb, itemsDelete } = setup([]);
+		const result = await callDelete(undefined);
 
-		await callDelete(pb, undefined);
-
-		expect(deleteConversationMock).not.toHaveBeenCalled();
-		expect(itemsDelete).not.toHaveBeenCalled();
+		expect(deleteItemMock).not.toHaveBeenCalled();
+		expect(result).toBeUndefined();
 	});
 
-	it('does not delete the item if a conversation deletion fails (error is swallowed)', async () => {
-		const { pb, itemsDelete } = setup([{ id: 'c1' }]);
-		deleteConversationMock.mockRejectedValueOnce(new Error('boom'));
+	it('swallows errors from deleteItem (resolves without throwing)', async () => {
+		deleteItemMock.mockRejectedValueOnce(new Error('boom'));
 
-		await expect(callDelete(pb, 'item1')).resolves.toBeUndefined();
-		expect(itemsDelete).not.toHaveBeenCalled();
+		await expect(callDelete('item1')).resolves.toBeUndefined();
 	});
 });


### PR DESCRIPTION
## What

Fixes the 2 failing tests in `src/routes/user/items/page.server.test.ts` (currently red on `main`).

The `user/items` delete action was refactored to delegate the cascade + open-loan guard to the `deleteItem()` helper (`$lib/server/items.ts`), but the test was never updated:
- it mocked the old inline flow (direct `deleteConversation` + `items.delete`), and
- it passed `locals` **without a `user`**, so on the current code the action threw on `locals.user.id`, swallowed the error, and never reached the mocks → 2 of 4 assertions failed.

This re-points the tests at the action's actual responsibilities: delegating to `deleteItem(pb, itemId, userId)`, mapping `has_open_conversations` → `fail(409)` (with the conversation ids), the no-`itemId` no-op, and swallowing errors. The cascade / open-loan behaviour itself is already covered by `src/lib/server/items.test.ts`, so this avoids duplicating it.

## Test notes

`npx vitest run src/routes/user/items/page.server.test.ts` → **4 passed**. Lint-clean. No production code changed — test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
