### PR TITLE
fix(navigation): clear loading overlay when a navigation is cancelled (#482)

### DIFF
--- a/src/lib/stores/navigationLoader.svelte.test.ts
+++ b/src/lib/stores/navigationLoader.svelte.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { NavigationLoader, type TrackableNavigation } from './navigationLoader.svelte';
+
+/**
+ * A navigation whose `complete` promise we can resolve or reject on demand, mirroring
+ * SvelteKit settling a navigation on success vs. failure/cancel.
+ */
+function deferredNavigation(willUnload = false): {
+	nav: TrackableNavigation;
+	finish: () => void;
+	cancel: () => void;
+} {
+	let finish!: () => void;
+	let cancel!: () => void;
+	const complete = new Promise<void>((resolve, reject) => {
+		finish = () => resolve();
+		// Swallow at the source too: the controller attaches a rejection handler, but a
+		// test that never awaits shouldn't emit an unhandled rejection.
+		cancel = () => reject(new Error('aborted'));
+	});
+	complete.catch(() => {});
+	return { nav: { willUnload, complete }, finish, cancel };
+}
+
+describe('NavigationLoader', () => {
+	it('activates when a client-side navigation starts', () => {
+		const loader = new NavigationLoader();
+		loader.track(deferredNavigation().nav);
+		expect(loader.active).toBe(true);
+	});
+
+	it('clears once the navigation completes successfully', async () => {
+		const loader = new NavigationLoader();
+		const { nav, finish } = deferredNavigation();
+		loader.track(nav);
+		finish();
+		await nav.complete;
+		expect(loader.active).toBe(false);
+	});
+
+	// The #482 / #346 regression: a cancelled/aborted navigation rejects `complete`,
+	// and the overlay must clear — afterNavigate never fires on this path.
+	it('clears when the navigation is cancelled (complete rejects)', async () => {
+		const loader = new NavigationLoader();
+		const { nav, cancel } = deferredNavigation();
+		loader.track(nav);
+		expect(loader.active).toBe(true);
+		cancel();
+		await nav.complete.catch(() => {});
+		expect(loader.active).toBe(false);
+	});
+
+	it('ignores full-page unloads (never activates for them)', () => {
+		const loader = new NavigationLoader();
+		loader.track(deferredNavigation(true).nav);
+		expect(loader.active).toBe(false);
+	});
+
+	// A superseded navigation settling later must not hide the overlay while a newer
+	// navigation is still running.
+	it('a superseded navigation does not clear the overlay for a newer one', async () => {
+		const loader = new NavigationLoader();
+		const first = deferredNavigation();
+		const second = deferredNavigation();
+
+		loader.track(first.nav);
+		loader.track(second.nav);
+		expect(loader.active).toBe(true);
+
+		// The first (now superseded) navigation is aborted; the overlay must stay up.
+		first.cancel();
+		await first.nav.complete.catch(() => {});
+		expect(loader.active).toBe(true);
+
+		// Only when the latest navigation settles does the overlay clear.
+		second.finish();
+		await second.nav.complete;
+		expect(loader.active).toBe(false);
+	});
+});

--- a/src/lib/stores/navigationLoader.svelte.ts
+++ b/src/lib/stores/navigationLoader.svelte.ts
@@ -1,0 +1,31 @@
+// Global navigation loading-overlay state (driven by the root layout). Keyed off
+// each navigation's `complete` promise, which — unlike afterNavigate — also settles
+// when a navigation is cancelled or aborted (#482 / #346).
+
+/** The slice of SvelteKit's `BeforeNavigate` this depends on; kept local so the store is unit-testable. */
+export interface TrackableNavigation {
+	willUnload: boolean;
+	complete: Promise<void>;
+}
+
+export class NavigationLoader {
+	active = $state(false);
+	#token = 0;
+
+	/** Wire to `beforeNavigate`: shows the overlay and clears it when the navigation settles. */
+	track(navigation: TrackableNavigation): void {
+		// willUnload navs' `complete` never resolves and the browser shows its own
+		// spinner, so tracking them would strand the overlay if the user stays.
+		if (navigation.willUnload) return;
+		const token = ++this.#token;
+		this.active = true;
+		// Latest-nav guard: a superseded navigation must not clear a newer one's overlay.
+		const clear = () => {
+			if (token === this.#token) this.active = false;
+		};
+		// Same handler on resolve and reject — success and cancel/abort both end the nav.
+		navigation.complete.then(clear, clear);
+	}
+}
+
+export const navigationLoader = new NavigationLoader();

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,6 +9,7 @@
 	import { getClientPB, syncClientPBAuth, subscribeRealtime } from '$lib/client-pb';
 	import { NOTIFICATIONS_DEP } from '$lib/constants';
 	import { setupPushSubscription, nextPushRegistration } from '$lib/utils/pushSubscription';
+	import { navigationLoader } from '$lib/stores/navigationLoader.svelte';
 	import { onMount } from 'svelte';
 	import { page } from '$app/state';
 	import { beforeNavigate, afterNavigate, invalidate } from '$app/navigation';
@@ -22,10 +23,10 @@
 
 	let { children, data } = $props();
 
-	let isNavigating = $state(false);
-	beforeNavigate(() => { isNavigating = true; });
+	// Loading overlay: cleared when the navigation settles (incl. cancel/abort), which
+	// afterNavigate misses. See $lib/stores/navigationLoader (#482 / #346).
+	beforeNavigate((navigation) => navigationLoader.track(navigation));
 	afterNavigate(() => {
-		isNavigating = false;
 		// Resync the badge after every navigation (issue #376): a destination load can
 		// mark notifications read server-side, and realtime may miss it. afterNavigate
 		// runs after that destination load has committed, so the re-fetch reflects it.
@@ -172,7 +173,7 @@
 		{/if}
 	</main>
 
-	{#if isNavigating}
+	{#if navigationLoader.active}
 		<div
 			in:fade={{ delay: 200, duration: 150 }}
 			out:fade={{ duration: 80 }}


### PR DESCRIPTION
## What & why

On the redesigned **Einstellungen** page (`/user/profile`, #465), editing a field and then trying to leave shows an unsaved-changes confirm (a `beforeNavigate` guard). Clicking **"Abbrechen"** correctly kept the user on the page, but the global `AllerLoader` overlay was triggered and never disappeared (#482).

Root cause is in the root layout: the overlay was driven by `beforeNavigate → isNavigating = true` and `afterNavigate → isNavigating = false`. `afterNavigate` never runs when a navigation is cancelled (`navigation.cancel()`) or aborted, so the overlay spun forever. The same stuck-overlay affected aborted back/forward navigations (#346).

## Fix

- Key the overlay off each navigation's `complete` promise, which settles on success **and** on cancel/abort (verified against SvelteKit's client runtime).
- Skip `willUnload` navigations — their `complete` never resolves and the browser shows its own spinner, so tracking them would strand the overlay if the user cancels the native beforeunload prompt.
- A monotonic token stops a superseded navigation from clearing the overlay while a newer one is still in flight.
- Extracted into a small, testable `NavigationLoader` store (mirrors the `toast.svelte.ts` pattern). `afterNavigate` keeps only the #376 badge `invalidate`.

## Test notes

- **Preflight:** `npm run lint` ✓ · `npm run check` → 0 errors ✓ · `npx vitest run` → 271 passing ✓ · `npm run build` ✓.
- **New unit tests** (`src/lib/stores/navigationLoader.svelte.test.ts`): activate on start, clear on success, **clear on cancel** (the #482/#346 regression), skip `willUnload`, and the supersession guard.
- **Manual verification for the reviewer:** log in → open `/user/profile` → change a field → try to leave (nav link) → click **"Abbrechen"** in the confirm → expected: no loader, stays on page. Also check browser back/forward leaves no stuck overlay.

Closes #482
Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)