### PR TITLE
feat: move preferredTransportMode + hasOnboarded into user_preferences (#426)

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -20,8 +20,6 @@ erDiagram
         bool isInstitution
         string profileImage
         string bio
-        string preferredTransportMode "foot|bicycle|car"
-        bool hasOnboarded
         string contactMethod "issue #438 — ''|email|link: item CTA becomes a mailto:/external link instead of the in-app flow"
         string contactEmail "dedicated contact address (contactMethod=email) — raw value never in a *_public view"
         string contactUrl "external lending-form link (contactMethod=link) — raw value never in a *_public view"
@@ -91,6 +89,16 @@ erDiagram
     }
 
     USER 1 to zero or one USER_CONTACT: "contact handles (private)"
+
+    USER_PREFERENCES{
+        string id PK
+        User user FK "owner only — unique"
+        bool emailNotifications "issue #233 — opt-out; absent/true = opted in"
+        string preferredTransportMode "issue #426 — foot|bicycle|car (was on users)"
+        bool hasOnboarded "issue #426 — onboarding-complete flag (was on users)"
+    }
+
+    USER 1 to zero or one USER_PREFERENCES: "settings (private)"
 
     ITEM{
         string id PK
@@ -281,6 +289,30 @@ Coordinates are **not** stored on `users` — they live in a separate `user_geol
 ## user_contacts
 
 Messenger handles (`telegramUsername`, `signalLink`) and their per-handle "visible to trusted only" flags live here, **not** on `users`. All API rules are `@request.auth.id = user` (owner-only). They reach other users only through the `GET /api/contact/{userId}` hook, which returns a handle to a caller only if it's public (flag off), the caller is the owner, or the owner trusts the caller (a `trusts` row `{truster: owner, trustee: caller}`) — so the "trusted only" toggle is enforced at the data layer, not just in the UI.
+
+## user_preferences
+
+Per-user settings sidecar (issue #233 introduced it for `emailNotifications`; issue #426 pulled
+`preferredTransportMode` and `hasOnboarded` off the `users` table into it, so `users` stays lean).
+One row per user — a `UNIQUE` index on `user`, relation `cascadeDelete: true`. All API rules
+(`list`/`view`/`create`/`update`/`delete`) are `@request.auth.id = user`, so a user only ever
+reads/writes **their own** row. A **missing row means "all defaults"** (`emailNotifications` opted
+in, `preferredTransportMode` falls back to `bicycle` in the UI, `hasOnboarded` falsy → the
+onboarding prompt shows), so every reader must tolerate a null row. Fields:
+
+- `emailNotifications` (bool) — notification-email opt-out; absent/`true` = opted in, only an
+  explicit `false` opts out. Read server-side by the backend `notification.pb.js` / `digest.pb.js`
+  hooks (keyed on the `user` relation).
+- `preferredTransportMode` (`foot`|`bicycle`|`car`) — seeds the ORS travel-time UI on search and
+  item-detail.
+- `hasOnboarded` (bool) — drives a soft onboarding prompt (there is **no** redirect gate).
+
+Frontend access goes through the `getUserPreferences` / `upsertUserPreferences` helpers in
+`$lib/server/userPreferences.ts` (the row is surfaced app-wide as `currentUserPreferences` from the
+root `+layout.server.ts`). `NotificationSettings.svelte` additionally reads/writes
+`emailNotifications` client-side; the helper patches fields individually so the two paths coexist.
+The row is hard-deleted on account anonymization (personal-only data). No `*_public` view exposes
+any of these fields.
 
 ## trusts
 

--- a/scripts/seed/lib.js
+++ b/scripts/seed/lib.js
@@ -55,16 +55,33 @@ export async function teardown(pb) {
 
 // --- Factories -------------------------------------------------------------
 
-export function createUser(pb, username, overrides = {}) {
-	return pb.collection('users').create({
+export async function createUser(pb, username, overrides = {}) {
+	// Preference fields live in the user_preferences sidecar (issue #426), not on the
+	// users row. Peel them off `overrides` and write them to the sidecar. `hasOnboarded`
+	// defaults to true so seeded accounts don't get the onboarding prompt when clicking through.
+	const {
+		hasOnboarded = true,
+		preferredTransportMode,
+		// emailNotifications is opt-out: default the created row to true so a seeded user
+		// matches a real "no row" user (opted in), consistent with the copy migration.
+		emailNotifications = true,
+		...userOverrides
+	} = overrides;
+
+	const user = await pb.collection('users').create({
 		username,
 		email: `${username}${SEED_DOMAIN}`,
 		password: USER_PASSWORD,
 		passwordConfirm: USER_PASSWORD,
 		verified: true,
-		hasOnboarded: true,
-		...overrides,
+		...userOverrides,
 	});
+
+	const prefs = { user: user.id, hasOnboarded, emailNotifications };
+	if (preferredTransportMode !== undefined) prefs.preferredTransportMode = preferredTransportMode;
+	await pb.collection('user_preferences').create(prefs);
+
+	return user;
 }
 
 // Tiny dependency-free PNG encoder so seeded items carry a real (offline, deterministic)

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -9,6 +9,7 @@ declare global {
 		// interface Error {}
 		interface PageData {
 			currentUser: import('pocketbase').Record | null;
+			currentUserPreferences?: import('$lib/types/models').UserPreferences | null;
 			unreadNotificationCount?: number;
 			pbAuthToken?: string | null;
 		}

--- a/src/lib/server/userPreferences.test.ts
+++ b/src/lib/server/userPreferences.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import type PocketBase from 'pocketbase';
+import { getUserPreferences, upsertUserPreferences } from './userPreferences';
+
+function mockFilter(raw: string, params?: Record<string, unknown>): string {
+	if (!params) return raw;
+	let result = raw;
+	for (const [key, value] of Object.entries(params)) {
+		const escaped = typeof value === 'string' ? `'${value.replace(/'/g, "\\'")}'` : `${value}`;
+		result = result.replaceAll(`{:${key}}`, escaped);
+	}
+	return result;
+}
+
+/** Build a pb whose `user_preferences` collection uses the provided method mocks. */
+function makePb(prefs: Record<string, ReturnType<typeof vi.fn>>): PocketBase {
+	return {
+		collection: vi.fn((name: string) => (name === 'user_preferences' ? prefs : {})),
+		filter: vi.fn(mockFilter),
+	} as unknown as PocketBase;
+}
+
+describe('getUserPreferences', () => {
+	it('returns the row when one exists', async () => {
+		const getFirstListItem = vi.fn().mockResolvedValue({ id: 'p1', user: 'u1', hasOnboarded: true });
+		const pb = makePb({ getFirstListItem });
+		expect(await getUserPreferences(pb, 'u1')).toEqual({ id: 'p1', user: 'u1', hasOnboarded: true });
+		expect(getFirstListItem).toHaveBeenCalledWith("user = 'u1'", { requestKey: 'user-preferences' });
+	});
+
+	it('returns null when no row exists (404)', async () => {
+		const pb = makePb({ getFirstListItem: vi.fn().mockRejectedValue(new Error('404')) });
+		expect(await getUserPreferences(pb, 'u1')).toBeNull();
+	});
+
+	it('forwards a caller-supplied requestKey (avoids SSR auto-cancellation collisions)', async () => {
+		const getFirstListItem = vi.fn().mockResolvedValue({ id: 'p1' });
+		const pb = makePb({ getFirstListItem });
+		await getUserPreferences(pb, 'u1', 'user-preferences-item');
+		expect(getFirstListItem).toHaveBeenCalledWith("user = 'u1'", { requestKey: 'user-preferences-item' });
+	});
+});
+
+describe('upsertUserPreferences', () => {
+	it('updates the existing row, patching only the given fields', async () => {
+		const update = vi.fn().mockResolvedValue({ id: 'p1' });
+		const create = vi.fn();
+		const pb = makePb({
+			getFirstListItem: vi.fn().mockResolvedValue({ id: 'p1', user: 'u1' }),
+			update,
+			create,
+		});
+		await upsertUserPreferences(pb, 'u1', { preferredTransportMode: 'car' });
+		expect(update).toHaveBeenCalledWith('p1', { preferredTransportMode: 'car' });
+		expect(create).not.toHaveBeenCalled();
+	});
+
+	it('creates a row when none exists', async () => {
+		const create = vi.fn().mockResolvedValue({ id: 'p2' });
+		const pb = makePb({
+			getFirstListItem: vi.fn().mockRejectedValue(new Error('404')),
+			create,
+			update: vi.fn(),
+		});
+		await upsertUserPreferences(pb, 'u1', { hasOnboarded: true });
+		expect(create).toHaveBeenCalledWith({ user: 'u1', hasOnboarded: true });
+	});
+
+	it('tolerates a create race: create rejects but a row now exists → update instead', async () => {
+		// First getFirstListItem (pre-check) → 404, then post-failure re-check → the row.
+		const getFirstListItem = vi
+			.fn()
+			.mockRejectedValueOnce(new Error('404'))
+			.mockResolvedValueOnce({ id: 'p3', user: 'u1' });
+		const create = vi.fn().mockRejectedValue(new Error('unique constraint'));
+		const update = vi.fn().mockResolvedValue({ id: 'p3' });
+		const pb = makePb({ getFirstListItem, create, update });
+		await expect(upsertUserPreferences(pb, 'u1', { hasOnboarded: true })).resolves.toBeUndefined();
+		expect(update).toHaveBeenCalledWith('p3', { hasOnboarded: true });
+	});
+
+	it('rethrows a genuine create error when still no row exists afterwards', async () => {
+		const getFirstListItem = vi
+			.fn()
+			.mockRejectedValueOnce(new Error('404'))
+			.mockRejectedValueOnce(new Error('still 404'));
+		const create = vi.fn().mockRejectedValue(new Error('boom'));
+		const pb = makePb({ getFirstListItem, create, update: vi.fn() });
+		await expect(upsertUserPreferences(pb, 'u1', { hasOnboarded: true })).rejects.toThrow('boom');
+	});
+});

--- a/src/lib/server/userPreferences.ts
+++ b/src/lib/server/userPreferences.ts
@@ -1,0 +1,66 @@
+import type PocketBase from 'pocketbase';
+import type { UserPreferences, UserId } from '$lib/types/models';
+
+// Central access point for the `user_preferences` sidecar collection (issue #426).
+// One owner-only row per user (unique index on `user`) holds settings pulled off the
+// `users` table — currently `emailNotifications`, `preferredTransportMode` and
+// `hasOnboarded`. A missing row means "all defaults", so readers must tolerate null.
+// NOTE: NotificationSettings.svelte reads/writes `emailNotifications` client-side; keep
+// these writes field-scoped (never overwrite the whole row) so the two paths coexist.
+
+/** The subset of preference fields callers may write. */
+export type UserPreferencesPatch = Partial<
+	Pick<UserPreferences, 'emailNotifications' | 'preferredTransportMode' | 'hasOnboarded'>
+>;
+
+/**
+ * Returns the user's preferences row, or null if none has been created yet.
+ *
+ * `requestKey` MUST be distinct per concurrent call site on the same request. The root
+ * layout load and a page load (item detail, profile) both fetch preferences and run
+ * concurrently on the same `locals.pb`; PocketBase's default auto-cancellation keys by
+ * method+path, so without distinct keys the second identical GET aborts the first and
+ * one caller silently gets null (the same class of bug as the `/social` trust fetch —
+ * see `trust.ts`). Pass a stable, call-site-specific key.
+ */
+export async function getUserPreferences(
+	pb: PocketBase,
+	userId: UserId,
+	requestKey = 'user-preferences'
+): Promise<UserPreferences | null> {
+	try {
+		return await pb
+			.collection('user_preferences')
+			.getFirstListItem<UserPreferences>(pb.filter('user = {:userId}', { userId }), { requestKey });
+	} catch {
+		// PocketBase throws 404 when no record matches — translate to null.
+		return null;
+	}
+}
+
+/**
+ * Upserts the user's own preferences row, patching only the given fields. Creates it
+ * on first save, updates it thereafter (one row per user, enforced by a unique index
+ * on `user`). If two saves race and both try to create, the loser's unique-index error
+ * is caught and retried as an update, so the user never sees a spurious failure.
+ */
+export async function upsertUserPreferences(
+	pb: PocketBase,
+	userId: UserId,
+	patch: UserPreferencesPatch
+): Promise<void> {
+	const existing = await getUserPreferences(pb, userId);
+	if (existing) {
+		await pb.collection('user_preferences').update(existing.id, patch);
+		return;
+	}
+	try {
+		await pb.collection('user_preferences').create({ user: userId, ...patch });
+	} catch (err) {
+		// Lost a create race (unique index on user) — fall back to updating the row
+		// that the other writer just created.
+		const row = await getUserPreferences(pb, userId);
+		if (row) await pb.collection('user_preferences').update(row.id, patch);
+		else throw err;
+	}
+}

--- a/src/lib/types/models.ts
+++ b/src/lib/types/models.ts
@@ -106,11 +106,6 @@ export interface User extends PocketBaseEntity {
 	geolocation?: { lon: number; lat: number };
 
 	/**
-	 * Preferred transport mode for distance-based search
-	 */
-	preferredTransportMode?: 'foot' | 'bicycle' | 'car';
-
-	/**
 	 * Unique invite code for this user's invite link.
 	 * Generated lazily on first profile visit if not set.
 	 */
@@ -120,11 +115,6 @@ export interface User extends PocketBaseEntity {
 	 * Foreign key: the user who invited this user (set at registration via invite link).
 	 */
 	invitedBy?: UserId;
-
-	/**
-	 * Whether the user has completed the onboarding flow.
-	 */
-	hasOnboarded?: boolean;
 
 	/**
 	 * Whether the user has verified their email address.
@@ -227,6 +217,26 @@ export interface Trust extends PocketBaseEntity {
 
 	/** Foreign key: the user being trusted (gains visibility of the truster's restricted items). */
 	trustee: UserId;
+}
+
+/**
+ * Per-user preferences sidecar (issue #426), one row per user (unique index on
+ * `user`, owner-only rules, cascadeDelete). Holds settings pulled off the `users`
+ * table so it stays lean. A missing row means "all defaults". Queried via
+ * `$lib/server/userPreferences`.
+ */
+export interface UserPreferences extends PocketBaseEntity {
+	/** Foreign key: the user these preferences belong to. */
+	user: UserId;
+
+	/** Email notifications opt-in. Absent/true = opted in; only an explicit false opts out. */
+	emailNotifications?: boolean;
+
+	/** Preferred transport mode for distance-based search / travel-time UI. */
+	preferredTransportMode?: 'foot' | 'bicycle' | 'car';
+
+	/** Whether the user has completed the onboarding flow (drives a soft prompt, no gate). */
+	hasOnboarded?: boolean;
 }
 
 // --- ITEM ---

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,4 +1,6 @@
 import { NOTIFICATIONS_DEP } from '$lib/constants';
+import { getUserPreferences } from '$lib/server/userPreferences';
+import type { UserPreferences } from '$lib/types/models';
 
 export const load = async (event) => {
 	// Lets invalidate(NOTIFICATIONS_DEP) re-fetch just the unread count (issue #376).
@@ -7,6 +9,9 @@ export const load = async (event) => {
 	const currentUser = event.locals.user;
 
 	let unreadNotificationCount = 0;
+	// Preferences (transport mode, onboarding flag, …) live in a sidecar collection
+	// (issue #426); surface them once here so every page can read them off `data`.
+	let currentUserPreferences: UserPreferences | null = null;
 	if (currentUser) {
 		try {
 			const result = await event.locals.pb
@@ -20,10 +25,16 @@ export const load = async (event) => {
 		} catch {
 			// notifications collection may not exist yet during setup
 		}
+		currentUserPreferences = await getUserPreferences(
+			event.locals.pb,
+			currentUser.id,
+			'user-preferences-layout'
+		);
 	}
 
 	return {
 		currentUser,
+		currentUserPreferences,
 		unreadNotificationCount,
 		pbAuthToken: event.locals.pb.authStore.token ?? null,
 	};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -190,7 +190,7 @@
 		onNotificationGranted={setupPushSubscription}
 		{installPromptEvent}
 	/>
-	<OnboardingPrompt show={!!data.currentUser && !data.currentUser.hasOnboarded} />
+	<OnboardingPrompt show={!!data.currentUser && !data.currentUserPreferences?.hasOnboarded} />
 
 	{#if page.url.pathname !== '/onboarding'}
 		<FooterComponent />

--- a/src/routes/items/[id]/+page.server.ts
+++ b/src/routes/items/[id]/+page.server.ts
@@ -7,6 +7,7 @@ import { createNotification, sendPushToUser } from '$lib/server/notifications.js
 import { getActiveTerms, hasAcceptedActiveTerms } from '$lib/server/lendingTerms';
 import { evaluateUnmetRequirements, requirementRegistry } from '$lib/server/lendingRequirements';
 import { isTrusting } from '$lib/server/trust';
+import { getUserPreferences } from '$lib/server/userPreferences';
 
 export async function load({ params, locals }) {
 	let item: ItemPublic;
@@ -152,6 +153,17 @@ export async function load({ params, locals }) {
 		}
 	}
 
+	// Transport mode lives in the user_preferences sidecar (issue #426), not on the
+	// auth record — fetch it directly (only when authenticated) rather than via the
+	// layout's `parent()`, so this already query-heavy load doesn't serialize behind it.
+	// Distinct requestKey from the layout's fetch so the two concurrent reads don't
+	// auto-cancel each other (PB keys by method+path).
+	const preferredTransportMode =
+		(currentUserId
+			? (await getUserPreferences(locals.pb, currentUserId, 'user-preferences-item'))
+					?.preferredTransportMode
+			: null) || 'bicycle';
+
 	return {
 		item,
 		PB_IMG_URL: PUBLIC_PB_URL,
@@ -162,7 +174,7 @@ export async function load({ params, locals }) {
 		viewerTrustsOwner,
 		ownerTrustsViewer,
 		ownerItemCount,
-		preferredTransportMode: locals.user?.preferredTransportMode || 'bicycle',
+		preferredTransportMode,
 		existingConversation,
 		requiresTermsAcceptance,
 		unmetRequirements,

--- a/src/routes/items/[id]/page.server.test.ts
+++ b/src/routes/items/[id]/page.server.test.ts
@@ -60,6 +60,7 @@ function makePb(opts: {
 	masked?: boolean;
 	itemExtra?: Record<string, unknown>;
 	conversationsGetFirstListItem?: ReturnType<typeof vi.fn>;
+	preferredTransportMode?: 'foot' | 'bicycle' | 'car';
 }) {
 	const usersGetOne = vi.fn().mockResolvedValue({
 		contactMethod: opts.contactMethod ?? '',
@@ -68,6 +69,14 @@ function makePb(opts: {
 	});
 	const convGetFirstListItem =
 		opts.conversationsGetFirstListItem ?? vi.fn().mockRejectedValue(new Error('none'));
+	// getUserPreferences() probes here; a rejection means "no row" (→ 'bicycle' fallback).
+	const prefsGetFirstListItem = opts.preferredTransportMode
+		? vi.fn().mockResolvedValue({
+				id: 'pref1',
+				user: VIEWER_ID,
+				preferredTransportMode: opts.preferredTransportMode,
+			})
+		: vi.fn().mockRejectedValue(new Error('none'));
 	const base = publicItem(opts.itemExtra);
 	const itemRow = opts.masked ? { ...base, name: null } : base;
 	const pb = {
@@ -88,6 +97,8 @@ function makePb(opts: {
 					return { getOne: usersGetOne };
 				case 'conversations':
 					return { getFirstListItem: convGetFirstListItem };
+				case 'user_preferences':
+					return { getFirstListItem: prefsGetFirstListItem };
 				default:
 					return {};
 			}
@@ -97,7 +108,7 @@ function makePb(opts: {
 		// callLoad() from whether a user is passed, so the anonymous path is faithful.
 		authStore: { isValid: true },
 	};
-	return { pb, usersGetOne, convGetFirstListItem };
+	return { pb, usersGetOne, convGetFirstListItem, prefsGetFirstListItem };
 }
 
 function callLoad(
@@ -238,6 +249,37 @@ describe('items/[id] load — off-platform-contact owners (#438)', () => {
 		expect(usersGetOne).not.toHaveBeenCalled();
 		// A guest never reaches the trust-restricted state (that requires authentication).
 		expect(data.isTrustRestricted).toBe(false);
+	});
+});
+
+describe('items/[id] load — preferred transport mode (#426, from user_preferences)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		getActiveTerms.mockResolvedValue(null);
+		hasAcceptedActiveTerms.mockResolvedValue(true);
+		evaluateUnmetRequirements.mockResolvedValue([]);
+	});
+
+	it("passes the viewer's saved transport mode through from user_preferences", async () => {
+		const { pb, prefsGetFirstListItem } = makePb({ preferredTransportMode: 'foot' });
+		const data = await callLoad(pb);
+		expect(data.preferredTransportMode).toBe('foot');
+		// The authenticated path DOES query user_preferences.
+		expect(prefsGetFirstListItem).toHaveBeenCalledTimes(1);
+	});
+
+	it('falls back to bicycle when the viewer has no preferences row', async () => {
+		const { pb } = makePb({});
+		const data = await callLoad(pb);
+		expect(data.preferredTransportMode).toBe('bicycle');
+	});
+
+	it('falls back to bicycle for an anonymous viewer without querying user_preferences', async () => {
+		const { pb, prefsGetFirstListItem } = makePb({});
+		const data = await callLoad(pb, null);
+		expect(data.preferredTransportMode).toBe('bicycle');
+		// The `currentUserId ? … : null` guard must short-circuit — no query for a guest.
+		expect(prefsGetFirstListItem).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/routes/layout.server.test.ts
+++ b/src/routes/layout.server.test.ts
@@ -6,12 +6,14 @@ type LoadEvent = Parameters<typeof load>[0];
 
 describe('Root layout load', () => {
 	let getList: ReturnType<typeof vi.fn>;
+	let prefsGetFirstListItem: ReturnType<typeof vi.fn>;
 	let depends: ReturnType<typeof vi.fn>;
 	let filter: ReturnType<typeof vi.fn>;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 		getList = vi.fn().mockResolvedValue({ totalItems: 3 });
+		prefsGetFirstListItem = vi.fn().mockResolvedValue({ hasOnboarded: true, preferredTransportMode: 'car' });
 		depends = vi.fn();
 		filter = vi.fn((raw: string) => raw);
 	});
@@ -22,7 +24,10 @@ describe('Root layout load', () => {
 			locals: {
 				user,
 				pb: {
-					collection: vi.fn(() => ({ getList })),
+					// notifications → getList; user_preferences → getFirstListItem (issue #426).
+					collection: vi.fn((name: string) =>
+						name === 'user_preferences' ? { getFirstListItem: prefsGetFirstListItem } : { getList }
+					),
 					filter,
 					authStore: { token: 'jwt-token' },
 				},
@@ -59,5 +64,22 @@ describe('Root layout load', () => {
 		// and that the dependency is still registered even when the query throws
 		expect(getList).toHaveBeenCalled();
 		expect(depends).toHaveBeenCalledWith(NOTIFICATIONS_DEP);
+	});
+
+	it('surfaces the user preferences with a distinct requestKey (issue #426)', async () => {
+		const result = await load(buildEvent({ id: 'user1' }));
+		expect(result.currentUserPreferences).toEqual({ hasOnboarded: true, preferredTransportMode: 'car' });
+		// Distinct requestKey so the concurrent item/profile fetch of the same collection
+		// doesn't auto-cancel this one under PocketBase SSR.
+		expect(prefsGetFirstListItem).toHaveBeenCalledTimes(1);
+		expect(prefsGetFirstListItem).toHaveBeenCalledWith('user = {:userId}', {
+			requestKey: 'user-preferences-layout',
+		});
+	});
+
+	it('does not query preferences and returns null for a guest (issue #426)', async () => {
+		const result = await load(buildEvent(null));
+		expect(result.currentUserPreferences).toBeNull();
+		expect(prefsGetFirstListItem).not.toHaveBeenCalled();
 	});
 });

--- a/src/routes/onboarding/+page.server.ts
+++ b/src/routes/onboarding/+page.server.ts
@@ -8,6 +8,7 @@ import { addTrust, removeTrust, getTrustees } from '$lib/server/trust';
 import { generateInviteSlug } from '$lib/inviteSlug';
 import { getUserGeolocation, upsertUserGeolocation } from '$lib/server/geolocation';
 import { getOwnContact, upsertOwnContact } from '$lib/server/contacts';
+import { upsertUserPreferences } from '$lib/server/userPreferences';
 
 export async function load({ locals, url }) {
 	let inviteCode = locals.user.inviteCode as string | undefined;
@@ -112,7 +113,7 @@ export const actions = {
 		const mode = formData.get('mode')?.toString();
 		if (mode === 'foot' || mode === 'bicycle' || mode === 'car') {
 			try {
-				await locals.pb.collection('users').update(locals.user.id, { preferredTransportMode: mode });
+				await upsertUserPreferences(locals.pb, locals.user.id, { preferredTransportMode: mode });
 			} catch {
 				// non-critical — proceed regardless
 			}
@@ -164,7 +165,7 @@ export const actions = {
 		}
 
 		try {
-			await locals.pb.collection('users').update(locals.user.id, { hasOnboarded: true });
+			await upsertUserPreferences(locals.pb, locals.user.id, { hasOnboarded: true });
 			await upsertOwnContact(locals.pb, locals.user.id, contact);
 			return { success: true };
 		} catch {

--- a/src/routes/onboarding/+page.svelte
+++ b/src/routes/onboarding/+page.svelte
@@ -73,7 +73,7 @@
 				initialGeolocation={data.geolocation}
 			/>
 		{:else if step === 6}
-			<StepTransportMode onNext={next} preferredTransportMode={data.currentUser.preferredTransportMode} />
+			<StepTransportMode onNext={next} preferredTransportMode={data.currentUserPreferences?.preferredTransportMode} />
 		{:else if step === 7}
 			<StepContact onNext={next} currentUser={data.contact} />
 		{:else if step === 8}

--- a/src/routes/search/+page.server.ts
+++ b/src/routes/search/+page.server.ts
@@ -2,6 +2,7 @@ import { PUBLIC_PB_URL } from '../../hooks.server';
 import type { ItemPublic } from '$lib/types/models';
 import { parseSearchParameters, buildItemFilter, type SearchParameters } from './searchFilter';
 import type { ListResult } from 'pocketbase';
+import { upsertUserPreferences } from '$lib/server/userPreferences';
 
 export async function load({ locals, url }) {
 	// 1. Parse search parameters from URL
@@ -60,9 +61,11 @@ export const actions = {
 		const formData = await request.formData();
 		const mode = formData.get('mode')?.toString();
 		if (mode === 'foot' || mode === 'bicycle' || mode === 'car') {
-			locals.pb
-				.collection('users')
-				.update(locals.user.id, { preferredTransportMode: mode });
+			// Fire-and-forget: the search UX doesn't wait on the save. The upsert is a
+			// two-step (read then create/update), so swallow any rejection explicitly.
+			void upsertUserPreferences(locals.pb, locals.user.id, { preferredTransportMode: mode }).catch(
+				() => {}
+			);
 		}
 	},
 };

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -16,7 +16,7 @@
 	const { data } = $props();
 
 	const preferredMode = $derived(
-		(data.currentUser?.preferredTransportMode || undefined) as TransportMode | undefined
+		(data.currentUserPreferences?.preferredTransportMode || undefined) as TransportMode | undefined
 	);
 
 	let transportMode = $state<TransportMode | null>(null);

--- a/src/routes/user/profile/+page.server.ts
+++ b/src/routes/user/profile/+page.server.ts
@@ -10,6 +10,7 @@ import {
 	requirementFields,
 	upsertOwnerRequirements
 } from '$lib/server/lendingRequirements';
+import { getUserPreferences, upsertUserPreferences } from '$lib/server/userPreferences';
 
 export async function load({ locals, url }) {
 	// Fetch directly so the profile page always has fresh data regardless of
@@ -26,11 +27,20 @@ export async function load({ locals, url }) {
 	const inviteUrl = `${url.origin}/invite/${inviteCode}`;
 	const contact = await getOwnContact(locals.pb, locals.user.id);
 	const lendingRequirements = await getOwnerRequirements(locals.pb, locals.user.id);
+	// Fetch preferences fresh too (same freshness reason as currentUser above); returned
+	// under the same key the layout uses so the page value wins for this route (#426).
+	// Distinct requestKey from the layout's fetch to avoid PB SSR auto-cancellation.
+	const currentUserPreferences = await getUserPreferences(
+		locals.pb,
+		locals.user.id,
+		'user-preferences-profile'
+	);
 
 	return {
 		PB_URL: PUBLIC_PB_URL,
 		inviteUrl,
 		currentUser,
+		currentUserPreferences,
 		contact,
 		requirementSettings: getRequirementSettings(lendingRequirements),
 	};
@@ -166,11 +176,12 @@ export const actions = {
 			geo = null;
 		}
 
-		// Handle preferred transport mode
-		const preferredTransportMode = formData?.get('preferredTransportMode')?.toString();
-		if (preferredTransportMode === 'foot' || preferredTransportMode === 'bicycle' || preferredTransportMode === 'car') {
-			updateData['preferredTransportMode'] = preferredTransportMode;
-		}
+		// Preferred transport mode → user_preferences sidecar (issue #426), not users.
+		const rawTransportMode = formData?.get('preferredTransportMode')?.toString();
+		const preferredTransportMode =
+			rawTransportMode === 'foot' || rawTransportMode === 'bicycle' || rawTransportMode === 'car'
+				? rawTransportMode
+				: undefined;
 
 		// Handle bio
 		const bio = formData?.get('bio')?.toString();
@@ -222,6 +233,9 @@ export const actions = {
 			// returns a spurious "nothing to update".
 			await upsertOwnContact(locals.pb, locals.user.id, contact);
 			await upsertOwnerRequirements(locals.pb, locals.user.id, requirementData);
+			if (preferredTransportMode) {
+				await upsertUserPreferences(locals.pb, locals.user.id, { preferredTransportMode });
+			}
 			return {
 				success: true,
 				message: texts.success.dataUpdated,

--- a/src/routes/user/profile/+page.svelte
+++ b/src/routes/user/profile/+page.svelte
@@ -22,7 +22,7 @@
 	let { data, form } = $props();
 
 	let selectedTransportMode = $state<TransportMode>(
-		(data.currentUser.preferredTransportMode as TransportMode | undefined) ??
+		(data.currentUserPreferences?.preferredTransportMode as TransportMode | undefined) ??
 			'bicycle'
 	);
 
@@ -121,7 +121,7 @@
 			{texts.pages.profile.title}
 		</h1>
 
-		{#if !data.currentUser.hasOnboarded}
+		{#if !data.currentUserPreferences?.hasOnboarded}
 			<a
 				href={resolve('/onboarding')}
 				class="flex items-center justify-center gap-2 w-full mb-6 py-3 px-6 min-button bg-primary-200 hover:bg-primary-300 text-white font-semibold rounded-xl hover:opacity-90 transition-opacity"

--- a/src/routes/user/profile/page.server.test.ts
+++ b/src/routes/user/profile/page.server.test.ts
@@ -24,10 +24,15 @@ vi.mock('$lib/server/lendingRequirements', () => ({
 	getOwnerRequirements: vi.fn(() => Promise.resolve({})),
 	getRequirementSettings: vi.fn(() => []),
 }));
+vi.mock('$lib/server/userPreferences', () => ({
+	upsertUserPreferences: vi.fn(() => Promise.resolve()),
+	getUserPreferences: vi.fn(() => Promise.resolve(null)),
+}));
 
 import { actions } from './+page.server';
 import { upsertOwnContact } from '$lib/server/contacts';
 import { upsertOwnerRequirements } from '$lib/server/lendingRequirements';
+import { upsertUserPreferences } from '$lib/server/userPreferences';
 
 type SaveEvent = Parameters<typeof actions.saveProfile>[0];
 
@@ -139,6 +144,22 @@ describe('profile: saveProfile action', () => {
 		expect(update).toHaveBeenCalledTimes(1);
 		const submitted = (update.mock.calls[0] as unknown[])[1] as FormData;
 		expect(submitted.get('profileImage')).toBe('');
+	});
+
+	it('upserts a valid transport mode to user_preferences (not the users row) (#426)', async () => {
+		const { result, pb } = callSave({ username: 'validname', preferredTransportMode: 'car' });
+
+		expect(await result).toMatchObject({ success: true });
+		expect(upsertUserPreferences).toHaveBeenCalledWith(pb, USER_ID, {
+			preferredTransportMode: 'car',
+		});
+	});
+
+	it('does not touch user_preferences when no valid transport mode is submitted (#426)', async () => {
+		const { result } = callSave({ username: 'validname', preferredTransportMode: 'spaceship' });
+
+		expect(await result).toMatchObject({ success: true });
+		expect(upsertUserPreferences).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/routes/users/[id]/+page.server.ts
+++ b/src/routes/users/[id]/+page.server.ts
@@ -97,7 +97,7 @@ export async function load({ params, locals }) {
 	// Strip fields that must not reach the client: sensitive data and fields not used by this page.
 	const fieldsToStrip = [
 		'email', 'geolocation', 'inviteCode', 'invitedBy',
-		'hasOnboarded', 'telegramUsername', 'signalLink',
+		'telegramUsername', 'signalLink',
 		'telegramVisibleToTrustedOnly', 'signalVisibleToTrustedOnly',
 	];
 	for (const field of fieldsToStrip) {


### PR DESCRIPTION
## What & why

Closes #426 (the `users` table had grown large; pull settings into a sidecar).
Moves `preferredTransportMode` and `hasOnboarded` out of `users` into the existing
owner-only `user_preferences` collection (which already held `emailNotifications`).
Both fields used to ride on the `locals.user` auth record for free; they now live in
their own collection, so every reader fetches them and every writer upserts them.

Backend counterpart (schema migration + hooks):
share-open-sharing-infrastructure/allerleih-backend#29 — **must be applied first.**

## Changes

- **`$lib/server/userPreferences.ts`** — `getUserPreferences` / `upsertUserPreferences`,
  modeled on `lendingRequirements`' owner-row upsert (unique-index create-race fallback).
  Takes a per-call-site `requestKey` so the concurrent layout+page reads don't
  auto-cancel each other under PocketBase SSR.
- **Reads** — `+layout.server.ts` surfaces the row app-wide as `currentUserPreferences`
  (drives the onboarding prompt); `items/[id]` and `profile` fetch it directly; `search`
  and `onboarding` read the layout value. All tolerate a null row (defaults:
  transport → `bicycle`, `emailNotifications` opted-in, `hasOnboarded` falsy).
- **Writes** — onboarding (`saveTransportMode` + `complete`), search (fire-and-forget),
  and profile (extracted out of the batched `users` update) now `upsertUserPreferences`.
- Types (`UserPreferences`, `App.PageData`), `docs/data-model.md` (new `USER_PREFERENCES`
  block), and the seed `createUser` factory updated; a dead `hasOnboarded` strip removed.
- **Tests** — new `userPreferences` unit tests + layout / profile-action / item-guard
  call-site coverage.

## Test notes

Preflight: `npm run lint` ✓, `npx vitest run` **508/508** ✓, `npm run build` ✓.
`npm run check` reports only 6 pre-existing `$env/static/private` errors
(`PB_SUPERUSER_*`, `SYNC_SECRET`) in untouched integration-sync files — a local
`.env` gap, present on `main`, resolved by CI's secrets; no errors from this change.

Verified end-to-end in a browser against a real-schema PocketBase seeded from actual
`pb_data`: migration moved the fields for all existing users with `emailNotifications`
preserved as opted-in; the onboarding prompt appears/disappears with `hasOnboarded`;
profile transport save lands in `user_preferences` (not `users`); the onboarding
`complete` flow round-trips with a single (non-duplicated) prefs row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
