### PR TITLE
feat(auth): allow spaces in usernames and clarify email login (#457)

### DIFF
--- a/docs/operations/onboarding-institutional-partner.md
+++ b/docs/operations/onboarding-institutional-partner.md
@@ -4,7 +4,7 @@ Short checklist for bringing a new institution onto AllerLeih.
 
 ## Steps
 
-1. **Create the account** — sign up at `/auth/register` using the institution's official email address. Choose a `username` matching the institution's display name (e.g. `RatsbüchereiLüneburg`).
+1. **Create the account** — sign up at `/auth/register` using the institution's official email address. Choose a `username` matching the institution's display name; spaces are allowed, up to 50 characters (e.g. `Ratsbücherei Lüneburg`). Login is always via the email address, not the username.
 
 2. **Set `isInstitution = true`** — in the PocketBase admin dashboard, open the `users` collection, find the new record, and toggle `isInstitution` to `true`. This cannot be done from the UI.
 

--- a/src/lib/server/registration.test.ts
+++ b/src/lib/server/registration.test.ts
@@ -22,6 +22,7 @@ import {
 } from './registration';
 import type { User } from '$lib/types/models';
 import { texts } from '$lib/texts';
+import { USERNAME_MAX_LENGTH } from '$lib/utils/username';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -150,13 +151,40 @@ describe('validateRegistrationForm', () => {
 		expect(result.fields).toMatchObject({ message: texts.errors.usernameRequired });
 	});
 
-	it('fails when username contains spaces', () => {
+	it('accepts usernames with internal spaces (e.g. institution names)', () => {
 		const result = validateRegistrationForm(
-			makeFormData({ ...validFormFields, username: 'user name' })
+			makeFormData({ ...validFormFields, username: 'Ratsbücherei Lüneburg' })
+		);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.username).toBe('Ratsbücherei Lüneburg');
+	});
+
+	it('collapses repeated internal whitespace', () => {
+		const result = validateRegistrationForm(
+			makeFormData({ ...validFormFields, username: 'AStA   Lüneburg' })
+		);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.username).toBe('AStA Lüneburg');
+	});
+
+	it('fails when username is too short', () => {
+		const result = validateRegistrationForm(
+			makeFormData({ ...validFormFields, username: 'ab' })
 		);
 		expect(result.ok).toBe(false);
 		if (result.ok) return;
-		expect(result.fields).toMatchObject({ message: texts.errors.usernameNoSpaces });
+		expect(result.fields).toMatchObject({ message: texts.errors.usernameTooShort });
+	});
+
+	it('fails when username is too long', () => {
+		const result = validateRegistrationForm(
+			makeFormData({ ...validFormFields, username: 'a'.repeat(USERNAME_MAX_LENGTH + 1) })
+		);
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.fields).toMatchObject({ message: texts.errors.usernameTooLong });
 	});
 
 	it('fails when username contains invalid characters', () => {

--- a/src/lib/server/registration.ts
+++ b/src/lib/server/registration.ts
@@ -3,6 +3,7 @@ import type { ClientResponseError } from 'pocketbase';
 import { texts } from '$lib/texts';
 import type { User } from '$lib/types/models';
 import { createNotification, sendPushToUser } from '$lib/server/notifications';
+import { normalizeUsername, validateUsername } from '$lib/utils/username';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -26,8 +27,6 @@ export type CreateUserResult = { ok: true; user: User } | { ok: false; error: 'e
 // Form validation
 // ---------------------------------------------------------------------------
 
-const USERNAME_REGEX = /^[\w\p{L}][\w\p{L}.-]*$/u;
-
 export function validateRegistrationForm(data: FormData): ValidationResult {
 	const email = data.get('email');
 	const password = data.get('password');
@@ -44,15 +43,17 @@ export function validateRegistrationForm(data: FormData): ValidationResult {
 		return { ok: false, status: 400, fields: { fail: true, message: texts.errors.userConsentRequired } };
 	}
 
-	const username = data.get('username')?.toString().trim();
+	const username = normalizeUsername(data.get('username')?.toString() ?? '');
 	if (!username) {
 		return { ok: false, status: 400, fields: { fail: true, message: texts.errors.usernameRequired } };
 	}
-	if (username.includes(' ')) {
-		return { ok: false, status: 400, fields: { fail: true, message: texts.errors.usernameNoSpaces } };
-	}
-	if (!USERNAME_REGEX.test(username)) {
-		return { ok: false, status: 400, fields: { fail: true, message: texts.errors.usernameInvalidFormat } };
+	switch (validateUsername(username)) {
+		case 'too_short':
+			return { ok: false, status: 400, fields: { fail: true, message: texts.errors.usernameTooShort } };
+		case 'too_long':
+			return { ok: false, status: 400, fields: { fail: true, message: texts.errors.usernameTooLong } };
+		case 'invalid':
+			return { ok: false, status: 400, fields: { fail: true, message: texts.errors.usernameInvalidFormat } };
 	}
 
 	return {

--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -1,3 +1,5 @@
+import { USERNAME_MIN_LENGTH, USERNAME_MAX_LENGTH } from '$lib/utils/username';
+
 export const ITEM_CATEGORIES = [
 	'Freizeit und Sport',
 	'Werkzeug und Garten',
@@ -31,7 +33,9 @@ export const texts = {
 	auth: {
 		emailPlaceholder: 'E-Mail Adresse',
 		passwordPlaceholder: '••••••••••',
-		usernamePlaceholder: 'z.B. NoahLüni',
+		usernamePlaceholder: 'z.B. Noah Lüni',
+		usernameHint: 'Öffentlich sichtbarer Anzeigename – Leerzeichen sind erlaubt. Anmelden kannst du dich mit deiner E-Mail-Adresse.',
+		loginWithEmailHint: 'Anmelden mit deiner E-Mail-Adresse.',
 		loginFailed: 'Login fehlgeschlagen.',
 		resetPassword: 'Setze mein Passwort zurück!',
 		register: 'Registrieren',
@@ -87,8 +91,10 @@ export const texts = {
 		failedToDeleteConversation: 'Failed to delete conversation.',
 		conversationNotFound: 'Unterhaltung wurde nicht gefunden.',
 		loginFailed: 'E-Mail-Adresse oder Passwort falsch.',
-		usernameNoSpaces: 'Nutzername darf keine Leerzeichen enthalten.',
-		usernameInvalidFormat: 'Nutzername darf nur Buchstaben, Zahlen, Punkte, Bindestriche und Unterstriche enthalten.',
+		usernameInvalidFormat:
+			'Nutzername darf nur Buchstaben, Zahlen, Leerzeichen, Punkte, Bindestriche und Unterstriche enthalten und nicht mit einem Leerzeichen beginnen oder enden.',
+		usernameTooShort: `Der Nutzername muss mindestens ${USERNAME_MIN_LENGTH} Zeichen lang sein.`,
+		usernameTooLong: `Der Nutzername darf höchstens ${USERNAME_MAX_LENGTH} Zeichen lang sein.`,
 		emailAlreadyTaken: 'Diese E-Mail-Adresse wird bereits verwendet.',
 		usernameRequired: 'Bitte gib einen Nutzernamen ein.',
 		usernameTaken: 'Dieser Nutzername ist bereits vergeben.',

--- a/src/lib/utils/username.test.ts
+++ b/src/lib/utils/username.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import {
+	normalizeUsername,
+	validateUsername,
+	USERNAME_MIN_LENGTH,
+	USERNAME_MAX_LENGTH,
+} from './username';
+
+describe('normalizeUsername', () => {
+	it('trims leading and trailing whitespace', () => {
+		expect(normalizeUsername('  alice  ')).toBe('alice');
+	});
+
+	it('collapses repeated internal whitespace to a single space', () => {
+		expect(normalizeUsername('AStA   Lüneburg')).toBe('AStA Lüneburg');
+	});
+
+	it('collapses tabs and newlines as whitespace', () => {
+		expect(normalizeUsername('a\t\nb')).toBe('a b');
+	});
+});
+
+describe('validateUsername', () => {
+	it('accepts a simple ascii name', () => {
+		expect(validateUsername('testuser')).toBe('ok');
+	});
+
+	it('accepts unicode letters', () => {
+		expect(validateUsername('MüllerMax')).toBe('ok');
+	});
+
+	it('accepts internal spaces (institution names)', () => {
+		expect(validateUsername('Ratsbücherei Lüneburg')).toBe('ok');
+		expect(validateUsername('janun e.V.')).toBe('ok');
+	});
+
+	it('accepts dots, hyphens and underscores', () => {
+		expect(validateUsername('a.b-c_d')).toBe('ok');
+	});
+
+	it('treats leading/trailing spaces as trimmed, not invalid', () => {
+		expect(validateUsername('  alice  ')).toBe('ok');
+	});
+
+	it('rejects names shorter than the minimum', () => {
+		expect(validateUsername('ab')).toBe('too_short');
+	});
+
+	it('accepts a name exactly at the minimum length', () => {
+		expect(validateUsername('a'.repeat(USERNAME_MIN_LENGTH))).toBe('ok');
+	});
+
+	it('rejects names longer than the maximum', () => {
+		expect(validateUsername('a'.repeat(USERNAME_MAX_LENGTH + 1))).toBe('too_long');
+	});
+
+	it('accepts a name exactly at the maximum length', () => {
+		expect(validateUsername('a'.repeat(USERNAME_MAX_LENGTH))).toBe('ok');
+	});
+
+	it('measures length in code points, not UTF-16 units (matches PocketBase runes)', () => {
+		// U+20000 is a supplementary-plane letter: 1 code point, 2 UTF-16 units.
+		const name = '\u{20000}'.repeat(USERNAME_MAX_LENGTH);
+		expect(name.length).toBe(USERNAME_MAX_LENGTH * 2); // UTF-16 units
+		expect(validateUsername(name)).toBe('ok');
+		expect(validateUsername('\u{20000}'.repeat(USERNAME_MAX_LENGTH + 1))).toBe('too_long');
+	});
+
+	it('rejects disallowed characters', () => {
+		expect(validateUsername('user@name')).toBe('invalid');
+		expect(validateUsername('bad/slash')).toBe('invalid');
+	});
+
+	it('rejects a leading dot or hyphen', () => {
+		expect(validateUsername('.hidden')).toBe('invalid');
+		expect(validateUsername('-dash')).toBe('invalid');
+	});
+});

--- a/src/lib/utils/username.ts
+++ b/src/lib/utils/username.ts
@@ -1,0 +1,30 @@
+// Shared username rules — single source of truth for client feedback (register /
+// profile forms) and server-side validation, so the two can't drift. Kept out of
+// $lib/server so it is importable from Svelte components. The backend enforces the
+// same constraints on the `users.username` field (pattern + min/max).
+
+export const USERNAME_MIN_LENGTH = 3;
+export const USERNAME_MAX_LENGTH = 50;
+
+// Letters/word chars, plus internal spaces, dots and hyphens. No leading or trailing
+// space (the last class excludes space); requires at least two chars, which the
+// min-length check already guarantees.
+export const USERNAME_REGEX = /^[\w\p{L}][\w\p{L} .-]*[\w\p{L}.-]$/u;
+
+export type UsernameValidation = 'ok' | 'too_short' | 'too_long' | 'invalid';
+
+export function normalizeUsername(raw: string): string {
+	return raw.trim().replace(/\s+/g, ' ');
+}
+
+export function validateUsername(raw: string): UsernameValidation {
+	const value = normalizeUsername(raw);
+	// Count Unicode code points, not UTF-16 units, to match PocketBase's `max`
+	// (Go `len([]rune(value))`) — otherwise a name of supplementary-plane letters
+	// would be rejected client-side while the backend accepts it.
+	const length = [...value].length;
+	if (length < USERNAME_MIN_LENGTH) return 'too_short';
+	if (length > USERNAME_MAX_LENGTH) return 'too_long';
+	if (!USERNAME_REGEX.test(value)) return 'invalid';
+	return 'ok';
+}

--- a/src/routes/auth/login/+page.svelte
+++ b/src/routes/auth/login/+page.svelte
@@ -44,6 +44,7 @@
 						autocomplete="email"
 						required
 					/>
+					<p class="text-sm text-tinte-500 dark:text-tinte-400">{texts.auth.loginWithEmailHint}</p>
 				</Label>
 				<PasswordInput autocomplete="current-password" />
 

--- a/src/routes/auth/register/+page.svelte
+++ b/src/routes/auth/register/+page.svelte
@@ -10,6 +10,7 @@
 	import { PUBLIC_PB_URL } from '$env/static/public';
 	import LegalDocModal from '$lib/components/LegalDocModal.svelte';
 	import SeoHead from '$lib/components/SeoHead.svelte';
+	import { USERNAME_MAX_LENGTH, normalizeUsername, validateUsername } from '$lib/utils/username';
 
 	let { data, form } = $props();
 
@@ -22,7 +23,8 @@
 	const pb = new PocketBase(PUBLIC_PB_URL);
 
 	let username = $state('');
-	let usernameStatus: 'idle' | 'checking' | 'available' | 'taken' | 'invalid' = $state('idle');
+	let usernameStatus: 'idle' | 'checking' | 'available' | 'taken' | 'too_short' | 'too_long' | 'invalid' =
+		$state('idle');
 	const checkUsername = debounce(async (value: string) => {
 		try {
 			await pb.collection('users_public').getFirstListItem(pb.filter('username = {:username}', { username: value }));
@@ -33,15 +35,16 @@
 	}, 500);
 
 	$effect(() => {
-		const value = username.trim();
+		const value = normalizeUsername(username);
 		if (value === '') {
 			checkUsername.clear();
 			usernameStatus = 'idle';
 			return;
 		}
-		if (value.includes(' ')) {
+		const validity = validateUsername(value);
+		if (validity !== 'ok') {
 			checkUsername.clear();
-			usernameStatus = 'invalid';
+			usernameStatus = validity;
 			return;
 		}
 		usernameStatus = 'checking';
@@ -80,30 +83,6 @@
 					<input type="hidden" name="inviteCode" value={data.inviteCode} />
 				{/if}
 				<Label class="space-y-2">
-					<span>{texts.forms.username}</span>
-					<Input
-						type="text"
-						name="username"
-						placeholder={texts.auth.usernamePlaceholder}
-						class="focus:border-primary-700 focus:ring-primary-700"
-						bind:value={username}
-						required
-						autocomplete="username"
-						autocorrect="off"
-						autocapitalize="off"
-						spellcheck={false}
-					/>
-					{#if usernameStatus === 'checking'}
-						<p class="text-sm text-tinte-500">...</p>
-					{:else if usernameStatus === 'available'}
-						<p class="text-sm text-green-600 dark:text-green-400">{texts.success.usernameAvailable}</p>
-					{:else if usernameStatus === 'taken'}
-						<p class="text-sm text-accent-600 dark:text-accent-400">{texts.errors.usernameTaken}</p>
-					{:else if usernameStatus === 'invalid'}
-						<p class="text-sm text-accent-600 dark:text-accent-400">{texts.errors.usernameNoSpaces}</p>
-					{/if}
-				</Label>
-				<Label class="space-y-2">
 					<span>{texts.forms.email}</span>
 					<Input
 						type="email"
@@ -115,6 +94,36 @@
 					/>
 				</Label>
 				<PasswordInput autocomplete="new-password" />
+				<Label class="space-y-2">
+					<span>{texts.forms.username}</span>
+					<Input
+						type="text"
+						name="username"
+						placeholder={texts.auth.usernamePlaceholder}
+						class="focus:border-primary-700 focus:ring-primary-700"
+						bind:value={username}
+						required
+						maxlength={USERNAME_MAX_LENGTH}
+						autocomplete="username"
+						autocorrect="off"
+						autocapitalize="off"
+						spellcheck={false}
+					/>
+					{#if usernameStatus === 'checking'}
+						<p class="text-sm text-tinte-500">...</p>
+					{:else if usernameStatus === 'available'}
+						<p class="text-sm text-green-600 dark:text-green-400">{texts.success.usernameAvailable}</p>
+					{:else if usernameStatus === 'taken'}
+						<p class="text-sm text-accent-600 dark:text-accent-400">{texts.errors.usernameTaken}</p>
+					{:else if usernameStatus === 'too_short'}
+						<p class="text-sm text-accent-600 dark:text-accent-400">{texts.errors.usernameTooShort}</p>
+					{:else if usernameStatus === 'too_long'}
+						<p class="text-sm text-accent-600 dark:text-accent-400">{texts.errors.usernameTooLong}</p>
+					{:else if usernameStatus === 'invalid'}
+						<p class="text-sm text-accent-600 dark:text-accent-400">{texts.errors.usernameInvalidFormat}</p>
+					{/if}
+					<p class="text-sm text-tinte-500 dark:text-tinte-400">{texts.auth.usernameHint}</p>
+				</Label>
 				<label class="flex items-start gap-2 text-sm text-gray-900 dark:text-gray-300">
 					<input type="checkbox" name="userConsent" required class="mt-0.5 rounded border-gray-300 text-primary-600 focus:ring-primary-500" />
 					<span>Ich habe die <button type="button" onclick={(e) => { e.preventDefault(); e.stopPropagation(); openTos = true; }} class="cursor-pointer text-primary hover:underline">AGB{tosDoc ? ` (v${tosDoc.version})` : ''}</button> und die <button type="button" onclick={(e) => { e.preventDefault(); e.stopPropagation(); openPrivacy = true; }} class="cursor-pointer text-primary hover:underline">Datenschutzerklärung{privacyDoc ? ` (v${privacyDoc.version})` : ''}</button> gelesen und stimme beiden zu.</span>

--- a/src/routes/user/profile/+page.server.ts
+++ b/src/routes/user/profile/+page.server.ts
@@ -2,6 +2,7 @@ import { PUBLIC_PB_URL } from '../../../hooks.server';
 import { texts } from '$lib/texts';
 import { generateInviteSlug } from '$lib/inviteSlug';
 import { upsertUserGeolocation } from '$lib/server/geolocation';
+import { normalizeUsername, validateUsername } from '$lib/utils/username';
 import { upsertOwnContact, getOwnContact } from '$lib/server/contacts';
 import {
 	getOwnerRequirements,
@@ -54,18 +55,19 @@ export const actions = {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const updateData: Record<string, any> = {};
 
-		// Get username separately to check for spaces
-		const username = formData?.get('username')?.toString();
-		if (username) {
-			const trimmedUsername = username.trim();
-			if (trimmedUsername.includes(' ')) {
-				return {
-					error: true,
-					message: texts.errors.usernameNoSpaces,
-				};
-			} else if (trimmedUsername !== '') {
-				updateData['username'] = trimmedUsername;
+		// Username: normalize (trim + collapse internal whitespace) and validate against
+		// the shared rules before writing. Empty means "left unchanged", so skip it.
+		const username = normalizeUsername(formData?.get('username')?.toString() ?? '');
+		if (username !== '') {
+			switch (validateUsername(username)) {
+				case 'too_short':
+					return { error: true, message: texts.errors.usernameTooShort };
+				case 'too_long':
+					return { error: true, message: texts.errors.usernameTooLong };
+				case 'invalid':
+					return { error: true, message: texts.errors.usernameInvalidFormat };
 			}
+			updateData['username'] = username;
 		}
 
 		// Handle other fields

--- a/src/routes/user/profile/page.server.test.ts
+++ b/src/routes/user/profile/page.server.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { texts } from '$lib/texts';
+import { USERNAME_MAX_LENGTH } from '$lib/utils/username';
 
 // hooks.server.ts (reached via +page.server's import chain) reads these.
 vi.mock('$env/static/public', () => ({
@@ -47,13 +48,46 @@ function callSave(fields: Record<string, string>) {
 describe('profile: saveProfile action', () => {
 	beforeEach(() => vi.clearAllMocks());
 
-	it('rejects a username containing spaces without writing anything', async () => {
-		const { result, update } = callSave({ username: 'foo bar' });
+	it('rejects a username with invalid characters without writing anything', async () => {
+		const { result, update } = callSave({ username: 'foo@bar' });
 
-		expect(await result).toMatchObject({ error: true });
+		expect(await result).toMatchObject({ error: true, message: texts.errors.usernameInvalidFormat });
 		expect(update).not.toHaveBeenCalled();
 		expect(upsertOwnContact).not.toHaveBeenCalled();
 		expect(upsertOwnerRequirements).not.toHaveBeenCalled();
+	});
+
+	it('accepts an institution username with spaces and writes it normalized', async () => {
+		const { result, update } = callSave({ username: 'Ratsbücherei  Lüneburg' });
+
+		expect(await result).toMatchObject({ success: true });
+		expect(update).toHaveBeenCalledTimes(1);
+		const pbFormData = update.mock.calls[0][1] as FormData;
+		expect(pbFormData.get('username')).toBe('Ratsbücherei Lüneburg');
+	});
+
+	it('rejects a too-short username without writing anything', async () => {
+		const { result, update } = callSave({ username: 'ab' });
+
+		expect(await result).toMatchObject({ error: true, message: texts.errors.usernameTooShort });
+		expect(update).not.toHaveBeenCalled();
+	});
+
+	it('rejects a too-long username without writing anything', async () => {
+		const { result, update } = callSave({ username: 'a'.repeat(USERNAME_MAX_LENGTH + 1) });
+
+		expect(await result).toMatchObject({ error: true, message: texts.errors.usernameTooLong });
+		expect(update).not.toHaveBeenCalled();
+	});
+
+	it('treats a whitespace-only username as "unchanged" — succeeds, writes no username', async () => {
+		// The action always writes the (unconditional) contact fields, so `update` still
+		// runs — but a whitespace-only username normalizes to '' and must NOT be included.
+		const { result, update } = callSave({ username: '   ' });
+
+		expect(await result).toMatchObject({ success: true });
+		const pbFormData = update.mock.calls[0]?.[1] as FormData | undefined;
+		expect(pbFormData?.get('username') ?? null).toBeNull();
 	});
 
 	it('rejects an invalid Telegram handle', async () => {


### PR DESCRIPTION
Closes #457

## Problem

Onboarding an institution surfaced two registration issues:
1. It was unclear **which field is the login** — the username sat at the top of the register form, reading like the login credential, so users were unsure what to store in their password manager.
2. **Usernames couldn't contain spaces**, so institution names like *Ratsbücherei Lüneburg* had to use underscores and looked bad.

## Changes

**Clarify the login**
- Register form reordered: **email + password first, username below**, with a hint that you sign in with your email address.
- Matching hint under the email field on the login page.

**Allow spaces in usernames**
- New `src/lib/utils/username.ts` — single source of truth (`USERNAME_MIN/MAX_LENGTH`, `USERNAME_REGEX`, `normalizeUsername`, `validateUsername`), importable client- and server-side so the two can't drift.
- Internal spaces allowed (leading/trailing trimmed, repeated whitespace collapsed); max length **25 → 50**. Length measured in **code points** to match PocketBase's rune count.
- Server validation (`registration.ts`) and the profile username edit use the shared util. New `usernameTooShort`/`usernameTooLong` messages; `usernameNoSpaces` removed.

## Tests

`username.test.ts` (normalize + validate, incl. boundaries and a code-point case), updated `registration.test.ts` and profile `page.server.test.ts`. Full suite green (464 tests), lint clean.

## Depends on

⚠️ **Merge/deploy the backend first:** share-open-sharing-infrastructure/allerleih-backend#25 widens the `users.username` pattern + max. Without it, a spaced username passes client validation but PocketBase rejects it.

## Review

Reviewed for filter injection, Svelte 5 runes, texts.ts placement, public-view/masking leaks, regex ReDoS and frontend/backend pattern equivalence — no blocking issues. Review findings folded in: code-point length counting, constants interpolated into messages, added test cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)