### PR TITLE
fix(items): surface upload errors inline instead of a hidden top-of-modal alert (#522)

### DIFF
--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -617,6 +617,8 @@ export const texts = {
 			imageMaxReached: (n: number) => `Maximal ${n} Bilder pro Gegenstand.`,
 			imageReplaceHint: 'Neue Bilder ersetzen die vorhandenen.',
 			saveFailed: 'Der Gegenstand konnte nicht gespeichert werden. Bitte versuche es erneut.',
+			validationFailed:
+				'Es fehlen erforderliche Felder oder es wurden ungültige Bilddateien hochgeladen.',
 			search: 'Suchen...',
 			filterAll: 'Alle',
 			filterAvailable: 'Verfügbar',

--- a/src/routes/user/items/+page.server.ts
+++ b/src/routes/user/items/+page.server.ts
@@ -100,8 +100,7 @@ export const actions = {
 			return fail(400, {
 				fail: true,
 				missingFields: validationResult.errors,
-				message:
-					'Es fehlen erforderliche Felder oder es wurden ungültige Bilddateien hochgeladen.',
+				message: texts.pages.items.validationFailed,
 			});
 		}
 
@@ -144,8 +143,7 @@ export const actions = {
 			return fail(400, {
 				fail: true,
 				missingFields: validationResult.errors,
-				message:
-					'Es fehlen erforderliche Felder oder es wurden ungültige Bilddateien hochgeladen.',
+				message: texts.pages.items.validationFailed,
 			});
 		}
 

--- a/src/routes/user/items/ItemModal.svelte
+++ b/src/routes/user/items/ItemModal.svelte
@@ -57,6 +57,11 @@
 	// discarding the user's input.
 	let isDirty = $state(false);
 	let imageError = $state<string | null>(null);
+	// Submit-time failure message, shown inline right above the submit button. A bottom
+	// toast can't be used here: the Flowbite modal is a native <dialog> in the browser's
+	// top layer, which paints above any z-indexed toast overlay (#522). Local (not the
+	// shared page-level `form` prop) so it's scoped to THIS modal's own submit.
+	let submitError = $state<string | null>(null);
 	let fileInput = $state<HTMLInputElement | undefined>(undefined);
 	// Newly chosen images (a multi-file field). previews mirrors selectedFiles for display.
 	let selectedFiles = $state<File[]>([]);
@@ -174,6 +179,7 @@
 		if (!isVisible) {
 			form = null;
 			imageError = null;
+			submitError = null;
 			clearPreviews();
 		}
 	});
@@ -189,17 +195,6 @@
 		}
 	}}
 >
-	{#if form?.fail}
-		<div class="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200">
-			<p>{form.message}</p>
-			{#if form?.conversationIds?.length}
-				<a
-					href={resolve(`/conversations/${form.conversationIds[0]}`)}
-					class="mt-1 inline-block font-semibold underline"
-				>{texts.pages.items.linkToConversation}</a>
-			{/if}
-		</div>
-	{/if}
 	<form
 		class="flex flex-col gap-6 md:flex-row"
 		action="?/{type === 'edit' ? 'update' : 'create'}"
@@ -208,6 +203,7 @@
 		oninput={() => (isDirty = true)}
 		onchange={() => (isDirty = true)}
 		use:enhance={async ({ formData, cancel }) => {
+			submitError = null;
 			// Multi-file field: compress each chosen image and re-append under the same
 			// `itemImage` key. SVGs skip compression (canvas can't draw them reliably);
 			// anything the browser can't decode (e.g. iPhone HEIC) surfaces a clear error.
@@ -221,7 +217,7 @@
 					const compressed = await compressImage(file);
 					formData.append('itemImage', compressed, file.name);
 				} catch {
-					imageError = texts.bulkUpload.imageFormatUnsupported;
+					submitError = texts.bulkUpload.imageFormatUnsupported;
 					cancel();
 					return;
 				}
@@ -230,6 +226,12 @@
 				if (result.type === 'success') {
 					isDirty = false;
 					isVisible = false;
+				} else if (result.type === 'failure') {
+					// Show the failure inline right above the submit button (#522). Sourced
+					// from this form's own result — not the shared page-level `form` prop,
+					// which is fanned out to every row's modal and written by unrelated
+					// inline/bulk actions — so it stays tied to *this* submit.
+					submitError = (result.data as { message?: string } | undefined)?.message ?? null;
 				}
 				await update();
 			};
@@ -444,6 +446,17 @@
 				{/if}
 			{/if}
 
+			<!-- Submit failure shown right where the user is looking (next to the button),
+				 so it's never scrolled out of view like the old top-of-modal alert (#522). -->
+			{#if submitError}
+				<p
+					class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200"
+					role="alert"
+				>
+					{submitError}
+				</p>
+			{/if}
+
 			<!-- SUBMIT BUTTON -->
 			<Button class="min-button bg-primary-200 hover:bg-primary" type="submit">
 				{type === 'edit' ? texts.buttons.save : texts.buttons.add}
@@ -453,6 +466,17 @@
 
 	<!-- DELETE BUTTON -->
 	{#if type === 'edit'}
+		<!-- Delete-blocked alert sits by the delete button (not the modal top) so it's in
+			 view right after the click, and carries the actionable conversation link. -->
+		{#if form?.fail && form?.conversationIds?.length}
+			<div class="mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200" role="alert">
+				<p>{form.message}</p>
+				<a
+					href={resolve(`/conversations/${form.conversationIds[0]}`)}
+					class="mt-1 inline-block font-semibold underline"
+				>{texts.pages.items.linkToConversation}</a>
+			</div>
+		{/if}
 		<form
 			method="POST"
 			action="?/delete"

--- a/src/routes/user/items/page.server.test.ts
+++ b/src/routes/user/items/page.server.test.ts
@@ -142,6 +142,8 @@ describe('user items: create action (multi-image)', () => {
 
 		expect(result?.status).toBe(400);
 		expect(failData(result).missingFields?.imageIsMissing).toBe(true);
+		// The message the modal surfaces inline by the submit button (#522) — pin it down.
+		expect(failData(result).message).toBe(texts.pages.items.validationFailed);
 		expect(createMock).not.toHaveBeenCalled();
 	});
 
@@ -260,6 +262,7 @@ describe('user items: create/update validation & guards', () => {
 
 		expect(result?.status).toBe(400);
 		expect(failData(result).missingFields?.nameIsMissing).toBe(true);
+		expect(failData(result).message).toBe(texts.pages.items.validationFailed);
 		expect(updateMock).not.toHaveBeenCalled();
 	});
 


### PR DESCRIPTION
## What & why

Fixes #522. When uploading an item "the regular way" (**Meine Dinge → Dinge einzeln hochladen**) without a required field (e.g. no image), the failure message was rendered as an alert at the **top** of the modal — but the submit button sits at the **bottom**. A user who scrolled down to submit never saw the error.

## Changes

- **`ItemModal.svelte`**: submit failures now show as an inline alert **right above the submit button** (always in view), driven by **per-instance local state** set from the form's own `use:enhance` result — not the shared page-level `form` prop that is fanned out to every row's edit modal and written by unrelated inline/bulk actions. The submit-time image-compression error routes through the same alert.
- The **delete-blocked** alert moves next to the delete button (same visibility reason) and keeps its actionable conversation link.
- **`+page.server.ts` / `texts.ts`**: the hard-coded German validation message moves into `texts.pages.items.validationFailed` (texts.ts guardrail).
- **`page.server.test.ts`**: assert the validation-failure message on create + update.

## Why not the toast overlay suggested in the issue

The issue suggested reusing the app's toast overlay. That **can't work above this modal**: Flowbite's `Modal` is a native `<dialog>` opened via `showModal()`, so it lives in the browser **top layer**, which paints above any `z-index`ed toast (`ToastHost` is `z-50`). Verified with Playwright — at the toast's center, `elementFromPoint` returned the dialog backdrop. Making toasts render above modals app-wide is a separate infrastructure change, tracked in #523.

## Testing

- Vitest: `516 passed` (incl. new message assertions); lint + build clean.
- Manual Playwright run against the real-schema local stack (login → single upload without image), **mobile (420×720) and desktop (1280×900)**: the inline alert is visible, is the top-most element at its center (not occluded by the dialog), sits ~24px above the submit button, and the modal stays open with input preserved. Happy path (with image) still creates the item and closes the modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)