### PR TITLE
fix(profile): pin mobile TOC strip to top of viewport (#500)

### DIFF
--- a/src/routes/user/profile/ProfileToc.svelte
+++ b/src/routes/user/profile/ProfileToc.svelte
@@ -111,9 +111,11 @@
 	</ul>
 </nav>
 
-<!-- Mobile: horizontal, scrollable chip strip pinned below the nav bar -->
+<!-- Mobile: horizontal, scrollable chip strip pinned to the top of the viewport.
+     The app header (NavBarComponent) is not fixed, so it scrolls away with the page;
+     top-0 pins the strip flush instead of leaving a 64px gap for a header that isn't there. -->
 <nav
-	class="lg:hidden sticky top-16 z-20 -mx-4 px-4 py-2 bg-secondary-100/95 dark:bg-tinte-900/95 backdrop-blur border-b border-tinte-200 dark:border-tinte-700 overflow-x-auto"
+	class="lg:hidden sticky top-0 z-20 -mx-4 px-4 py-2 bg-secondary-100/95 dark:bg-tinte-900/95 backdrop-blur border-b border-tinte-200 dark:border-tinte-700 overflow-x-auto"
 	aria-label={title}
 >
 	<ul class="flex gap-2 w-max">


### PR DESCRIPTION
## What

Fixes #500 — on mobile, the profile settings tab strip (**Profil · Standort & Mobilität · Kontakt · Verleih-Voraussetzungen**) stuck partway down the viewport instead of at the top, letting a slice of the scrolled page bleed through above it.

## Why

`src/routes/user/profile/ProfileToc.svelte` positioned the mobile strip with `sticky top-16` (64px), assuming a fixed 64px app header beneath which it should pin. But `NavBarComponent` is a plain Flowbite `<Navbar>` — **not** fixed/sticky — so it scrolls away with the page and nothing fills those top 64px. The strip therefore pinned 64px below the viewport edge, exposing the gap.

## Change

- Mobile branch (`lg:hidden`): `sticky top-16` → `sticky top-0`, so the strip pins flush to the top. It already carries its own `bg-secondary-100/95 … backdrop-blur` + bottom border, so it reads cleanly.
- Desktop vertical TOC (`sticky top-24`) is unchanged.
- Scroll-spy `TRIGGER_OFFSET` (120px) left as-is — still clears the ~48px strip comfortably.

One-line class change; no logic touched.

## Verification

Drove the running app in a 360px mobile viewport (matching the issue screenshot), logged in, opened `/user/profile`, and scrolled: the tab strip now pins flush to the top with no gap and no content bleeding through above it.

No unit test added — `ProfileToc` is a presentational component with no server logic, and this repo's Vitest suite covers server functions/actions with a mocked PocketBase, not CSS/DOM. `npm run check` shows only pre-existing, unrelated `$env/static/private` errors (integration-sync vars supplied in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)