### PR TITLE
ci(lint): fix Lint & Typecheck failing on every PR (missing integration-sync env vars)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,6 +22,9 @@ jobs:
       VAPID_SUBJECT: mailto:ci@example.com
       ORS_API_KEY: dummy
       MISTRAL_API_KEY: dummy
+      SYNC_SECRET: dummy
+      PB_SUPERUSER_EMAIL: ci@example.com
+      PB_SUPERUSER_PASSWORD: dummy
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The **Lint & Typecheck** workflow's `Type check (svelte-check)` step has been failing on **every PR** since the leihlokal integration (#400) merged on 2026-07-04, e.g.:

```
$env/static/private has no exported member 'SYNC_SECRET'
$env/static/private has no exported member 'PB_SUPERUSER_EMAIL'
$env/static/private has no exported member 'PB_SUPERUSER_PASSWORD'
```

## Root cause

`.github/workflows/lint.yaml` was added by #486 (2026-07-03) with an `env:` block declaring the then-known private env vars. The next day #400 added imports of `SYNC_SECRET`, `PB_SUPERUSER_EMAIL` and `PB_SUPERUSER_PASSWORD` from `$env/static/private` (in `integrations/core/pocketbase.ts`, `integrations/syncEndpoint.ts`, `user/import/+page.server.ts`) but only updated `deploy-to-uberspace.yaml`, not `lint.yaml`.

`svelte-kit sync` only generates `$env/static/private` type declarations for members present in the environment, so the type check fails without them. (Confirmed independently by #495 and #499, which both report the same "pre-existing" errors.)

## Fix

Add the three members to the typecheck job's `env:` block with dummy values — matching the existing pattern (only presence matters for type generation, not the values).

## Verification

`npm run check` with the CI env (including the three new vars) → `svelte-check found 0 errors`. This PR's own Lint & Typecheck run validates the fix end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)