### PR TITLE
docs(retention): document lastLoginAt + automated GDPR retention (#461)

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -28,6 +28,8 @@ erDiagram
         string tosAcceptedVersion "legal-consent cache (Issue #399) — server-only"
         string privacyAcceptedVersion "legal-consent cache — server-only"
         bool legalLocked "decline lock — set/cleared only by backend hooks"
+        date lastLoginAt "stamped on auth (throttled 24h) — drives inactive-account retention; hidden field, superuser-only"
+        date retentionNotifiedAt "last open-loan skip-notice (retention job); hidden field, superuser-only"
         date created
         date updated
     }
@@ -301,9 +303,23 @@ Self-service account deletion (GDPR Art. 17) is **two-phase, anonymize-in-place*
 - Deletion is refused while any of the user's conversations is `accepted` / `active` /
   `return_requested` (open loan).
 
-**Phase 2 — purge** (not yet implemented): a scheduled job uses `deletedAt` to finally remove
-`deleted_accounts` rows and the anonymized `users` rows after the retention window; the same
-routine will drive auto-deletion of long-inactive accounts.
+**Phase 2 — purge** (partially implemented, issue #461): purging `deleted_accounts` rows and the
+anonymized `users` rows after their dispute-resolution window is still open. **Automated retention
+is implemented** as four nightly cron jobs in the backend (`pb_hooks/retention.pb.js` +
+`pb_hooks/jobs/retention.js`), enforcing the privacy policy (DSE v2.8):
+
+- **Inactive accounts** (6 months without login, keyed on `users.lastLoginAt`, stamped on auth and
+  throttled to once per 24h; empty `lastLoginAt` falls back to `created`): anonymized through the
+  same `anonymizeAccount` path as self-service deletion. Accounts with an open loan are skipped and
+  the user plus a platform admin (`ADMIN_NOTIFY_EMAIL`) are notified by email (deduped via a cooldown
+  recorded in `users.retentionNotifiedAt`, so the nightly job doesn't re-mail every night).
+- **Conversations** (6 months after last activity = `conversations.updated`): the conversation, its
+  `messages`, and notifications whose `relatedId` points at it are deleted — regardless of
+  `lendingStatus` (product decision in #461).
+- **Notifications** older than 90 days and **feedback** older than 6 months are deleted.
+
+Windows are configurable per deployment via `RETENTION_*` env vars (0 disables a job); jobs are
+idempotent and log counts only, never personal data.
 
 Login for a `deleted` account is blocked by an `onRecordAuthRequest` hook and, defensively, in
 `hooks.server.ts`. In the app, **never render `user.username` directly** — use `displayName()`

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -174,6 +174,9 @@ Institutions (public libraries, lending shops, tool libraries) are regular `User
 - Personal-only data (contacts, geolocation, push subscriptions, owned `Item`s, own notifications) is hard-deleted; the user is removed from every other user's `trusts[]`
 - The original email + username are retained in a restricted `deleted_accounts` record for the dispute-resolution window, then purged by a future scheduled job (see [data-model.md](data-model.md))
 
+**Automated data retention (issue #461)**
+- Nightly backend cron jobs enforce the privacy policy's retention limits: accounts inactive for 6 months are anonymized through the same deletion path (skipped with user + admin email notice while a loan is open), conversations incl. messages are deleted 6 months after last activity, in-app notifications after 90 days, feedback after 6 months (see [data-model.md](data-model.md))
+
 # Platform Legal Consent (ToS & Privacy)
 
 Distinct from the per-institution `LendingTerms` above, the **platform operator's** Terms of Service and privacy statement are versioned centrally (Issue #399):

--- a/src/lib/types/models.ts
+++ b/src/lib/types/models.ts
@@ -129,6 +129,14 @@ export interface User extends PocketBaseEntity {
 	deletedAt?: string;
 
 	/**
+	 * ISO datetime of the last authentication, stamped (throttled to 24h) by the
+	 * backend auth hook. Drives the inactive-account retention job (#461).
+	 * `hidden: true` on the collection — only readable via the superuser context, so
+	 * it never reaches a client (kept here to document the schema).
+	 */
+	lastLoginAt?: string;
+
+	/**
 	 * Cache of the latest platform ToS version this user has accepted (Issue #399).
 	 * Authoritative record lives in `user_legal_acceptances`; this mirror lets the
 	 * consent gate decide from the already-loaded auth record without a DB query.


### PR DESCRIPTION
## What

Companion to the backend GDPR data-retention jobs
(share-open-sharing-infrastructure/allerleih-backend#22) for #461. Docs + types only,
no runtime code change.

- `src/lib/types/models.ts` — add `User.lastLoginAt` (a `hidden` field on the collection:
  superuser-only, never reaches a client; kept in the type to document the schema).
- `docs/data-model.md` — add `lastLoginAt` + `retentionNotifiedAt` to the USER ERD and
  replace the "Phase 2 purge — not yet implemented" note with the implemented four-job
  retention behaviour and its env-configurable windows.
- `docs/domain-model.md` — note automated retention / inactive-account auto-deletion.

## Notes

The actual retention logic (four nightly PocketBase cron jobs) lives in the backend repo;
this PR only keeps the frontend types and the published docs in sync, per the repo's
keep-in-sync rule. Should merge together with the backend PR.

Preflight: `npm run lint`, `npm run check` (0 errors), `npm run build` all pass.
