### PR TITLE
fix(redirect): stop logging messenger links to outbound_clicks (#520)

### DIFF
--- a/src/routes/api/redirect/+server.ts
+++ b/src/routes/api/redirect/+server.ts
@@ -1,6 +1,30 @@
 import { error, redirect } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
+// Messenger deep links are personal contact data (a Signal handle or Telegram
+// username), and for trustees-only handles they are outright private. They must
+// never be persisted to outbound_clicks, which only exists to track outbound
+// links to partner/institution offers (issue #520). We recognise them by the
+// `conversation` source (the only messenger caller) and, as defence-in-depth
+// against a hand-crafted source param, by destination host.
+const MESSENGER_HOSTS = new Set([
+	't.me',
+	'telegram.me',
+	'signal.me',
+	'signal.group',
+]);
+
+function isMessengerClick(source: string, to: string): boolean {
+	if (source === 'conversation') return true;
+	try {
+		const host = new URL(to).hostname.toLowerCase().replace(/^www\./, '');
+		return MESSENGER_HOSTS.has(host);
+	} catch {
+		// Unparseable destination — err on the side of not logging.
+		return true;
+	}
+}
+
 export const GET: RequestHandler = async ({ url, locals }) => {
 	const to = url.searchParams.get('to');
 	const source = url.searchParams.get('source') ?? 'unknown';
@@ -9,16 +33,19 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 	if (!to) throw error(400, 'Missing destination');
 
 	// signalLink is user-supplied — block non-https to prevent open-redirect abuse
-	if (!to.startsWith('https://')) throw error(400, 'Only https destinations allowed');
+	if (!to.startsWith('https://'))
+		throw error(400, 'Only https destinations allowed');
 
-	locals.pb
-		.collection('outbound_clicks')
-		.create({
-			destination: to,
-			source_page: source,
-			item: itemId ?? undefined,
-		})
-		.catch(() => {});
+	if (!isMessengerClick(source, to)) {
+		locals.pb
+			.collection('outbound_clicks')
+			.create({
+				destination: to,
+				source_page: source,
+				item: itemId ?? undefined,
+			})
+			.catch(() => {});
+	}
 
 	throw redirect(302, to);
 };

--- a/src/routes/api/redirect/server.test.ts
+++ b/src/routes/api/redirect/server.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from './+server';
+
+function makeLocals() {
+	const create = vi.fn().mockResolvedValue({});
+	const collection = vi.fn(() => ({ create }));
+	const pb = { collection };
+	return { locals: { pb }, create, collection };
+}
+
+function makeUrl(params: Record<string, string | null>): URL {
+	const search = new URLSearchParams();
+	for (const [k, v] of Object.entries(params)) if (v !== null) search.set(k, v);
+	return new URL(`https://allerleih.org/api/redirect?${search.toString()}`);
+}
+
+let create: ReturnType<typeof makeLocals>['create'];
+let collection: ReturnType<typeof makeLocals>['collection'];
+let locals: ReturnType<typeof makeLocals>['locals'];
+
+beforeEach(() => {
+	({ create, collection, locals } = makeLocals());
+});
+
+function get(params: Record<string, string | null>) {
+	return GET({ url: makeUrl(params), locals } as never);
+}
+
+describe('GET /api/redirect', () => {
+	it('rejects a missing destination with 400 and logs nothing', async () => {
+		await expect(get({})).rejects.toMatchObject({ status: 400 });
+		expect(create).not.toHaveBeenCalled();
+	});
+
+	it('rejects a non-https destination with 400 (open-redirect guard) and logs nothing', async () => {
+		await expect(
+			get({ to: 'http://evil.example/', source: 'item-detail' })
+		).rejects.toMatchObject({
+			status: 400,
+		});
+		expect(create).not.toHaveBeenCalled();
+	});
+
+	it('logs a partner link and redirects (302)', async () => {
+		await expect(
+			get({
+				to: 'https://verleih.example/form',
+				source: 'item-detail',
+				item: 'itm123',
+			})
+		).rejects.toMatchObject({
+			status: 302,
+			location: 'https://verleih.example/form',
+		});
+		expect(collection).toHaveBeenCalledWith('outbound_clicks');
+		expect(create).toHaveBeenCalledWith({
+			destination: 'https://verleih.example/form',
+			source_page: 'item-detail',
+			item: 'itm123',
+		});
+	});
+
+	it('logs a footer/social link with no item as item: undefined and redirects (302)', async () => {
+		await expect(
+			get({ to: 'https://norden.social/@AllerLeih', source: 'footer' })
+		).rejects.toMatchObject({
+			status: 302,
+		});
+		expect(collection).toHaveBeenCalledWith('outbound_clicks');
+		expect(create).toHaveBeenCalledWith({
+			destination: 'https://norden.social/@AllerLeih',
+			source_page: 'footer',
+			item: undefined,
+		});
+	});
+
+	it('does NOT log a messenger click from the conversation source (issue #520)', async () => {
+		await expect(
+			get({
+				to: 'https://signal.me/#eu/abc',
+				source: 'conversation',
+				item: 'itm1',
+			})
+		).rejects.toMatchObject({
+			status: 302,
+			location: 'https://signal.me/#eu/abc',
+		});
+		expect(create).not.toHaveBeenCalled();
+	});
+
+	it('does NOT log a conversation-source click even when the destination is not a messenger host', async () => {
+		// Isolates the `source === 'conversation'` branch: verleih.example is NOT a
+		// messenger host, so only the source check keeps this out of outbound_clicks.
+		await expect(
+			get({
+				to: 'https://verleih.example/form',
+				source: 'conversation',
+				item: 'itm9',
+			})
+		).rejects.toMatchObject({
+			status: 302,
+		});
+		expect(create).not.toHaveBeenCalled();
+	});
+
+	it('does NOT log a messenger host even if the source param is spoofed', async () => {
+		await expect(
+			get({ to: 'https://t.me/someuser', source: 'item-detail' })
+		).rejects.toMatchObject({
+			status: 302,
+		});
+		expect(create).not.toHaveBeenCalled();
+
+		await expect(
+			get({ to: 'https://www.signal.me/#eu/x', source: 'footer' })
+		).rejects.toMatchObject({
+			status: 302,
+		});
+		expect(create).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary
Fixes #520 (frontend half — pairs with the backend PR).

Messenger deep links (Signal/Telegram) are personal contact data — for trustees-only handles outright private — yet they were being persisted to the `outbound_clicks` analytics table: the conversation-header messenger buttons route the deep link through `/api/redirect`, which logged the destination.

`/api/redirect` now skips the click log when the click is a **messenger click**, recognised by:
- `source === 'conversation'` (the only messenger caller), and
- as defence-in-depth against a hand-crafted `source` param, the destination **host** (`t.me`, `telegram.me`, `signal.me`, `signal.group`).

The https open-redirect guard and the 302 redirect are unchanged, and legitimate partner / footer / item-detail clicks are still logged.

## Companion PR
Needs the backend PR (`520-outbound-clicks-lock-list` on `allerleih-backend`), which locks `outbound_clicks` read access to superusers and purges the already-exposed messenger rows. Both are required for the complete fix.

## Tests
`src/routes/api/redirect/server.test.ts` (7 tests): partner & footer links logged with the exact payload (incl. `item: undefined`) to the `outbound_clicks` collection; messenger clicks not logged (conversation source, messenger host, spoofed source, and the source branch isolated with a non-messenger host); 400 guards for missing / non-https destinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)