### PR TITLE
fix(pwa): harden service-worker asset fetch against Safari "Load failed" (#291)

### DIFF
--- a/src/lib/serviceWorker/respondWithAsset.test.ts
+++ b/src/lib/serviceWorker/respondWithAsset.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { respondWithAsset } from './respondWithAsset';
+
+const PATH = '/_app/immutable/chunks/search.abc123.js';
+const req = () => new Request(`https://app.example${PATH}`);
+
+/** Minimal in-memory stand-in for the Cache API. */
+function makeCache(initial: Record<string, Response> = {}) {
+	const store = new Map<string, Response>(Object.entries(initial));
+	return {
+		store,
+		match: vi.fn(async (key: string) => store.get(key)),
+		put: vi.fn(async (key: string, res: Response) => {
+			store.set(key, res);
+		}),
+	};
+}
+
+describe('respondWithAsset', () => {
+	it('serves the precached asset without touching the network', async () => {
+		const cached = new Response('cached-js');
+		const cache = makeCache({ [PATH]: cached });
+		const fetchFn = vi.fn();
+
+		const res = await respondWithAsset(req(), PATH, cache as unknown as Cache, fetchFn);
+
+		expect(res).toBe(cached);
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+
+	it('falls back to the network on a cache miss and self-heals the cache', async () => {
+		const cache = makeCache();
+		const networkRes = new Response('fresh-js', { status: 200 });
+		const fetchFn = vi.fn(async () => networkRes);
+
+		const res = await respondWithAsset(req(), PATH, cache as unknown as Cache, fetchFn);
+
+		expect(res).toBe(networkRes);
+		expect(cache.put).toHaveBeenCalledWith(PATH, expect.any(Response));
+	});
+
+	it('does not cache a non-ok network response', async () => {
+		const cache = makeCache();
+		const fetchFn = vi.fn(async () => new Response('nope', { status: 404 }));
+
+		await respondWithAsset(req(), PATH, cache as unknown as Cache, fetchFn);
+
+		expect(cache.put).not.toHaveBeenCalled();
+	});
+
+	// Regression for #291: a cache miss + failing network fetch must resolve to a
+	// Response, never reject. A rejected respondWith is what surfaced Safari's
+	// "FetchEvent.respondWith received an error: TypeError: Load failed" and
+	// crashed the page after onboarding.
+	it('resolves to a network-error Response instead of rejecting when offline', async () => {
+		const cache = makeCache();
+		const fetchFn = vi.fn(async () => {
+			throw new TypeError('Load failed');
+		});
+
+		const res = await respondWithAsset(req(), PATH, cache as unknown as Cache, fetchFn);
+
+		expect(res).toBeInstanceOf(Response);
+		expect(res.type).toBe('error');
+	});
+
+	it('recovers from the cache if a parallel request populated it after the network failed', async () => {
+		const cache = makeCache();
+		const healed = new Response('healed-js');
+		const fetchFn = vi.fn(async () => {
+			// simulate another in-flight request warming the cache before we retry
+			cache.store.set(PATH, healed);
+			throw new TypeError('Load failed');
+		});
+
+		const res = await respondWithAsset(req(), PATH, cache as unknown as Cache, fetchFn);
+
+		expect(res).toBe(healed);
+	});
+});

--- a/src/lib/serviceWorker/respondWithAsset.ts
+++ b/src/lib/serviceWorker/respondWithAsset.ts
@@ -1,0 +1,40 @@
+/**
+ * Cache-first response strategy for precached build assets. Extracted from the
+ * service worker so the failure mode behind issue #291 can be unit-tested
+ * without a ServiceWorkerGlobalScope.
+ *
+ * Hardening over a plain `cached ?? fetch(request)`:
+ *  - matches by pathname, so a stray `?v=…` query string can't miss an
+ *    otherwise-cached immutable asset;
+ *  - self-heals the cache on a successful network fetch, so an asset that a
+ *    partial install (`Promise.allSettled`) or a mid-session skipWaiting/claim
+ *    takeover left uncached gets stored on first use;
+ *  - never rejects: a failed network fetch resolves to `Response.error()`
+ *    instead. A rejected `respondWith` is what surfaced Safari's
+ *    "FetchEvent.respondWith received an error: TypeError: Load failed" and
+ *    crashed the page after onboarding — returning a Response lets SvelteKit's
+ *    own navigation error handling take over instead.
+ */
+export async function respondWithAsset(
+	request: Request,
+	pathname: string,
+	cache: Cache,
+	fetchFn: typeof fetch = fetch
+): Promise<Response> {
+	const cached = await cache.match(pathname);
+	if (cached) return cached;
+
+	try {
+		const response = await fetchFn(request);
+		// Best-effort self-heal; caching must never discard a good response, so
+		// fire-and-forget and swallow put failures (e.g. quota, opaque response).
+		if (response.ok) void cache.put(pathname, response.clone()).catch(() => {});
+		return response;
+	} catch {
+		// Network failed (flaky mobile connection). A parallel request may have
+		// warmed the cache in the meantime — retry once — otherwise fail
+		// gracefully with a network-error Response rather than rejecting.
+		const retry = await cache.match(pathname);
+		return retry ?? Response.error();
+	}
+}

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -5,6 +5,7 @@ declare const self: ServiceWorkerGlobalScope;
 
 // SvelteKit service-worker module (provides build, files, version)
 import { build, files, version } from '$service-worker';
+import { respondWithAsset } from '$lib/serviceWorker/respondWithAsset';
 
 // ─── Precaching (optional, keeps the shell fast) ─────────────────────────────
 
@@ -68,11 +69,10 @@ self.addEventListener('fetch', (event) => {
 	if (url.origin !== self.location.origin) return;
 	if (!ASSETS.includes(url.pathname)) return;
 
+	// Cache-first with self-heal; never rejects (see respondWithAsset for why —
+	// a rejected respondWith is what crashed the page after onboarding, #291).
 	event.respondWith(
-		caches.open(CACHE).then(async (cache) => {
-			const cached = await cache.match(event.request);
-			return cached ?? fetch(event.request);
-		})
+		caches.open(CACHE).then((cache) => respondWithAsset(event.request, url.pathname, cache))
 	);
 });
 


### PR DESCRIPTION
## Problem

`FetchEvent.respondWith received an error: TypeError: Load failed` (Safari), reported in #291 after finishing onboarding and navigating to `/search`.

Root cause: the service worker's asset handler did `cached ?? fetch(request)` inside `respondWith`. When a precached build chunk was missing from the cache **and** the network fetch failed (flaky mobile connection), the promise rejected — Safari surfaces this as "Load failed" and the page crashes. Reachable when the onboarding "Suchen" link client-side-navigates to `/search` and dynamically imports its route chunk.

The reported navigation-wide crash was already largely fixed by #278 (the handler now only intercepts `ASSETS`, not navigations / API / `__data.json`), but a narrower variant survived and was made *more* likely by the later `Promise.allSettled` install (assets can silently fail to precache) and `skipWaiting()` + `clients.claim()` (a new worker takes over mid-session with a possibly-incomplete cache).

## Fix

Extract the strategy into a pure, unit-tested `respondWithAsset()`:

- match by pathname (a stray `?v=…` query string can't miss an immutable asset),
- self-heal the cache via `cache.put` on a successful fetch, so an asset a partial install missed is stored on first use,
- resolve to `Response.error()` on network failure instead of rejecting, so the page degrades to SvelteKit's own error handling instead of crashing.

## Tests

`src/lib/serviceWorker/respondWithAsset.test.ts` — 5 cases incl. the #291 regression: a cache miss + failing network fetch must resolve to a `Response`, never reject. A true device repro (iOS Safari + flaky network + fresh SW) isn't deterministic, so the failure mode is captured at the logic level.

- `npx vitest run` → 473 passed
- `npm run check` → no new errors/warnings vs. `main`
- production build transforms the SW bundle cleanly

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)