### PR TITLE
feat(pwa): App install page + entry points (#409)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,6 +22,9 @@ jobs:
       VAPID_SUBJECT: mailto:ci@example.com
       ORS_API_KEY: dummy
       MISTRAL_API_KEY: dummy
+      SYNC_SECRET: dummy
+      PB_SUPERUSER_EMAIL: ci@example.com
+      PB_SUPERUSER_PASSWORD: dummy
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/vitest.yaml
+++ b/.github/workflows/vitest.yaml
@@ -27,6 +27,12 @@ jobs:
         env:
           PUBLIC_PB_URL: ${{ secrets.PUBLIC_PB_URL }}
           LOGIN_SECRET: ${{ secrets.LOGIN_SECRET }}
+          # Static private env members must exist at build time or `$env/static/private`
+          # fails with "Missing export" (added by the leihlokal integration, #400). Dummy
+          # values are fine — they're only read at runtime, not baked into behaviour here.
+          SYNC_SECRET: dummy
+          PB_SUPERUSER_EMAIL: ci@example.com
+          PB_SUPERUSER_PASSWORD: dummy
   test:
     # This matrix tests both the main and pull request branches
     name: Test ${{ matrix.artifact }}

--- a/src/lib/components/FooterComponent.svelte
+++ b/src/lib/components/FooterComponent.svelte
@@ -42,6 +42,9 @@
 						<FooterLink classes={{ link: "hover:no-underline" }} class="mb-2 hover:text-accent" href={resolve('/misc/guide')}
 							>{texts.nav.guide}</FooterLink
 						>
+						<FooterLink classes={{ link: "hover:no-underline" }} class="mb-2 hover:text-accent" href={resolve('/misc/app')}
+							>{texts.nav.app}</FooterLink
+						>
 						<FooterLink classes={{ link: "hover:no-underline" }} class="mb-2 hover:text-accent" href={resolve('/misc/newsletter')}
 							>{texts.nav.newsletter}</FooterLink
 						>

--- a/src/lib/components/NavBarComponent.svelte
+++ b/src/lib/components/NavBarComponent.svelte
@@ -87,7 +87,6 @@
 		}}
 	>
 		<NavLi href={resolve('/search')}>{texts.nav.search}</NavLi>
-		<NavLi href={resolve('/misc/app')}>{texts.nav.app}</NavLi>
 		{#if !loggedIn}
 			<NavLi href={resolve('/auth/login')}>{texts.nav.login}</NavLi>
 			<NavLi href={resolve('/auth/register')}>{texts.nav.register}</NavLi>

--- a/src/lib/components/NavBarComponent.svelte
+++ b/src/lib/components/NavBarComponent.svelte
@@ -87,6 +87,7 @@
 		}}
 	>
 		<NavLi href={resolve('/search')}>{texts.nav.search}</NavLi>
+		<NavLi href={resolve('/misc/app')}>{texts.nav.app}</NavLi>
 		{#if !loggedIn}
 			<NavLi href={resolve('/auth/login')}>{texts.nav.login}</NavLi>
 			<NavLi href={resolve('/auth/register')}>{texts.nav.register}</NavLi>

--- a/src/lib/components/PwaPrompts.svelte
+++ b/src/lib/components/PwaPrompts.svelte
@@ -1,26 +1,23 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { resolve } from '$app/paths';
+	import { page } from '$app/state';
 	import { texts } from '$lib/texts';
+	import { pwaInstall } from '$lib/stores/pwaInstall.svelte';
 	import { BellOutline, MobilePhoneOutline, CloseOutline } from 'flowbite-svelte-icons';
-
-	interface BeforeInstallPromptEvent extends Event {
-		prompt(): Promise<void>;
-		userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
-	}
 
 	let {
 		loggedIn,
 		onNotificationGranted,
-		installPromptEvent,
 	}: {
 		loggedIn: boolean;
 		onNotificationGranted: () => Promise<void>;
-		installPromptEvent: BeforeInstallPromptEvent | null;
 	} = $props();
+
+	const appPath = resolve('/misc/app');
 
 	let showNotifBanner = $state(false);
 	let showInstallBanner = $state(false);
-	let installManualHint = $state<string | null>(null);
 
 	function isMobileDevice(): boolean {
 		return /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent);
@@ -29,7 +26,7 @@
 	// React when Chrome delivers the install prompt after mount
 	$effect(() => {
 		if (
-			installPromptEvent &&
+			pwaInstall.event &&
 			isMobileDevice() &&
 			!window.matchMedia('(display-mode: standalone)').matches &&
 			!localStorage.getItem('pwa-install-dismissed')
@@ -58,17 +55,10 @@
 			return;
 		}
 
-		// If beforeinstallprompt hasn't fired after 3 s, show the manual hint
+		// Show the banner even if beforeinstallprompt never fires: without the event it
+		// just links to /misc/app, where the per-browser install steps live. Give Chrome
+		// 3 s to fire first so users there get the one-tap "Installieren" button instead.
 		const timer = setTimeout(() => {
-			if (installPromptEvent) return; // Chrome fired it — handled by $effect
-			const ua = navigator.userAgent;
-			if (/Firefox/i.test(ua)) {
-				installManualHint = texts.pwa.installManualFirefox;
-			} else if (/iPhone|iPad/i.test(ua)) {
-				installManualHint = texts.pwa.installManualIos;
-			} else {
-				installManualHint = texts.pwa.installManualGeneric;
-			}
 			showInstallBanner = true;
 		}, 3000);
 
@@ -97,11 +87,11 @@
 	// ── Install handlers ──────────────────────────────────────────────────────
 
 	async function triggerInstall() {
-		if (!installPromptEvent) return;
-		await installPromptEvent.prompt();
-		await installPromptEvent.userChoice;
-		showInstallBanner = false;
-		localStorage.setItem('pwa-install-dismissed', '1');
+		try {
+			await pwaInstall.prompt();
+		} finally {
+			dismissInstallBanner();
+		}
 	}
 
 	function dismissInstallBanner() {
@@ -135,8 +125,8 @@
 		</div>
 	</div>
 
-<!-- Install banner — shown only when notification banner is gone -->
-{:else if showInstallBanner}
+<!-- Install banner — shown only when notification banner is gone and not already on the App page -->
+{:else if showInstallBanner && page.url.pathname !== appPath}
 	<div
 		class="fixed bottom-10 right-4 z-40 w-72 rounded-xl shadow-lg bg-sand border border-tinte-200 p-4 flex flex-col gap-3"
 	>
@@ -149,25 +139,29 @@
 				<CloseOutline class="h-4 w-4" />
 			</button>
 		</div>
-		{#if installManualHint}
-			<p class="text-xs text-tinte-500 bg-papier rounded px-2 py-1">{installManualHint}</p>
-		{/if}
-		<div class="flex gap-2 justify-end">
-			{#if !installManualHint}
-				<button
+		<div class="flex gap-2 justify-end items-center">
+			{#if pwaInstall.canPrompt}
+				<a
+					href={appPath}
 					onclick={dismissInstallBanner}
-					class="text-xs text-tinte-400 hover:text-tinte-600 px-2 py-1"
+					class="text-xs text-tinte-400 hover:text-accent px-2 py-1"
 				>
-					{texts.pwa.installDismiss}
-				</button>
-			{/if}
-			{#if installPromptEvent}
+					{texts.pwa.installLearnMore}
+				</a>
 				<button
 					onclick={triggerInstall}
 					class="text-xs font-semibold text-white bg-accent hover:bg-accent/90 rounded-lg px-3 py-1"
 				>
 					{texts.pwa.installButton}
 				</button>
+			{:else}
+				<a
+					href={appPath}
+					onclick={dismissInstallBanner}
+					class="text-xs font-semibold text-accent hover:underline px-2 py-1"
+				>
+					{texts.pwa.installManualLink} →
+				</a>
 			{/if}
 		</div>
 	</div>

--- a/src/lib/stores/pwaInstall.svelte.test.ts
+++ b/src/lib/stores/pwaInstall.svelte.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { PwaInstall, type BeforeInstallPromptEvent } from './pwaInstall.svelte';
+
+/** A stand-in for the browser's `beforeinstallprompt` event with a fixed choice. */
+function fakePrompt(outcome: 'accepted' | 'dismissed'): BeforeInstallPromptEvent {
+	return {
+		prompt: async () => {},
+		userChoice: Promise.resolve({ outcome }),
+	} as BeforeInstallPromptEvent;
+}
+
+describe('PwaInstall', () => {
+	it('cannot prompt before an event is captured', () => {
+		const store = new PwaInstall();
+		expect(store.canPrompt).toBe(false);
+	});
+
+	it('captures the deferred prompt and reports it can prompt', () => {
+		const store = new PwaInstall();
+		store.capture(fakePrompt('accepted'));
+		expect(store.canPrompt).toBe(true);
+	});
+
+	it('returns "unavailable" and stays not-installed when there is no prompt', async () => {
+		const store = new PwaInstall();
+		expect(await store.prompt()).toBe('unavailable');
+		expect(store.installed).toBe(false);
+	});
+
+	it('marks installed and clears the (single-use) event when accepted', async () => {
+		const store = new PwaInstall();
+		store.capture(fakePrompt('accepted'));
+		expect(await store.prompt()).toBe('accepted');
+		expect(store.installed).toBe(true);
+		expect(store.canPrompt).toBe(false);
+	});
+
+	it('clears the event but does not mark installed when dismissed', async () => {
+		const store = new PwaInstall();
+		store.capture(fakePrompt('dismissed'));
+		expect(await store.prompt()).toBe('dismissed');
+		expect(store.installed).toBe(false);
+		expect(store.canPrompt).toBe(false);
+	});
+
+	it('markInstalled sets installed and drops any pending prompt', () => {
+		const store = new PwaInstall();
+		store.capture(fakePrompt('accepted'));
+		store.markInstalled();
+		expect(store.installed).toBe(true);
+		expect(store.canPrompt).toBe(false);
+	});
+});

--- a/src/lib/stores/pwaInstall.svelte.ts
+++ b/src/lib/stores/pwaInstall.svelte.ts
@@ -1,0 +1,53 @@
+// Shared PWA-install state. The browser fires `beforeinstallprompt` at most once
+// (Chrome/Edge), so the captured event has to be stashed somewhere both the
+// bottom-right pop-up (PwaPrompts.svelte) and the /misc/app page can reach — hence
+// a singleton store rather than layout-local state. Same runes-class pattern as
+// navigationLoader.svelte.ts.
+
+/** The subset of the non-standard `beforeinstallprompt` event we use. */
+export interface BeforeInstallPromptEvent extends Event {
+	prompt(): Promise<void>;
+	userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+export type InstallOutcome = 'accepted' | 'dismissed' | 'unavailable';
+
+export class PwaInstall {
+	/** The deferred install prompt, once the browser has offered one. */
+	event = $state<BeforeInstallPromptEvent | null>(null);
+	/** Set once the app has been installed (via prompt acceptance or the `appinstalled` event). */
+	installed = $state(false);
+
+	/** True when a native install prompt can be triggered right now (Chrome/Edge). */
+	get canPrompt(): boolean {
+		return this.event !== null;
+	}
+
+	/** Stash the browser's deferred `beforeinstallprompt` event for later use. */
+	capture(e: BeforeInstallPromptEvent): void {
+		this.event = e;
+	}
+
+	/** Mark the app as installed and drop the now-spent prompt (fired from `appinstalled`). */
+	markInstalled(): void {
+		this.installed = true;
+		this.event = null;
+	}
+
+	/**
+	 * Trigger the native install prompt and await the user's choice. A prompt can
+	 * only be used once, so the event is cleared afterwards regardless of outcome.
+	 * Returns 'unavailable' when no prompt was captured (Firefox / iOS / already installed).
+	 */
+	async prompt(): Promise<InstallOutcome> {
+		const event = this.event;
+		if (!event) return 'unavailable';
+		await event.prompt();
+		const { outcome } = await event.userChoice;
+		this.event = null;
+		if (outcome === 'accepted') this.installed = true;
+		return outcome;
+	}
+}
+
+export const pwaInstall = new PwaInstall();

--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -69,6 +69,7 @@ export const texts = {
 		guide: "Wie funktioniert's?",
 		privacy: 'Datenschutz',
 		tos: 'AGB',
+		app: 'App',
 	},
 
 	// Footer
@@ -517,6 +518,116 @@ export const texts = {
 					a: 'Wir sind noch im Aufbau und es gibt noch Allerlei(h) zu tun, deswegen läuft hier vielleicht noch nicht alles 100% rund. Aber digitale Freiheitsrechte (Persönlichkeitsrecht, Datenschutz, Teilhabe) sind für uns unverhandelbare Grundwerte und wir werden AllerLeih so entwickeln, dass ihr die volle Kontrolle über eure Daten habt. Zu jeder Zeit. Für immer. Das heißt: wir verkaufen keine Daten, Daten liegen auf Servern in Deutschland oder maximal der EU, und wir schützen eure Daten bestmöglich. Falls ihr feststellt, dass das nicht der Fall ist, meldet euch gerne sofort bei uns! Wir wollen transparent sein und Fehler schnellstmöglich beheben.',
 				},
 			],
+		},
+		app: {
+			title: 'AllerLeih als App',
+			intro:
+				'AllerLeih ist eine sogenannte Progressive Web App (PWA). Das heißt: Du kannst AllerLeih mit einem Tippen auf deinen Startbildschirm legen und wie eine ganz normale App nutzen – ganz ohne App-Store und ohne großen Download.',
+			installNow: 'Jetzt installieren',
+			installNowHint: 'Dein Browser unterstützt die Installation mit einem Klick.',
+			alreadyInstalled: 'AllerLeih ist auf diesem Gerät bereits als App installiert. 🎉',
+			followStepsHint:
+				'Wähle unten deinen Browser aus – dort steht Schritt für Schritt, wie du AllerLeih installierst.',
+			whatIs: {
+				title: 'Was bringt mir die App?',
+				intro:
+					'Einmal installiert, verhält sich AllerLeih wie eine App aus dem Store – nur eben direkt aus deinem Browser heraus:',
+				features: [
+					{
+						title: 'Eigenes Icon',
+						text: 'AllerLeih bekommt ein eigenes Symbol auf deinem Startbildschirm – ein Tipp und du bist drin.',
+					},
+					{
+						title: 'Benachrichtigungen',
+						text: 'Du wirst über neue Nachrichten und Anfragen informiert, auch wenn AllerLeih gerade nicht offen ist.',
+					},
+					{
+						title: 'Vollbild ohne Browserleiste',
+						text: 'Die App öffnet sich im Vollbild, ohne Adress- und Menüleiste – mehr Platz zum Stöbern.',
+					},
+					{
+						title: 'Schnell & sparsam',
+						text: 'Die Installation belegt kaum Speicherplatz und AllerLeih startet spürbar schneller.',
+					},
+					{
+						title: 'Immer aktuell',
+						text: 'Updates kommen automatisch – du musst nie etwas nachladen oder aktualisieren.',
+					},
+				],
+			},
+			howTo: {
+				title: 'So installierst du AllerLeih',
+				intro:
+					'Die Schritte unterscheiden sich je nach Gerät und Browser. Wir haben deinen Browser markiert – wenn das nicht passt, klapp einfach den passenden auf.',
+				detectedNote: 'Das ist vermutlich dein Gerät:',
+				platforms: [
+					{
+						id: 'ios',
+						label: 'iPhone / iPad (Safari)',
+						steps: [
+							'Öffne allerleih.org in Safari.',
+							'Tippe unten auf das Teilen-Symbol (Quadrat mit Pfeil nach oben).',
+							'Wähle „Zum Home-Bildschirm".',
+							'Tippe oben rechts auf „Hinzufügen".',
+						],
+					},
+					{
+						id: 'android-chrome',
+						label: 'Android (Chrome, Edge, Brave)',
+						steps: [
+							'Öffne allerleih.org im Browser.',
+							'Tippe oben rechts auf das Menü (⋮).',
+							'Wähle „App installieren" oder „Zum Startbildschirm hinzufügen".',
+							'Bestätige mit „Installieren".',
+						],
+					},
+					{
+						id: 'android-firefox',
+						label: 'Android (Firefox)',
+						steps: [
+							'Öffne allerleih.org in Firefox.',
+							'Tippe oben rechts auf das Menü (⋮).',
+							'Wähle „Zum Startbildschirm hinzufügen".',
+							'Bestätige mit „Hinzufügen".',
+						],
+					},
+					{
+						id: 'desktop-chromium',
+						label: 'Computer (Chrome, Edge)',
+						steps: [
+							'Öffne allerleih.org im Browser.',
+							'Klicke rechts in der Adressleiste auf das Installations-Symbol (Bildschirm mit Pfeil nach unten).',
+							'Alternativ: Menü (⋮) → „AllerLeih installieren".',
+							'Bestätige mit „Installieren".',
+						],
+					},
+					{
+						id: 'desktop-firefox',
+						label: 'Computer (Firefox)',
+						steps: [
+							'Firefox am Computer bietet keine Installation an.',
+							'Du kannst AllerLeih trotzdem als Lesezeichen speichern – oder nutze am Handy einen der anderen Browser.',
+						],
+					},
+					{
+						id: 'other',
+						label: 'Anderer Browser',
+						steps: [
+							'Öffne allerleih.org im Browser.',
+							'Öffne das Browser-Menü.',
+							'Suche nach „App installieren" oder „Zum Startbildschirm hinzufügen".',
+						],
+					},
+				],
+			},
+			whyNoNative: {
+				title: 'Warum gibt es (noch) keine eigene App im Store?',
+				paragraphs: [
+					'Wir sind ein kleines, gemeinnütziges Team und entwickeln AllerLeih als Open-Source-Software. Eine eigene App für iOS und Android würde bedeuten, gleich drei Programme parallel zu pflegen – das kostet Zeit und Geld, die wir lieber in die Plattform selbst stecken.',
+					'Native Apps müssen außerdem durch die Stores von Apple und Google, die Gebühren verlangen und eigene Regeln vorgeben. Als PWA bleiben wir unabhängig, und du bekommst Updates sofort, ohne etwas herunterzuladen.',
+					'Das Beste: Eine PWA fühlt sich schon heute fast wie eine echte App an – mit eigenem Icon, Vollbild und Benachrichtigungen. Sollte der Bedarf wachsen, schließen wir eine App im Store für die Zukunft nicht aus.',
+				],
+			},
 		},
 		search: {
 			title: 'Suche',
@@ -997,6 +1108,11 @@ export const texts = {
 			description:
 				'Schritt-für-Schritt-Anleitungen zum Leihen und Verleihen auf AllerLeih. Tipps, FAQs und erste Schritte.',
 		},
+		app: {
+			title: 'AllerLeih als App installieren',
+			description:
+				'Lege AllerLeih als App auf deinen Startbildschirm – ohne App-Store. So installierst du die Progressive Web App Schritt für Schritt auf iPhone, Android und Computer.',
+		},
 		contact: {
 			title: 'Kontakt – AllerLeih',
 			description: 'Schreib uns! Fragen, Feedback oder Kooperationsanfragen sind herzlich willkommen.',
@@ -1062,10 +1178,8 @@ export const texts = {
 		notifDismiss: 'Später',
 		installBannerText: 'Installiere AllerLeih für das beste Erlebnis.',
 		installButton: 'Installieren',
-		installDismiss: 'Nicht jetzt',
-		installManualFirefox: 'Tippe auf ⋮ → „Zum Startbildschirm hinzufügen"',
-		installManualIos: 'Tippe auf ⬆ → „Zum Home-Bildschirm"',
-		installManualGeneric: 'Tippe im Browser-Menü auf „Zum Startbildschirm hinzufügen"',
+		installLearnMore: 'So geht’s',
+		installManualLink: 'So installierst du AllerLeih',
 	},
 
 	// Flash messages and alerts

--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -587,7 +587,7 @@ export const texts = {
 						steps: [
 							'Öffne allerleih.org in Firefox.',
 							'Tippe oben rechts auf das Menü (⋮).',
-							'Wähle „Zum Startbildschirm hinzufügen".',
+							'Wähle „Zum Startbildschirm hinzufügen". Möglicherweise musst du zuerst auf „Mehr" tippen, bevor dieser Menüpunkt erscheint.',
 							'Bestätige mit „Hinzufügen".',
 						],
 					},

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -16,10 +16,7 @@
 	import { dev } from '$app/environment';
 	import { fade } from 'svelte/transition';
 	import AllerLoader from '$lib/components/AllerLoader.svelte';
-	interface BeforeInstallPromptEvent extends Event {
-		prompt(): Promise<void>;
-		userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
-	}
+	import { pwaInstall, type BeforeInstallPromptEvent } from '$lib/stores/pwaInstall.svelte';
 
 	let { children, data } = $props();
 
@@ -38,7 +35,6 @@
 
 	// svelte-ignore state_referenced_locally
 	let unreadCount = $state(data.unreadNotificationCount ?? 0);
-	let installPromptEvent = $state<BeforeInstallPromptEvent | null>(null);
 
 	// Sync from server when the layout load genuinely re-runs (navigation).
 	// Using a plain variable prevents spurious resets when only the page load
@@ -78,11 +74,14 @@
 	});
 
 	onMount(() => {
-		// Capture Chrome/Edge's install prompt before it shows the mini-infobar
+		// Capture Chrome/Edge's install prompt before it shows the mini-infobar, and stash it
+		// in the shared store so both the PwaPrompts banner and the /misc/app page can use it.
 		window.addEventListener('beforeinstallprompt', (e) => {
 			e.preventDefault();
-			installPromptEvent = e as BeforeInstallPromptEvent;
+			pwaInstall.capture(e as BeforeInstallPromptEvent);
 		});
+		// Reflect a completed install (from any surface, incl. the browser's own UI).
+		window.addEventListener('appinstalled', () => pwaInstall.markInstalled());
 
 		// The realtime notification subscription below is set up once at mount, not in
 		// an $effect: an $effect's cleanup/re-run cycle would tear it down and recreate
@@ -185,11 +184,7 @@
 		</div>
 	{/if}
 
-	<PwaPrompts
-		loggedIn={!!data.currentUser}
-		onNotificationGranted={setupPushSubscription}
-		{installPromptEvent}
-	/>
+	<PwaPrompts loggedIn={!!data.currentUser} onNotificationGranted={setupPushSubscription} />
 	<OnboardingPrompt show={!!data.currentUser && !data.currentUser.hasOnboarded} />
 
 	{#if page.url.pathname !== '/onboarding'}

--- a/src/routes/misc/app/+page.svelte
+++ b/src/routes/misc/app/+page.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { texts } from '$lib/texts';
+	import { pwaInstall } from '$lib/stores/pwaInstall.svelte';
+	import SeoHead from '$lib/components/SeoHead.svelte';
+	import {
+		HomeOutline,
+		BellOutline,
+		MobilePhoneOutline,
+		CheckCircleOutline,
+		ArrowsRepeatOutline,
+	} from 'flowbite-svelte-icons';
+
+	const app = texts.pages.app;
+
+	// Icons for the capability list, in the same order as app.whatIs.features (kept here
+	// because texts.ts holds strings only, not components).
+	const featureIcons = [
+		HomeOutline,
+		BellOutline,
+		MobilePhoneOutline,
+		CheckCircleOutline,
+		ArrowsRepeatOutline,
+	];
+
+	let detectedPlatform = $state<string | null>(null);
+	let isStandalone = $state(false);
+
+	// Best-effort guess of the user's device/browser so we can pre-open the matching
+	// install guide. Intentionally coarse — all iOS browsers share WebKit's share-sheet
+	// flow, so we key on the platform, not the exact browser build.
+	function detectPlatform(): string {
+		const ua = navigator.userAgent;
+		const iPadOS = navigator.maxTouchPoints > 1 && /Macintosh/i.test(ua);
+		const isIOS = /iPhone|iPad|iPod/i.test(ua) || iPadOS;
+		const isAndroid = /Android/i.test(ua);
+		const isFirefox = /Firefox|FxiOS/i.test(ua);
+
+		if (isIOS) return 'ios';
+		if (isAndroid) return isFirefox ? 'android-firefox' : 'android-chrome';
+		if (isFirefox) return 'desktop-firefox';
+		if (/Chrome|Chromium|Edg|OPR|Brave/i.test(ua)) return 'desktop-chromium';
+		return 'other';
+	}
+
+	onMount(() => {
+		isStandalone = window.matchMedia('(display-mode: standalone)').matches;
+		detectedPlatform = detectPlatform();
+	});
+
+	const installed = $derived(isStandalone || pwaInstall.installed);
+</script>
+
+<SeoHead
+	title={texts.seo.app.title}
+	description={texts.seo.app.description}
+	canonical="https://allerleih.org/misc/app"
+/>
+
+<!-- Intro / install call-to-action -->
+<section class="py-8">
+	<div class="flex flex-col items-center text-center">
+		<span class="mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-accent-100">
+			<MobilePhoneOutline class="h-8 w-8 text-accent" />
+		</span>
+		<h1 class="mb-3 text-2xl font-bold text-tinte-900">{app.title}</h1>
+		<p class="max-w-xl leading-relaxed text-tinte-500">{app.intro}</p>
+
+		<div class="mt-6">
+			{#if installed}
+				<p class="flex items-center gap-2 rounded-lg bg-primary-50 px-4 py-2 text-primary-700">
+					<CheckCircleOutline class="h-5 w-5 shrink-0" />
+					{app.alreadyInstalled}
+				</p>
+			{:else if pwaInstall.canPrompt}
+				<button
+					onclick={() => pwaInstall.prompt().catch(() => {})}
+					class="rounded-lg bg-accent px-6 py-3 font-semibold text-white shadow-sm hover:bg-accent/90"
+				>
+					{app.installNow}
+				</button>
+				<p class="mt-2 text-sm text-tinte-400">{app.installNowHint}</p>
+			{:else}
+				<p class="text-sm text-tinte-400">{app.followStepsHint}</p>
+			{/if}
+		</div>
+	</div>
+</section>
+
+<!-- What a PWA can do -->
+<section class="py-8">
+	<h2 class="mb-2 text-xl font-semibold text-tinte-900">{app.whatIs.title}</h2>
+	<p class="mb-6 text-tinte-500">{app.whatIs.intro}</p>
+	<ul class="grid gap-4 sm:grid-cols-2">
+		{#each app.whatIs.features as feature, i (feature.title)}
+			{@const Icon = featureIcons[i] ?? CheckCircleOutline}
+			<li class="flex items-start gap-3 rounded-2xl border border-gray-200 bg-white p-4">
+				<span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary-100">
+					<Icon class="h-5 w-5 text-primary-600" />
+				</span>
+				<div>
+					<p class="font-semibold text-tinte-900">{feature.title}</p>
+					<p class="mt-0.5 text-sm leading-relaxed text-tinte-500">{feature.text}</p>
+				</div>
+			</li>
+		{/each}
+	</ul>
+</section>
+
+<!-- Per-device install instructions -->
+<section class="py-8">
+	<h2 class="mb-2 text-xl font-semibold text-tinte-900">{app.howTo.title}</h2>
+	<p class="mb-6 text-tinte-500">{app.howTo.intro}</p>
+
+	<div class="space-y-3">
+		{#each app.howTo.platforms as platform (platform.id)}
+			{@const isDetected = platform.id === detectedPlatform}
+			<details
+				open={isDetected}
+				class="group overflow-hidden rounded-2xl border {isDetected
+					? 'border-accent bg-accent-50'
+					: 'border-gray-200 bg-white'}"
+			>
+				<summary
+					class="flex cursor-pointer list-none items-center justify-between gap-2 px-5 py-4 font-semibold text-tinte-900 select-none [&::-webkit-details-marker]:hidden"
+				>
+					<span class="flex items-center gap-2">
+						{platform.label}
+						{#if isDetected}
+							<span
+								class="rounded-full bg-accent px-2 py-0.5 text-[11px] font-bold tracking-wide text-white uppercase"
+							>
+								{app.howTo.detectedNote}
+							</span>
+						{/if}
+					</span>
+					<span aria-hidden="true" class="text-tinte-400 transition-transform group-open:rotate-180">▾</span>
+				</summary>
+				<ol class="list-decimal space-y-2 px-5 pb-5 pl-9 text-sm leading-relaxed text-tinte-600">
+					{#each platform.steps as step, i (i)}
+						<li>{step}</li>
+					{/each}
+				</ol>
+			</details>
+		{/each}
+	</div>
+</section>
+
+<!-- Why no native app -->
+<section class="py-8">
+	<div class="rounded-2xl border border-gray-200 bg-white p-6 sm:p-8">
+		<h2 class="mb-4 text-xl font-semibold text-tinte-900">{app.whyNoNative.title}</h2>
+		<div class="space-y-4 leading-relaxed text-tinte-500">
+			{#each app.whyNoNative.paragraphs as paragraph (paragraph)}
+				<p>{paragraph}</p>
+			{/each}
+		</div>
+	</div>
+</section>

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -7,6 +7,7 @@ const STATIC_PATHS = [
 	'/search',
 	'/misc/about',
 	'/misc/guide',
+	'/misc/app',
 	'/misc/contact',
 	'/misc/imprint',
 	'/misc/newsletter',


### PR DESCRIPTION
## What & why

Users frequently ask for a "native app" and the concept of a Progressive Web App (PWA) is not widely understood. Until now the only install surface was a terse bottom-right pop-up that gave no explanation of what a PWA is or why there's no store app. This adds a proper, self-explaining install experience.

Implements #409.

### New page `/misc/app`
- **Intro + install CTA** — one-click "Jetzt installieren" on Chrome/Edge; "Bereits installiert" when already running standalone; otherwise a hint to pick a browser below.
- **"Was bringt mir die App?"** — PWA capabilities (home-screen icon, notifications, fullscreen, low storage, always up to date).
- **Per-device install steps** — native `<details>` for iOS-Safari, Android-Chrome, Android-Firefox, Desktop-Chromium, Desktop-Firefox, and a generic fallback. The user's device is auto-detected client-side and its card opens with a "Dein Gerät" badge; steps are kept generic to avoid churn on minor browser updates.
- **"Warum (noch) keine eigene App?"** — the open-source / small-team / no-app-store rationale + future plans.

Public page (under the unprotected `/misc` prefix), added to the sitemap.

### Shared install store
`src/lib/stores/pwaInstall.svelte.ts` — a runes-class singleton (same pattern as `navigationLoader`) that holds the captured `beforeinstallprompt` event so both the page and the pop-up trigger the same one-tap install. `+layout.svelte` now writes `beforeinstallprompt`/`appinstalled` into it (replacing the old layout-local state + prop drilling).

### Adapted pop-up + entry points
- `PwaPrompts.svelte` reads the store; the install banner keeps the direct button on Chrome/Edge plus a "So geht's" link, and the Firefox/iOS fallback now links to `/misc/app` instead of a one-line hint. It hides itself on the App page.
- Added an "App" link to the header nav and footer.
- Removed the now-unused `pwa.installManual*` / `installDismiss` text keys.

## Test notes

Preflight: `npm run lint` ✅ · `npx vitest run` ✅ (474 passed, incl. 6 new store tests) · `npm run build` ✅.

`npm run check` locally reports 6 pre-existing `$env/static/private` errors (`SYNC_SECRET`, `PB_SUPERUSER_EMAIL`, `PB_SUPERUSER_PASSWORD`) because those prod-only sync secrets aren't in the local `.env`; none are in the changed files and the build passes once they're provided (as CI does).

Manual verification (dev server): `/misc/app` renders with all sections; header/footer "App" links navigate correctly; browser auto-detection opens the matching card; the install button is correctly absent server-side (client-only event). Reviewed with the `sveltekit-pb-reviewer` agent — no blocking/should-fix findings; all suggested polish applied.

Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)