### PR TITLE
fix(items): show owner bio on item detail page

### DIFF
--- a/src/routes/items/[id]/+page.svelte
+++ b/src/routes/items/[id]/+page.svelte
@@ -24,6 +24,7 @@
 		isInstitution: item.isInstitution,
 		profileImage: item.profileImage,
 		created: item.userCreated,
+		bio: item.bio,
 	}) as UserPublic;
 
 	const isTrustRestricted = $derived(data.isTrustRestricted);


### PR DESCRIPTION
## What & why

The item detail page's owner card (`OwnerCard.svelte`) has a bio block
(`{#if owner.bio}`) that stopped rendering. Root cause is purely in the
frontend: the `owner` object assembled in `items/[id]/+page.svelte` for
`OwnerCard` was built field-by-field from the `items_public` row and simply
omitted `bio`, so `owner.bio` was always `undefined`.

The suspected cause in the issue (bio missing from the public view) was **not**
the case — `items_public` already selects `users.bio` in both the masked and
unmasked view variants, and `ItemPublic` declares it. The one-line fix forwards
`item.bio` into the owner object; no schema, query, or backend change needed.

## Changes

- `src/routes/items/[id]/+page.svelte`: add `bio: item.bio` to the `owner` object.

The existing `line-clamp-3` + `whitespace-pre-wrap` in `OwnerCard.svelte` keeps
the display to the first three lines (the "show more" affordance mentioned in
the issue is intentionally left out of scope).

## Test notes

Preflight: `npm run lint` ✅ · `npx vitest run` (468/468) ✅ · `npm run build` ✅.
(`npm run check` reports only the pre-existing `$env/static/private` errors for
the integration-sync vars, unrelated to this change.)

Manually verified in the running app (local PocketBase + dev server, guest view
via `items_public`):
- Owner **with** bio → bio now renders in the owner card.
- Multi-line bio → line breaks preserved, clamped to 3 lines with an ellipsis.
- Owner **without** bio → no bio block, no layout break.

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)