### PR TITLE
Add local Playwright e2e suite, drive-app skill, and lint/typecheck CI

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -36,6 +36,15 @@ npm run test       # Vitest in WATCH mode
 npx vitest run                       # run all tests once (CI-style)
 npx vitest run src/path/to/file.test.ts  # run a single test file
 
+# Bring up the whole local stack (real-schema PocketBase + dev server + optional seed) in one
+# command, with all env gotchas baked in. Backend lives in a sibling ../allerleih-backend.
+scripts/dev-stack.sh --seed e2e
+
+# Playwright end-to-end tests (browser-level; require a running PocketBase + superuser creds).
+# Playwright starts the dev server itself; global-setup seeds the deterministic `e2e` scenario.
+# See e2e/README.md for env + conventions.
+PB_URL=http://127.0.0.1:8091 PB_SUPERUSER_EMAIL=you@example.com PB_SUPERUSER_PASSWORD=secret npm run test:e2e
+
 # Seed a running PocketBase with deterministic test data. Scenarios live in
 # scripts/seed/scenarios/ (one file per feature); shared helpers in scripts/seed/lib.js.
 # Idempotent; only touches its own `@seed.test` records. Requires superuser creds.

--- a/.claude/skills/drive-app/SKILL.md
+++ b/.claude/skills/drive-app/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: drive-app
+description: Bring up the local AllerLeih stack and drive the running app in a browser via the Playwright MCP — to click through a flow, verify a change end-to-end, take screenshots, or reproduce a bug in the real UI (not just tests). Use whenever the user wants to "open the app", "click through", "see it in the browser", "verify it works", or manually exercise a page. Handles this machine's stack-startup and Playwright-MCP gotchas so it works on the first try.
+---
+
+# drive-app
+
+Drive the real AllerLeih app in a browser for interactive verification. This captures the
+setup this machine needs so you don't rediscover it every session. For automated regression
+tests instead, use the Playwright suite (`npm run test:e2e`, see `e2e/README.md`).
+
+## 1. Bring up the stack
+
+One command starts PocketBase (real schema) + the dev server + seed, with every env gotcha
+baked in (trailing-slash `PUBLIC_PB_URL`, `DEV_DISABLE_MKCERT`, 127.0.0.1, absolute paths):
+
+```
+scripts/dev-stack.sh --seed e2e
+```
+
+**Reap gotcha:** a long-lived `pocketbase serve` started as a Claude **background task** gets
+killed after ~1–2 min (the vite dev server survives). So either:
+- ask the user to run `! scripts/dev-stack.sh --seed e2e` in their own terminal (survives), or
+- start it yourself and drive the app **promptly**, restarting PB if it dies.
+
+Ports: PB `127.0.0.1:8091`, web `127.0.0.1:5173`. Superuser `admin@local.test` /
+`localdev12345`. Health-check both before driving: `curl -sf http://127.0.0.1:8091/api/health`
+and `curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:5173/`.
+
+## 2. Playwright MCP browser gotcha
+
+The MCP browser defaults to the `chrome` channel (system Google Chrome). If `browser_navigate`
+errors with "Chromium distribution 'chrome' is not found" and you can't install Chrome, point
+the expected path at Playwright's own bundled chromium — no MCP restart needed. On Linux (e.g.
+CachyOS, where `npx playwright install chrome` is unsupported):
+
+```
+# use the actual chromium-<n> build present in ~/.cache/ms-playwright/
+sudo ln -sf ~/.cache/ms-playwright/chromium-<n>/chrome-linux64/chrome /opt/google/chrome/chrome
+```
+
+Colleagues who already have Google Chrome installed won't hit this. Repoint the symlink if
+Playwright later bumps the `chromium-<n>` build number.
+
+## 3. Log in as a seeded user
+
+The `e2e` seed scenario creates `e2e_owner_seed@seed.test` (owns one public item) and
+`e2e_viewer_seed@seed.test`; password for all `@seed.test` users is `password123` (see
+`e2e/fixtures/users.ts`). Other scenarios add their own users — `npm run seed` lists them.
+
+Login flow via the MCP browser:
+1. `browser_navigate` → `http://127.0.0.1:5173/auth/login`
+2. `browser_snapshot` to get field refs.
+3. Fill `getByRole('textbox', { name: 'E-Mail' })` and `{ name: 'Passwort' }`, then click
+   the **Anmelden** button.
+4. **Stale-ref gotcha:** filling a field invalidates the snapshot's element refs, so a
+   ref-based click on the submit button then fails. Click it by selector
+   (`button:has-text("Anmelden")`) or re-snapshot first.
+5. Success = redirect to `/` and the "Login" nav link disappears (nav shows the username).
+
+## Driving tips
+
+- Prefer `browser_snapshot` (accessibility tree) over screenshots for deciding actions;
+  screenshots are for showing the user. Use `depth` / `target` to keep snapshots small.
+- The UI is **German** — match on German role names / text ("Anmelden", "Suche",
+  "Unterhaltungen", "Mein Netzwerk").
+- Protected routes redirect to `/auth/login` when logged out; a landing page with
+  Login/Registrieren renders at `/` for logged-out visitors.
+- `/user` has no index (404 is expected); use `/user/profile`, `/user/items`.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,39 @@
+name: Lint & Typecheck on PR
+env:
+  node_version: '25.2.1'
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  lint:
+    name: Lint & Typecheck
+    runs-on: ubuntu-latest
+    # Skip on fork PRs (mirrors the Vitest workflow); still runs on manual dispatch.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    # `svelte-kit sync` generates the `$env/static/*` type declarations from the environment,
+    # so `npm run check` fails on missing members without these. Dummy values are fine — only
+    # the presence of the members matters for type-checking, not the values.
+    env:
+      PUBLIC_PB_URL: http://127.0.0.1:8090
+      PUBLIC_VAPID_PUBLIC_KEY: dummy
+      VAPID_PRIVATE_KEY: dummy
+      VAPID_SUBJECT: mailto:ci@example.com
+      ORS_API_KEY: dummy
+      MISTRAL_API_KEY: dummy
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.node_version }}
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: ESLint
+        run: npm run lint
+      - name: Type check (svelte-check)
+        run: npm run check

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,10 @@ dist
 .claude/settings.json
 .claude/worktrees
 .claude/CLAUDE.md
+
+# Playwright e2e
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/e2e/.auth/

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -10,7 +10,41 @@ For running tests, we rely on [vitest](https://vitest.dev/) because it is integr
 
 For now, we aim to build test coverage up as we go to achieve a reasonable balance of flexibility and robustness that provides enough security to prevent bigger problems whilst still allowing us to implement improvements to our code at pace.
 
-Currently, this means that we gradually implement unit tests for server-side functions. Integration and UI tests will follow as soon as reasonable.
+Currently, this means that we gradually implement unit tests for server-side functions. Browser-level end-to-end tests (Playwright) now cover a first set of full flows — see [End-to-end tests](#end-to-end-tests-playwright) below.
+
+## End-to-end tests (Playwright)
+
+The unit tests above mock PocketBase; the end-to-end suite (in [`/e2e`](/e2e)) instead drives
+the real app in a browser against a running PocketBase, covering page rendering, login, and
+access to protected routes.
+
+- **Config:** [`playwright.config.ts`](/playwright.config.ts). Playwright starts the SvelteKit
+  dev server itself (`webServer`) and points it at `PB_URL`; an already-running dev server is
+  reused.
+- **Data:** [`e2e/global-setup.ts`](/e2e/global-setup.ts) health-checks PocketBase and seeds the
+  deterministic `e2e` scenario ([`scripts/seed/scenarios/e2e.js`](/scripts/seed/scenarios/e2e.js)),
+  which the seed runner resets on every run. Credentials live in
+  [`e2e/fixtures/users.ts`](/e2e/fixtures/users.ts).
+- **Auth:** [`e2e/auth.setup.ts`](/e2e/auth.setup.ts) logs in once and saves the storage state;
+  the `authenticated` project reuses it.
+
+Requires a PocketBase with the real backend schema plus superuser credentials for seeding:
+
+```bash
+PB_URL=http://127.0.0.1:8091 \
+PB_SUPERUSER_EMAIL=you@example.com \
+PB_SUPERUSER_PASSWORD=secret \
+npm run test:e2e
+```
+
+Locally, [`scripts/dev-stack.sh`](/scripts/dev-stack.sh) brings up the backend (and optionally
+seeds) in one command. Conventions (role/label locators, web-first assertions, no
+`waitForTimeout`) and the full env reference are documented in [`e2e/README.md`](/e2e/README.md).
+
+The e2e suite runs **locally only** — it is deliberately not wired into CI, because running it
+there would couple every frontend PR to the backend repo's current state. Lint and type-checking,
+however, **do** run on every PR via [`.github/workflows/lint.yaml`](/.github/workflows/lint.yaml)
+(`npm run lint` + `npm run check`), alongside the existing Vitest + build workflow.
 
 ## Practice
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,67 @@
+# End-to-end tests (Playwright)
+
+Browser-level tests that drive the real app against a running PocketBase. They complement
+the Vitest unit tests (which mock PocketBase) by exercising full flows — page rendering,
+login, and access to protected routes.
+
+## Prerequisites
+
+1. **A running PocketBase with the real backend schema.** These tests expect the
+   `allerleih-backend` schema (collections + API rules), not the open throwaway instance.
+2. **Superuser credentials** for that PocketBase — `global-setup.ts` uses them to seed the
+   deterministic `e2e` scenario before the suite runs.
+
+The SvelteKit dev server is started automatically by Playwright (`webServer` in
+`playwright.config.ts`) and pointed at `PB_URL`. If a dev server is already running on the
+target port it is reused.
+
+The quickest way to satisfy the PocketBase prerequisite locally is the stack bootstrapper,
+which starts the real-schema backend (and can seed) in one command:
+
+```bash
+scripts/dev-stack.sh --no-web   # PB only, so `npm run test:e2e` starts its own dev server
+```
+
+The suite runs locally only for now; wiring it into CI is a possible future step.
+
+## Running
+
+```bash
+PB_URL=http://127.0.0.1:8091 \
+PB_SUPERUSER_EMAIL=you@example.com \
+PB_SUPERUSER_PASSWORD=secret \
+npm run test:e2e
+
+npm run test:e2e:ui       # interactive UI mode
+npm run test:e2e:report   # open the last HTML report
+```
+
+### Environment variables
+
+| Var                     | Default                 | Purpose                                                                |
+| ----------------------- | ----------------------- | ---------------------------------------------------------------------- |
+| `PB_URL`                | `http://127.0.0.1:8091` | PocketBase base URL (also passed to the dev server as `PUBLIC_PB_URL`) |
+| `PB_SUPERUSER_EMAIL`    | — (required)            | superuser used for seeding                                             |
+| `PB_SUPERUSER_PASSWORD` | — (required)            | superuser password                                                     |
+| `E2E_BASE_URL`          | `http://127.0.0.1:5173` | app base URL                                                           |
+
+## What it does
+
+- **`global-setup.ts`** — health-checks PocketBase, then runs `node scripts/seed.js e2e`.
+  The seed runner tears down previous `@seed.test` data first, so every run starts clean.
+- **`auth.setup.ts`** — logs in as the seeded owner through the real form and saves the
+  authenticated storage state to `e2e/.auth/owner.json` (git-ignored).
+- **`tests/*.spec.ts`** — three projects: `public` (logged-out), `authenticated` (reuses the
+  saved state), and `setup` (produces it).
+
+## Fixtures
+
+The `e2e` seed scenario (`scripts/seed/scenarios/e2e.js`) creates `e2e_owner_seed` (owns one
+public item) and `e2e_viewer_seed`; password for both is `password123`. Credentials are
+mirrored in `e2e/fixtures/users.ts` — keep the two in sync.
+
+## Conventions
+
+- Locate by role/label/text (`getByRole`, `getByText`), not CSS selectors.
+- Web-first assertions (`await expect(locator)…`) that auto-retry; never `waitForTimeout`.
+- One behavior per test. Traces are captured `on-first-retry`.

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,0 +1,18 @@
+import { test as setup, expect } from '@playwright/test';
+import { OWNER, STORAGE_STATE } from './fixtures/users';
+
+/**
+ * Logs in as the seeded owner through the real login form and saves the authenticated
+ * storage state, which the `authenticated` project reuses so each test starts logged in.
+ */
+setup('authenticate as owner', async ({ page }) => {
+	await page.goto('/auth/login');
+	await page.getByRole('textbox', { name: 'E-Mail' }).fill(OWNER.email);
+	await page.getByRole('textbox', { name: 'Passwort' }).fill(OWNER.password);
+	await page.getByRole('button', { name: 'Anmelden' }).click();
+
+	// A successful login redirects to the home page; the "Login" nav link then disappears.
+	await expect(page.getByRole('link', { name: 'Login' })).toHaveCount(0);
+
+	await page.context().storageState({ path: STORAGE_STATE });
+});

--- a/e2e/fixtures/users.ts
+++ b/e2e/fixtures/users.ts
@@ -1,0 +1,20 @@
+/**
+ * Credentials for the users created by the `e2e` seed scenario
+ * (scripts/seed/scenarios/e2e.js). Keep these in sync with that file.
+ */
+export const SEED_PASSWORD = 'password123';
+
+export const OWNER = {
+	username: 'e2e_owner_seed',
+	email: 'e2e_owner_seed@seed.test',
+	password: SEED_PASSWORD,
+};
+
+export const VIEWER = {
+	username: 'e2e_viewer_seed',
+	email: 'e2e_viewer_seed@seed.test',
+	password: SEED_PASSWORD,
+};
+
+/** Where the authenticated storageState produced by auth.setup.ts is written. */
+export const STORAGE_STATE = 'e2e/.auth/owner.json';

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,59 @@
+import { spawn } from 'node:child_process';
+
+/**
+ * Runs once before the whole suite: verify PocketBase is reachable, then seed the
+ * deterministic `e2e` scenario (scripts/seed/scenarios/e2e.js). The seed runner tears
+ * down previous `@seed.test` data first, so every run starts from a known state.
+ */
+export default async function globalSetup() {
+	const pbUrl = (process.env.PB_URL ?? 'http://127.0.0.1:8091').replace(
+		/\/$/,
+		''
+	);
+	const email = process.env.PB_SUPERUSER_EMAIL;
+	const password = process.env.PB_SUPERUSER_PASSWORD;
+
+	await assertPocketBaseUp(pbUrl);
+
+	if (!email || !password) {
+		throw new Error(
+			'e2e seeding needs superuser credentials. Set PB_SUPERUSER_EMAIL and PB_SUPERUSER_PASSWORD ' +
+				'(and optionally PB_URL, default http://127.0.0.1:8091) before running the e2e suite.'
+		);
+	}
+
+	await runSeed({
+		PB_URL: pbUrl,
+		PB_SUPERUSER_EMAIL: email,
+		PB_SUPERUSER_PASSWORD: password,
+	});
+}
+
+async function assertPocketBaseUp(pbUrl: string) {
+	try {
+		const res = await fetch(`${pbUrl}/api/health`, {
+			signal: AbortSignal.timeout(5000),
+		});
+		if (!res.ok) throw new Error(`health check returned ${res.status}`);
+	} catch (err) {
+		throw new Error(
+			`PocketBase is not reachable at ${pbUrl} (${err instanceof Error ? err.message : err}). ` +
+				'Start the backend before running the e2e suite. See e2e/README.md.'
+		);
+	}
+}
+
+function runSeed(env: Record<string, string>) {
+	return new Promise<void>((resolve, reject) => {
+		const child = spawn('node', ['scripts/seed.js', 'e2e'], {
+			stdio: 'inherit',
+			env: { ...process.env, ...env },
+		});
+		child.on('error', reject);
+		child.on('exit', (code) =>
+			code === 0
+				? resolve()
+				: reject(new Error(`Seeding "e2e" failed with exit code ${code}.`))
+		);
+	});
+}

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+import { OWNER } from '../fixtures/users';
+
+/** The login form itself — starts logged out (no stored auth state in this project). */
+test.describe('login', () => {
+	test('valid credentials log the user in', async ({ page }) => {
+		await page.goto('/auth/login');
+		await page.getByRole('textbox', { name: 'E-Mail' }).fill(OWNER.email);
+		await page.getByRole('textbox', { name: 'Passwort' }).fill(OWNER.password);
+		await page.getByRole('button', { name: 'Anmelden' }).click();
+
+		// Redirected away from the login form; the "Login" nav link is gone once authenticated.
+		await expect(page).not.toHaveURL(/\/auth\/login/);
+		await expect(page.getByRole('link', { name: 'Login' })).toHaveCount(0);
+	});
+
+	test('invalid credentials keep the user on the login page', async ({
+		page,
+	}) => {
+		await page.goto('/auth/login');
+		await page.getByRole('textbox', { name: 'E-Mail' }).fill(OWNER.email);
+		await page
+			.getByRole('textbox', { name: 'Passwort' })
+			.fill('definitely-wrong-password');
+		await page.getByRole('button', { name: 'Anmelden' }).click();
+
+		await expect(page).toHaveURL(/\/auth\/login/);
+		await expect(page.getByRole('link', { name: 'Login' })).toBeVisible();
+	});
+});

--- a/e2e/tests/authenticated.spec.ts
+++ b/e2e/tests/authenticated.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+import { OWNER } from '../fixtures/users';
+
+/** These run with the storage state saved by auth.setup.ts — already logged in. */
+test.describe('authenticated', () => {
+	test('home shows the authenticated navigation', async ({ page }) => {
+		await page.goto('/');
+
+		await expect(page.getByRole('link', { name: 'Login' })).toHaveCount(0);
+		await expect(page.getByText(OWNER.username).first()).toBeVisible();
+	});
+
+	test('the profile page is reachable without a redirect to login', async ({
+		page,
+	}) => {
+		await page.goto('/user/profile');
+
+		await expect(page).toHaveURL(/\/user\/profile/);
+		await expect(page).not.toHaveURL(/\/auth\/login/);
+	});
+
+	test('the own-items page is reachable without a redirect to login', async ({
+		page,
+	}) => {
+		await page.goto('/user/items');
+
+		await expect(page).toHaveURL(/\/user\/items/);
+		await expect(page).not.toHaveURL(/\/auth\/login/);
+	});
+});

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+/** Public pages render for logged-out visitors. */
+test.describe('smoke (logged out)', () => {
+	test('home page renders with the login/register entry points', async ({
+		page,
+	}) => {
+		await page.goto('/');
+
+		await expect(page).toHaveTitle(/AllerLeih/);
+		await expect(
+			page.getByText('Leihe und teile kostenlos Dinge in Lüneburg')
+		).toBeVisible();
+		await expect(page.getByRole('link', { name: 'Login' })).toBeVisible();
+		await expect(
+			page.getByRole('link', { name: 'Registrieren' }).first()
+		).toBeVisible();
+		await expect(page.getByRole('link', { name: 'Suche' })).toBeVisible();
+	});
+
+	test('login page renders the sign-in form', async ({ page }) => {
+		await page.goto('/auth/login');
+
+		await expect(page).toHaveTitle(/Anmelden/);
+		await expect(
+			page.getByRole('heading', { name: 'Willkommen zurück!' })
+		).toBeVisible();
+		await expect(page.getByRole('textbox', { name: 'E-Mail' })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Anmelden' })).toBeVisible();
+	});
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
 				"@eslint/compat": "^2.0.1",
 				"@eslint/js": "^9.39.2",
 				"@flowbite-svelte-plugins/datatable": "^0.4.1",
+				"@playwright/test": "^1.61.1",
 				"@sveltejs/adapter-auto": "^6.1.1",
 				"@sveltejs/adapter-node": "^5.4.0",
 				"@sveltejs/adapter-static": "^3.0.10",
@@ -505,6 +506,22 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/@playwright/test": {
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+			"integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright": "1.61.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@polka/url": {
@@ -4022,6 +4039,53 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+			"integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.61.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+			"integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/pocketbase": {

--- a/package.json
+++ b/package.json
@@ -15,12 +15,16 @@
 		"lint:fix": "eslint . --ext .ts,.svelte,.js --fix",
 		"format": "prettier --write .",
 		"test": "vitest",
+		"test:e2e": "playwright test",
+		"test:e2e:ui": "playwright test --ui",
+		"test:e2e:report": "playwright show-report",
 		"seed": "node scripts/seed.js"
 	},
 	"devDependencies": {
 		"@eslint/compat": "^2.0.1",
 		"@eslint/js": "^9.39.2",
 		"@flowbite-svelte-plugins/datatable": "^0.4.1",
+		"@playwright/test": "^1.61.1",
 		"@sveltejs/adapter-auto": "^6.1.1",
 		"@sveltejs/adapter-node": "^5.4.0",
 		"@sveltejs/adapter-static": "^3.0.10",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,63 @@
+import { defineConfig } from '@playwright/test';
+import { STORAGE_STATE } from './e2e/fixtures/users';
+
+/**
+ * End-to-end tests (see e2e/README.md).
+ *
+ * Requires a running PocketBase (real backend schema). Configure via env:
+ *   PB_URL                 PocketBase base URL       (default http://127.0.0.1:8091)
+ *   PB_SUPERUSER_EMAIL     superuser for seeding     (required — global-setup seeds the `e2e` scenario)
+ *   PB_SUPERUSER_PASSWORD  superuser password        (required)
+ *   E2E_BASE_URL           app base URL              (default http://127.0.0.1:5173)
+ *
+ * The dev server is started automatically (webServer) and pointed at PB_URL.
+ */
+const HOST = '127.0.0.1';
+const PORT = 5173;
+const baseURL = process.env.E2E_BASE_URL ?? `http://${HOST}:${PORT}`;
+
+const rawPbUrl = process.env.PB_URL ?? 'http://127.0.0.1:8091';
+// itemImageUrl builds `${PUBLIC_PB_URL}api/files/…`, so the trailing slash matters.
+const pbUrl = rawPbUrl.endsWith('/') ? rawPbUrl : `${rawPbUrl}/`;
+
+export default defineConfig({
+	testDir: './e2e',
+	globalSetup: './e2e/global-setup.ts',
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: [['list'], ['html', { open: 'never' }]],
+
+	use: {
+		baseURL,
+		trace: 'on-first-retry',
+		screenshot: 'only-on-failure',
+	},
+
+	projects: [
+		{ name: 'setup', testMatch: 'auth.setup.ts' },
+		{
+			name: 'public',
+			use: { browserName: 'chromium' },
+			testMatch: ['tests/smoke.spec.ts', 'tests/auth.spec.ts'],
+		},
+		{
+			name: 'authenticated',
+			use: { browserName: 'chromium', storageState: STORAGE_STATE },
+			dependencies: ['setup'],
+			testMatch: ['tests/authenticated.spec.ts'],
+		},
+	],
+
+	webServer: {
+		command: `npm run dev -- --host ${HOST} --port ${PORT}`,
+		url: baseURL,
+		reuseExistingServer: !process.env.CI,
+		timeout: 120_000,
+		env: {
+			PUBLIC_PB_URL: pbUrl,
+			DEV_DISABLE_MKCERT: 'true',
+		},
+	},
+});

--- a/scripts/dev-stack.sh
+++ b/scripts/dev-stack.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Bring up the full local AllerLeih stack with one command: the real-schema PocketBase
+# backend, the SvelteKit dev server, and (optionally) seed data — with all the env
+# gotchas baked in (trailing-slash PUBLIC_PB_URL, DEV_DISABLE_MKCERT, 127.0.0.1 binding).
+#
+# The PocketBase backend lives in a SEPARATE repo (share-open-sharing-infrastructure/
+# allerleih-backend). Point this script at your checkout via PB_BACKEND_DIR (default: a
+# sibling `../allerleih-backend` with the `pocketbase` binary copied in).
+#
+# Usage:
+#   scripts/dev-stack.sh                 # start PB + dev server
+#   scripts/dev-stack.sh --seed e2e      # also seed the `e2e` scenario first
+#   scripts/dev-stack.sh --no-web        # only PB (e.g. to run `npm run test:e2e` yourself)
+#
+# Env overrides: PB_BACKEND_DIR, PB_BIN, PB_PORT (8091), WEB_PORT (5173),
+#                PB_SUPERUSER_EMAIL (admin@local.test), PB_SUPERUSER_PASSWORD (localdev12345)
+#
+# PB runs in the background; the dev server runs in the foreground. Ctrl-C stops both.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PB_BACKEND_DIR="${PB_BACKEND_DIR:-$(cd "$REPO_ROOT/.." && pwd)/allerleih-backend}"
+PB_BIN="${PB_BIN:-$PB_BACKEND_DIR/pocketbase}"
+PB_PORT="${PB_PORT:-8091}"
+WEB_PORT="${WEB_PORT:-5173}"
+PB_SUPERUSER_EMAIL="${PB_SUPERUSER_EMAIL:-admin@local.test}"
+PB_SUPERUSER_PASSWORD="${PB_SUPERUSER_PASSWORD:-localdev12345}"
+
+SEED_SCENARIO=""
+START_WEB=1
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--seed) SEED_SCENARIO="${2:?--seed needs a scenario name}"; shift 2 ;;
+		--no-web) START_WEB=0; shift ;;
+		-h|--help) grep '^#' "$0" | grep -v '^#!' | sed 's/^# \{0,1\}//'; exit 0 ;;
+		*) echo "Unknown argument: $1" >&2; exit 2 ;;
+	esac
+done
+
+if [[ ! -x "$PB_BIN" ]]; then
+	echo "PocketBase binary not found/executable at: $PB_BIN" >&2
+	echo "Clone share-open-sharing-infrastructure/allerleih-backend and copy the pocketbase" >&2
+	echo "binary in, or set PB_BACKEND_DIR / PB_BIN. See docs/testing-strategy.md." >&2
+	exit 1
+fi
+
+PB_URL="http://127.0.0.1:${PB_PORT}"
+PB_PID=""
+cleanup() { [[ -n "$PB_PID" ]] && kill "$PB_PID" 2>/dev/null || true; }
+trap cleanup EXIT INT TERM
+
+echo "▶ Starting PocketBase (real schema) on $PB_URL …"
+# Absolute paths only — PocketBase does NOT expand ~; a fresh pb_data auto-applies migrations.
+"$PB_BIN" serve \
+	--http="127.0.0.1:${PB_PORT}" \
+	--dir="$PB_BACKEND_DIR/pb_data" \
+	--migrationsDir="$PB_BACKEND_DIR/pb_migrations" \
+	--hooksDir="$PB_BACKEND_DIR/pb_hooks" \
+	--publicDir="$PB_BACKEND_DIR/pb_public" &
+PB_PID=$!
+
+echo -n "  waiting for PocketBase"
+for _ in $(seq 1 30); do
+	if curl -sf -o /dev/null "$PB_URL/api/health"; then echo " — up"; break; fi
+	if ! kill -0 "$PB_PID" 2>/dev/null; then echo; echo "PocketBase exited early." >&2; exit 1; fi
+	echo -n "."; sleep 1
+done
+curl -sf -o /dev/null "$PB_URL/api/health" || { echo "PocketBase did not become healthy." >&2; exit 1; }
+
+echo "▶ Ensuring superuser $PB_SUPERUSER_EMAIL …"
+"$PB_BIN" superuser upsert "$PB_SUPERUSER_EMAIL" "$PB_SUPERUSER_PASSWORD" --dir="$PB_BACKEND_DIR/pb_data" >/dev/null
+
+if [[ -n "$SEED_SCENARIO" ]]; then
+	echo "▶ Seeding scenario '$SEED_SCENARIO' …"
+	PB_URL="$PB_URL" PB_SUPERUSER_EMAIL="$PB_SUPERUSER_EMAIL" PB_SUPERUSER_PASSWORD="$PB_SUPERUSER_PASSWORD" \
+		npm run --silent seed -- "$SEED_SCENARIO"
+fi
+
+if [[ "$START_WEB" -eq 0 ]]; then
+	echo "▶ PB ready at $PB_URL (superuser: $PB_SUPERUSER_EMAIL). Press Ctrl-C to stop."
+	wait "$PB_PID"
+	exit 0
+fi
+
+echo "▶ Starting SvelteKit dev server on http://127.0.0.1:${WEB_PORT} …"
+# Trailing slash matters (itemImageUrl builds `${PUBLIC_PB_URL}api/files/…`); HTTP (no mkcert)
+# so the page and PB images share a scheme.
+PUBLIC_PB_URL="${PB_URL}/" DEV_DISABLE_MKCERT=true \
+	npm run dev -- --host 127.0.0.1 --port "$WEB_PORT"

--- a/scripts/seed/scenarios/e2e.js
+++ b/scripts/seed/scenarios/e2e.js
@@ -1,0 +1,32 @@
+/**
+ * Scenario: end-to-end test fixtures.
+ *
+ * Deterministic, minimal data owned by the Playwright suite (e2e/) so the tests do
+ * not depend on any feature scenario's internals. The seed runner tears down all
+ * `@seed.test` users before seeding, so running this yields a known clean state.
+ *
+ *  - e2e_owner_seed  — an ordinary owner with one public item, used as the login user.
+ *  - e2e_viewer_seed — a second account for viewer-side flows.
+ *
+ * Login for both: password from lib.js (`password123`), email `<username>@seed.test`.
+ */
+import { createUser, createItem, USER_PASSWORD, SEED_DOMAIN } from '../lib.js';
+
+export const description =
+	'End-to-end test fixtures (Playwright): a login user with one public item.';
+
+export async function run(pb) {
+	const owner = await createUser(pb, 'e2e_owner_seed');
+	await createUser(pb, 'e2e_viewer_seed');
+
+	const bohrmaschine = await createItem(pb, owner.id, 'E2E Bohrmaschine', [
+		'Werkzeug und Garten',
+	]);
+
+	return `  Login (password for all: "${USER_PASSWORD}"):
+    e2e_owner_seed${SEED_DOMAIN}   (owner of the item below)
+    e2e_viewer_seed${SEED_DOMAIN}  (second account)
+
+  Items:
+    E2E Bohrmaschine (public, owner) → /items/${bohrmaschine.id}`;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import tailwindcss from '@tailwindcss/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig, loadEnv, type PluginOption } from 'vite';
+import { loadEnv, type PluginOption } from 'vite';
+import { defineConfig, configDefaults } from 'vitest/config';
 import mkcert from 'vite-plugin-mkcert';
 
 export default defineConfig(({ mode }) => {
@@ -36,6 +37,11 @@ export default defineConfig(({ mode }) => {
 		server: {
 			host: true, // oder explizit: host: '0.0.0.0'
 			...(allowedHosts.length ? { allowedHosts } : {})
+		},
+		test: {
+			// Vitest (unit tests) must not pick up the Playwright e2e specs in e2e/,
+			// which use `@playwright/test` and run via `npm run test:e2e` instead.
+			exclude: [...configDefaults.exclude, 'e2e/**']
 		}
 	};
 });


### PR DESCRIPTION
## What & why

Adds a browser-level end-to-end test layer plus dev tooling, and closes a gap in CI.

The existing Vitest tests mock PocketBase, so there was no coverage of full flows (page
rendering, login, access to protected routes). This adds a Playwright suite that drives the
real app against a real-schema PocketBase, a one-command local stack bootstrapper, and a
lint/typecheck CI gate.

### Testing (e2e) — local only

- `e2e/` Playwright suite: `smoke` (logged-out pages render), `auth` (valid/invalid login),
  `authenticated` (protected routes via saved storage state).
- `e2e/global-setup.ts` health-checks PocketBase and seeds a dedicated `e2e` seed scenario;
  `auth.setup.ts` logs in once and saves the session for the authenticated project.
- Run with `npm run test:e2e` (see [`e2e/README.md`](e2e/README.md)). **Deliberately not wired
  into CI** — running it there would couple every frontend PR to the backend repo's state.
- `vite.config.ts`: exclude `e2e/**` from Vitest so the unit-test run doesn't collect the
  Playwright specs.

### Dev tooling

- `scripts/dev-stack.sh`: bring up the real-schema PocketBase + dev server + optional seed in
  one command, with the local env gotchas (trailing-slash `PUBLIC_PB_URL`, `DEV_DISABLE_MKCERT`)
  baked in.
- `.claude/skills/drive-app/`: shared recipe for driving the running app in a browser via the
  Playwright MCP (interactive verification, not automated tests).

### CI

- `.github/workflows/lint.yaml`: gate PRs on `npm run lint` and `npm run check`. The existing
  CI only ran Vitest + build, so lint/type errors could slip through.

## Test notes

Preflight all green: `npm run lint`, `npm run check` (0 errors), `npx vitest run` (266 passed),
`npm run build`. The Playwright suite passes 8/8 locally against the real backend, and
`scripts/dev-stack.sh` was verified bringing up a fresh backend end-to-end.

To run the e2e suite locally: start a real-schema PocketBase (or `scripts/dev-stack.sh --no-web`),
then `PB_URL=… PB_SUPERUSER_EMAIL=… PB_SUPERUSER_PASSWORD=… npm run test:e2e`.
