### PR TITLE
fix(lint): resolve all 26 ESLint errors

### DIFF
--- a/src/routes/groups/join/[token]/+page.svelte
+++ b/src/routes/groups/join/[token]/+page.svelte
@@ -45,12 +45,14 @@
 			{:else}
 				<!-- Preview is public, but joining needs an account. Send guests to
 				     login and bring them straight back to this invite. -->
+				<!-- eslint-disable svelte/no-navigation-without-resolve -- path is resolve()d; the rule can't match the appended ?redirectTo query string -->
 				<a
 					href={`${resolve('/auth/login')}?redirectTo=${encodeURIComponent('/groups/join/' + data.token)}`}
 					class="inline-block w-full rounded-lg bg-primary-200 hover:bg-primary px-4 py-2 text-center font-medium"
 				>
 					{texts.groups.loginToJoin}
 				</a>
+				<!-- eslint-enable svelte/no-navigation-without-resolve -->
 			{/if}
 		{:else if data.state === 'expired'}
 			<CustomAlert type="error" message={texts.groups.expiredInvite} />

--- a/src/routes/invite/[slug]/+page.svelte
+++ b/src/routes/invite/[slug]/+page.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { resolve } from '$app/paths';
 	import { texts } from '$lib/texts';
 
 	let { data } = $props();
 
 	const origin = $derived(page.url.origin);
-	const registerUrl = $derived(`/auth/register?invite=${data.slug}`);
+	const registerUrl = $derived(`${resolve('/auth/register')}?invite=${data.slug}`);
 	const ogTitle = 'Du wurdest zu AllerLeih eingeladen!';
 	const ogDescription = texts.pages.inviteLanding.description;
 </script>
@@ -38,11 +39,13 @@
 			{ogDescription}
 		</p>
 
+		<!-- eslint-disable svelte/no-navigation-without-resolve -- registerUrl is resolve()d; the rule can't match the appended ?invite query string -->
 		<a
 			href={registerUrl}
 			class="block w-full min-button rounded-full bg-primary-200 px-5 py-3 text-center text-base font-medium text-white hover:bg-primary focus:outline-none focus:ring-4 focus:ring-primary-300 dark:bg-primary-600 dark:hover:bg-primary-700 dark:focus:ring-primary-800"
 		>
 			{texts.pages.inviteLanding.cta}
 		</a>
+		<!-- eslint-enable svelte/no-navigation-without-resolve -->
 	</div>
 </div>

--- a/src/routes/items/[id]/terms/+page.svelte
+++ b/src/routes/items/[id]/terms/+page.svelte
@@ -67,6 +67,7 @@
 	<article
 		class="terms-body rounded-2xl border border-tinte-200 dark:border-tinte-700 bg-sand dark:bg-tinte-800 p-6 leading-relaxed text-tinte-800 dark:text-tinte-200"
 	>
+		<!-- eslint-disable-next-line svelte/no-at-html-tags -- admin-only source, server-side normalized via lendingTerms.cleanTermsHtml (see comment above) -->
 		{@html data.terms.body}
 	</article>
 

--- a/src/routes/misc/about/+page.svelte
+++ b/src/routes/misc/about/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { texts } from '$lib/texts';
-	import { GithubSolid, LinkedinSolid, UsersGroupOutline, HeartOutline, GlobeOutline, EnvelopeOutline } from 'flowbite-svelte-icons';
+	import { GithubSolid, LinkedinSolid, EnvelopeOutline } from 'flowbite-svelte-icons';
 
 	const members = [
 		{

--- a/src/routes/misc/guide/+page.svelte
+++ b/src/routes/misc/guide/+page.svelte
@@ -1,21 +1,8 @@
 <script lang="ts">
 	import { texts } from '$lib/texts';
 	import { Accordion, AccordionItem } from 'flowbite-svelte';
-	import {
-		SearchOutline,
-		MessageDotsOutline,
-		UsersGroupOutline,
-		RefreshOutline,
-		UploadOutline,
-		InboxOutline,
-		ShieldCheckOutline,
-		CheckCircleOutline,
-	} from 'flowbite-svelte-icons';
 
 	const { guide } = texts.pages;
-
-	const borrowingIcons = [SearchOutline, MessageDotsOutline, UsersGroupOutline, RefreshOutline];
-	const lendingIcons = [UploadOutline, InboxOutline, ShieldCheckOutline, CheckCircleOutline];
 </script>
 
 <svelte:head>

--- a/src/routes/notifications/+page.svelte
+++ b/src/routes/notifications/+page.svelte
@@ -48,6 +48,7 @@
 			{#each data.notifications as notification (notification.id)}
 				<li class="flex items-center gap-2 py-4 px-2 rounded-lg hover:bg-papier transition-colors">
 					
+					<!-- eslint-disable svelte/no-navigation-without-resolve -- notificationHref() already returns resolve()d internal paths; the rule can't see through the function call -->
 					<a
 						href={notificationHref(notification)}
 						class="flex items-start gap-4 flex-1 min-w-0"
@@ -81,6 +82,7 @@
 							<p class="text-xs text-tinte-400 mt-0.5">{formatTimestamp(notification.created)}</p>
 						</div>
 					</a>
+					<!-- eslint-enable svelte/no-navigation-without-resolve -->
 					<form
 						method="POST"
 						action="?/toggleRead"

--- a/src/routes/search/CategoryFilter.svelte
+++ b/src/routes/search/CategoryFilter.svelte
@@ -23,10 +23,12 @@
 
 	function toggleCat(cat: string) {
 		const next = selectedCategories.includes(cat) ? [] : [cat];
+		// eslint-disable-next-line svelte/no-navigation-without-resolve -- buildSearchUrl() already resolve()s the /search path; the rule can't see through the helper
 		goto(buildUrl(next, op));
 	}
 
 	function toggleOp() {
+		// eslint-disable-next-line svelte/no-navigation-without-resolve -- buildSearchUrl() already resolve()s the /search path; the rule can't see through the helper
 		goto(buildUrl(selectedCategories, op === 'or' ? 'and' : 'or'));
 	}
 

--- a/src/routes/user/import/+page.svelte
+++ b/src/routes/user/import/+page.svelte
@@ -215,7 +215,7 @@
 				</Alert>
 				{#if form.rowErrors && form.rowErrors.length > 0}
 					<ul class="text-xs text-accent-700 font-mono space-y-0.5 list-disc list-inside">
-						{#each form.rowErrors as e}
+						{#each form.rowErrors as e, i (i)}
 							<li>{e}</li>
 						{/each}
 					</ul>

--- a/src/routes/user/items/+page.svelte
+++ b/src/routes/user/items/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
 	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
+	import { SvelteSet, SvelteURLSearchParams } from 'svelte/reactivity';
 	import { Button } from 'flowbite-svelte';
 	import { texts } from '$lib/texts';
 	import ItemModal from './ItemModal.svelte';
@@ -10,16 +12,16 @@
 	let { data, form } = $props();
 
 	let showAddModal = $state(false);
-	let searchValue = $state(data.search);
+	let searchValue = $derived(data.search);
 	let debounceTimer: ReturnType<typeof setTimeout>;
-	let selectedIds = $state(new Set<string>());
-
-	$effect(() => { searchValue = data.search; });
+	const selectedIds = new SvelteSet<string>();
 
 	$effect(() => {
-		// Clear selection when item list changes (navigation, filter)
-		data.items;
-		selectedIds = new Set();
+		// Reading the current item ids registers this effect as a dependency of
+		// data.items, so the bulk selection is cleared on every list change
+		// (navigation, filter, page, delete).
+		data.items.map((item) => item.id);
+		selectedIds.clear();
 	});
 
 	function onSearchInput(e: Event) {
@@ -27,29 +29,31 @@
 		searchValue = value;
 		clearTimeout(debounceTimer);
 		debounceTimer = setTimeout(() => {
-			const params = new URLSearchParams(window.location.search);
+			const params = new SvelteURLSearchParams(window.location.search);
 			params.set('search', value);
 			params.set('page', '1');
+			// eslint-disable-next-line svelte/no-navigation-without-resolve -- same-page query-string update; resolve() does not handle query strings
 			goto('?' + params.toString(), { keepFocus: true });
 		}, 300);
 	}
 
 	function onStatusChange(e: Event) {
 		const value = (e.currentTarget as HTMLSelectElement).value;
-		const params = new URLSearchParams(window.location.search);
+		const params = new SvelteURLSearchParams(window.location.search);
 		params.set('status', value);
 		params.set('page', '1');
+		// eslint-disable-next-line svelte/no-navigation-without-resolve -- same-page query-string update; resolve() does not handle query strings
 		goto('?' + params.toString());
 	}
 
 	function toggleSelectAll(checked: boolean) {
-		selectedIds = checked ? new Set(data.items.map((i) => i.id)) : new Set();
+		selectedIds.clear();
+		if (checked) for (const item of data.items) selectedIds.add(item.id);
 	}
 
 	function updateSelection(id: string, v: boolean) {
-		const next = new Set(selectedIds);
-		if (v) next.add(id); else next.delete(id);
-		selectedIds = next;
+		if (v) selectedIds.add(id);
+		else selectedIds.delete(id);
 	}
 
 	const allSelected = $derived(
@@ -121,7 +125,7 @@
 		{#if form && 'bulkBlocked' in form && form.conversationIds?.length}
 			<div class="mb-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200">
 				<p>{form.message}</p>
-				<a href="/conversations" class="mt-1 inline-block font-semibold underline">
+				<a href={resolve('/conversations')} class="mt-1 inline-block font-semibold underline">
 					{texts.pages.items.linkToConversations}
 				</a>
 			</div>
@@ -177,7 +181,6 @@
 						return async ({ update }) => {
 							await update({ reset: false });
 							for (const id of submitted) selectedIds.delete(id);
-							selectedIds = new Set(selectedIds);
 						};
 					}}
 				>
@@ -193,7 +196,7 @@
 				</form>
 				<button
 					type="button"
-					onclick={() => { selectedIds = new Set(); }}
+					onclick={() => selectedIds.clear()}
 					class="ml-auto text-xs text-tinte-500 hover:text-tinte-700 dark:hover:text-tinte-300 cursor-pointer"
 				>
 					{texts.pages.items.deselectAll}

--- a/src/routes/user/items/ItemModal.svelte
+++ b/src/routes/user/items/ItemModal.svelte
@@ -135,7 +135,7 @@
 			<p>{form.message}</p>
 			{#if form?.conversationIds?.length}
 				<a
-					href="/conversations/{form.conversationIds[0]}"
+					href={resolve(`/conversations/${form.conversationIds[0]}`)}
 					class="mt-1 inline-block font-semibold underline"
 				>{texts.pages.items.linkToConversation}</a>
 			{/if}

--- a/src/routes/user/items/Pagination.svelte
+++ b/src/routes/user/items/Pagination.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import { SvelteURLSearchParams } from 'svelte/reactivity';
 
 	interface Props {
 		currentPage: number;
@@ -8,7 +9,7 @@
 	let { currentPage, totalPages }: Props = $props();
 
 	function pageUrl(n: number): string {
-		const params = new URLSearchParams($page.url.searchParams);
+		const params = new SvelteURLSearchParams($page.url.searchParams);
 		params.set('page', String(n));
 		return '?' + params.toString();
 	}
@@ -28,6 +29,7 @@
 	}
 </script>
 
+<!-- eslint-disable svelte/no-navigation-without-resolve -- same-page pagination links carry only a ?page query string, which resolve() does not handle -->
 {#if totalPages > 1}
 	<div class="mt-6 flex items-center justify-center gap-1">
 		<!-- Prev -->
@@ -66,3 +68,4 @@
 		{/if}
 	</div>
 {/if}
+<!-- eslint-enable svelte/no-navigation-without-resolve -->


### PR DESCRIPTION
## What & why

`npm run lint` reported **26 errors** on `main` — all pre-existing, repo-wide
issues (no feature branch introduced them), mostly from the
`svelte.configs.recommended` rule set (`no-navigation-without-resolve`,
`prefer-svelte-reactivity`, etc.). This brings `npm run lint` to a clean pass so
CI and future branches start from zero lint debt.

## Changes by rule

- **`@typescript-eslint/no-unused-vars`** — remove dead icon imports/arrays in `misc/about` and `misc/guide`.
- **`svelte/no-navigation-without-resolve`** — wrap plain internal paths in `resolve()` (`user/items`, `ItemModal`); `invite` `registerUrl` now uses `resolve('/auth/register')`. For query-string / helper-indirected navigations (`notificationHref()`, `buildSearchUrl()`, pagination, same-page query updates) add **justified `eslint-disable` comments** — SvelteKit's `resolve()` only accepts internal paths/route IDs and cannot express query strings, and the rule can't see through helper calls.
- **`svelte/prefer-svelte-reactivity`** — `user/items` bulk selection uses `SvelteSet`; transient params use `SvelteURLSearchParams`. The old immutable-reassign pattern (`selectedIds = new Set(selectedIds)`) is dropped because `SvelteSet` mutations are themselves reactive.
- **`svelte/prefer-writable-derived`** — `searchValue` becomes a writable `$derived(data.search)` (replacing `$state` + `$effect`).
- **`@typescript-eslint/no-unused-expressions`** — the clear-selection `$effect` now reads `data.items` via `.map()` (a valid call statement) instead of a bare expression, preserving the clear-on-change behavior.
- **`svelte/require-each-key`** — index key on the import row-error list.
- **`svelte/no-at-html-tags`** — justified `eslint-disable` on the lending-terms `{@html}` (admin-only source, server-normalized via `lendingTerms.cleanTermsHtml`).

## Test notes

- Preflight all green: `npm run lint` (0 errors), `npm run check` (0 errors), `npx vitest run` (229/229), `npm run build`.
- Only `.svelte` client files changed — no `+page.server.ts` / server logic touched, so the server-side test surface is unchanged.
- Reviewer manual check (optional): on **Meine Gegenstände** (`/user/items`), verify bulk selection still works — select-all, individual toggle, deselect-all, and that the selection clears on search/filter/page navigation. This is the only behavior-sensitive change (Set → SvelteSet); equivalence was verified in review.