### PR TITLE
test(e2e): Playwright end-to-end suite (16 feature areas)

### DIFF
--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,18 +1,69 @@
-import { test as setup, expect } from '@playwright/test';
-import { OWNER, STORAGE_STATE } from './fixtures/users';
+import { test as setup, expect, type Page } from '@playwright/test';
+import {
+	OWNER,
+	VIEWER,
+	THIRD,
+	STRANGER,
+	NEWBIE,
+	LOCKED,
+	INSTITUTION,
+	STORAGE_STATE,
+	VIEWER_STORAGE_STATE,
+	THIRD_STORAGE_STATE,
+	STRANGER_STORAGE_STATE,
+	NEWBIE_STORAGE_STATE,
+	LOCKED_STORAGE_STATE,
+	INSTITUTION_STORAGE_STATE,
+} from './fixtures/users';
 
 /**
- * Logs in as the seeded owner through the real login form and saves the authenticated
- * storage state, which the `authenticated` project reuses so each test starts logged in.
+ * Logs a seeded user in through the real login form and saves the authenticated
+ * storage state, which the `authenticated` / `multiuser` projects reuse so their
+ * tests start logged in. One setup test per role produces one storageState file.
  */
-setup('authenticate as owner', async ({ page }) => {
+async function login(
+	page: Page,
+	email: string,
+	password: string,
+	statePath: string
+) {
 	await page.goto('/auth/login');
-	await page.getByRole('textbox', { name: 'E-Mail' }).fill(OWNER.email);
-	await page.getByRole('textbox', { name: 'Passwort' }).fill(OWNER.password);
+	await page.getByRole('textbox', { name: 'E-Mail' }).fill(email);
+	await page.getByRole('textbox', { name: 'Passwort' }).fill(password);
 	await page.getByRole('button', { name: 'Anmelden' }).click();
 
 	// A successful login redirects to the home page; the "Login" nav link then disappears.
 	await expect(page.getByRole('link', { name: 'Login' })).toHaveCount(0);
 
-	await page.context().storageState({ path: STORAGE_STATE });
+	await page.context().storageState({ path: statePath });
+}
+
+setup('authenticate as owner', async ({ page }) => {
+	await login(page, OWNER.email, OWNER.password, STORAGE_STATE);
+});
+
+setup('authenticate as viewer', async ({ page }) => {
+	await login(page, VIEWER.email, VIEWER.password, VIEWER_STORAGE_STATE);
+});
+
+setup('authenticate as third user', async ({ page }) => {
+	await login(page, THIRD.email, THIRD.password, THIRD_STORAGE_STATE);
+});
+
+setup('authenticate as stranger', async ({ page }) => {
+	await login(page, STRANGER.email, STRANGER.password, STRANGER_STORAGE_STATE);
+});
+
+setup('authenticate as newbie', async ({ page }) => {
+	await login(page, NEWBIE.email, NEWBIE.password, NEWBIE_STORAGE_STATE);
+});
+
+setup('authenticate as locked user', async ({ page }) => {
+	// A locked account can still authenticate; the consent gate then routes it to
+	// /legal/locked (so the "Login" link is still gone — the assertion in login() holds).
+	await login(page, LOCKED.email, LOCKED.password, LOCKED_STORAGE_STATE);
+});
+
+setup('authenticate as institution', async ({ page }) => {
+	await login(page, INSTITUTION.email, INSTITUTION.password, INSTITUTION_STORAGE_STATE);
 });

--- a/e2e/fixtures/users.ts
+++ b/e2e/fixtures/users.ts
@@ -16,5 +16,45 @@ export const VIEWER = {
 	password: SEED_PASSWORD,
 };
 
-/** Where the authenticated storageState produced by auth.setup.ts is written. */
+export const THIRD = {
+	username: 'e2e_third_seed',
+	email: 'e2e_third_seed@seed.test',
+	password: SEED_PASSWORD,
+};
+
+/** A stably-untrusted bystander: no test mutates it, so parallel tests can rely on it. */
+export const STRANGER = {
+	username: 'e2e_stranger_seed',
+	email: 'e2e_stranger_seed@seed.test',
+	password: SEED_PASSWORD,
+};
+
+/** A fresh, un-onboarded user (hasOnboarded:false) for the onboarding wizard. */
+export const NEWBIE = {
+	username: 'e2e_newbie_seed',
+	email: 'e2e_newbie_seed@seed.test',
+	password: SEED_PASSWORD,
+};
+
+/** A locked account (declined legal terms) — gated to /legal/locked. */
+export const LOCKED = {
+	username: 'e2e_locked_seed',
+	email: 'e2e_locked_seed@seed.test',
+	password: SEED_PASSWORD,
+};
+
+/** An institutional account — unlocks the CSV bulk-import UI at /user/import. */
+export const INSTITUTION = {
+	username: 'e2e_institution_seed',
+	email: 'e2e_institution_seed@seed.test',
+	password: SEED_PASSWORD,
+};
+
+/** Where the authenticated storageStates produced by auth.setup.ts are written. */
 export const STORAGE_STATE = 'e2e/.auth/owner.json';
+export const VIEWER_STORAGE_STATE = 'e2e/.auth/viewer.json';
+export const THIRD_STORAGE_STATE = 'e2e/.auth/third.json';
+export const STRANGER_STORAGE_STATE = 'e2e/.auth/stranger.json';
+export const NEWBIE_STORAGE_STATE = 'e2e/.auth/newbie.json';
+export const LOCKED_STORAGE_STATE = 'e2e/.auth/locked.json';
+export const INSTITUTION_STORAGE_STATE = 'e2e/.auth/institution.json';

--- a/e2e/tests/account.spec.ts
+++ b/e2e/tests/account.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+import { STRANGER_STORAGE_STATE, STRANGER } from '../fixtures/users';
+
+/**
+ * Account — the GDPR data export (Art. 15/20). Fetches the export endpoint from within
+ * the authenticated page context (so the pb_auth cookie is sent) and confirms it returns
+ * the user's own data. (Account deletion is destructive and covered separately.)
+ */
+
+test.describe('account', () => {
+	test('data export returns the user’s data', async ({ browser }) => {
+		const ctx = await browser.newContext({ storageState: STRANGER_STORAGE_STATE });
+		const page = await ctx.newPage();
+		try {
+			await page.goto('/');
+			const body = await page.evaluate(() =>
+				fetch('/user/account/export').then((r) => r.text())
+			);
+			// The export includes the account's own identifying data.
+			expect(body).toContain(STRANGER.email);
+		} finally {
+			await ctx.close();
+		}
+	});
+});

--- a/e2e/tests/external-fallbacks.spec.ts
+++ b/e2e/tests/external-fallbacks.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+import { STORAGE_STATE } from '../fixtures/users';
+
+/**
+ * Tier-3 external services — assert the app degrades gracefully rather than driving the
+ * real third-party round-trip (not deterministic locally). The geocode endpoint (ORS)
+ * always returns a `{ suggestions: [] }`-shaped body and swallows errors, so with or
+ * without an ORS key it yields a suggestions array. Fetched from the authenticated page
+ * context so the auth cookie is sent.
+ */
+
+test.describe('external service fallbacks (T3)', () => {
+	test('the geocode endpoint returns a suggestions array', async ({ browser }) => {
+		const ctx = await browser.newContext({ storageState: STORAGE_STATE });
+		const page = await ctx.newPage();
+		try {
+			await page.goto('/');
+			const json = await page.evaluate(() =>
+				fetch('/api/geocode?q=Berlin').then((r) => r.json())
+			);
+			expect(Array.isArray(json.suggestions)).toBeTruthy();
+		} finally {
+			await ctx.close();
+		}
+	});
+});

--- a/e2e/tests/feedback.spec.ts
+++ b/e2e/tests/feedback.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Feedback — the home-page feedback modal creates a feedback record. Runs in the
+ * `authenticated` project, so `page` is the owner ('/' requires auth). The modal opens
+ * via client state, so retry the opener until it appears (dev hydration race).
+ */
+
+test.describe('feedback', () => {
+	test('submitting feedback from the home page shows a success message', async ({ page }) => {
+		await page.goto('/');
+
+		const dialog = page.getByRole('dialog');
+		await expect(async () => {
+			await page.getByRole('button', { name: 'Feedback' }).first().click();
+			await expect(dialog).toBeVisible({ timeout: 1000 });
+		}).toPass({ timeout: 15_000 });
+
+		await dialog.locator('textarea#feedbackMessage').fill('E2E Feedback: alles gut');
+		await dialog.getByRole('button', { name: 'Feedback absenden' }).click();
+
+		await expect(
+			dialog.getByText('Feedback erfolgreich gesendet. Vielen Dank!')
+		).toBeVisible();
+	});
+});

--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test';
+import { STORAGE_STATE, THIRD_STORAGE_STATE, VIEWER } from '../fixtures/users';
+
+/**
+ * Groups — the owner-managed lifecycle and the invite-token join.
+ *
+ * Runs in the `multiuser` project and opens its own per-role contexts:
+ *  - the management test drives everything from a fresh group it creates itself, so it
+ *    needs no pre-seeded group id;
+ *  - the join test uses the seeded private group's fixed invite token (see e2e.js).
+ */
+
+// Kept in sync with scripts/seed/scenarios/e2e.js (backend requires exactly 24 chars).
+const INVITE_TOKEN = 'e2ejointoken000000000000';
+const PRIVATE_GROUP = 'E2E Werkzeuggruppe';
+
+/**
+ * In dev a route compiles on first hit, so an early click/fill can land before Svelte
+ * hydrates the handler (or hydration resets a too-early input). Retry the interaction
+ * until the expected result appears.
+ */
+async function untilReady(action: () => Promise<void>, expectation: () => Promise<void>) {
+	await expect(async () => {
+		await action();
+		await expectation();
+	}).toPass({ timeout: 15_000 });
+}
+
+test.describe('groups', () => {
+	test('owner creates a group, manages a member, mints an invite, deletes it', async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext({ storageState: STORAGE_STATE });
+		const page = await ctx.newPage();
+		page.on('dialog', (d) => d.accept()); // leave/remove/delete use confirm()
+		try {
+			const groupName = `E2E Gruppe ${Date.now()}`;
+			const dialog = page.getByRole('dialog');
+
+			// Create — retry the opener until the modal actually opens.
+			await page.goto('/user/groups');
+			await untilReady(
+				() => page.getByRole('button', { name: 'Gruppe erstellen' }).first().click(),
+				() => expect(dialog).toBeVisible({ timeout: 1000 })
+			);
+			await dialog.getByPlaceholder('z. B. Nachbarschaft Nord').fill(groupName);
+			await dialog.getByRole('button', { name: 'Gruppe erstellen' }).click();
+			await expect(dialog).toBeHidden();
+
+			// The new group shows in the owned list; open it and grab its id.
+			const card = page.getByRole('link', { name: groupName });
+			await expect(card).toBeVisible();
+			await card.click();
+			await expect(page).toHaveURL(/\/user\/groups\/[^/]+$/);
+			const groupId = page.url().split('/').pop();
+
+			// Members: add the viewer (retry the search until the candidate appears), then remove.
+			await page.goto(`/user/groups/${groupId}/members`);
+			const addBtn = page.getByRole('button', { name: `@${VIEWER.username}` });
+			await untilReady(
+				() => page.getByPlaceholder('Nutzername suchen…').fill(VIEWER.username),
+				() => expect(addBtn).toBeVisible({ timeout: 1000 })
+			);
+			await addBtn.click();
+			const memberRow = page
+				.getByRole('listitem')
+				.filter({ hasText: VIEWER.username });
+			await expect(memberRow).toBeVisible();
+			await memberRow.getByRole('button', { name: 'Entfernen' }).click();
+			await expect(memberRow).toHaveCount(0);
+
+			// Settings: mint an invite link (progressive-enhanced form → the revoke control appears).
+			await page.goto(`/user/groups/${groupId}/settings`);
+			await page.getByRole('button', { name: 'Einladungslink erstellen' }).click();
+			await expect(page.getByRole('button', { name: 'Link widerrufen' })).toBeVisible();
+
+			// Delete → back to the list, group gone.
+			await page.getByRole('button', { name: 'Gruppe löschen' }).click();
+			await expect(page).toHaveURL(/\/user\/groups$/);
+			await expect(page.getByRole('link', { name: groupName })).toHaveCount(0);
+		} finally {
+			await ctx.close();
+		}
+	});
+
+	test('a logged-in user joins a private group via its invite token', async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext({ storageState: THIRD_STORAGE_STATE });
+		const page = await ctx.newPage();
+		try {
+			await page.goto(`/groups/join/${INVITE_TOKEN}`);
+			await expect(page.getByText(new RegExp(PRIVATE_GROUP))).toBeVisible();
+			await page.getByRole('button', { name: 'Gruppe beitreten' }).click();
+			await expect(
+				page.getByText(new RegExp(`Gruppe .${PRIVATE_GROUP}. beigetreten`))
+			).toBeVisible();
+		} finally {
+			await ctx.close();
+		}
+	});
+});

--- a/e2e/tests/import.spec.ts
+++ b/e2e/tests/import.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+import { INSTITUTION_STORAGE_STATE } from '../fixtures/users';
+
+/**
+ * Institutional CSV import (/user/import) — an institution uploads a WINBIAP-shaped CSV,
+ * previews the per-row actions, and applies it. Runs as the seeded institution account in
+ * the `multiuser` project. Created items are owned by the seed institution, so the seed
+ * teardown removes them on the next run.
+ */
+
+const CSV = [
+	'externalId,name,description,place,categories,status,trusteesOnly',
+	'e2e-imp-1,E2E Import Bohrer,Testbohrer,Lüneburg,Werkzeug und Garten,available,false',
+	'e2e-imp-2,E2E Import Zelt,Testzelt,Lüneburg,Reisen und Outdoor,available,false',
+].join('\n');
+
+test.describe('institutional import', () => {
+	test('an institution previews and applies a CSV import', async ({ browser }) => {
+		const ctx = await browser.newContext({ storageState: INSTITUTION_STORAGE_STATE });
+		const page = await ctx.newPage();
+		try {
+			await page.goto('/user/import');
+			await expect(
+				page.getByRole('heading', { name: 'Bestand als CSV importieren' })
+			).toBeVisible();
+
+			// Upload the CSV; the preview button enables once the file is picked (needs hydration).
+			const preview = page.getByRole('button', { name: 'Vorschau laden' });
+			await expect(async () => {
+				await page.locator('input#csv').setInputFiles({
+					name: 'import.csv',
+					mimeType: 'text/csv',
+					buffer: Buffer.from(CSV, 'utf-8'),
+				});
+				await expect(preview).toBeEnabled({ timeout: 1000 });
+			}).toPass({ timeout: 15_000 });
+			await preview.click();
+
+			// Preview lists the CSV rows.
+			await expect(page.getByText('E2E Import Bohrer')).toBeVisible();
+			await expect(page.getByText('E2E Import Zelt')).toBeVisible();
+
+			// Apply → done.
+			await page.getByRole('button', { name: 'Importieren' }).click();
+			await expect(
+				page.getByRole('heading', { name: 'Import abgeschlossen' })
+			).toBeVisible();
+		} finally {
+			await ctx.close();
+		}
+	});
+});

--- a/e2e/tests/item-upload.spec.ts
+++ b/e2e/tests/item-upload.spec.ts
@@ -1,0 +1,220 @@
+import { test, expect, type Page, type Locator } from '@playwright/test';
+
+/**
+ * Item upload improvements (#246): the single-item modal on /user/items and the
+ * AI-upload dropzone. Runs with the seeded owner's storage state (auth.setup.ts).
+ */
+
+const PNG_B64 =
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+const PNG_1x1 = Buffer.from(PNG_B64, 'base64');
+const IMAGE_UPLOAD = 'Bilder hochladen oder hierher ziehen'; // dropzone aria-label
+
+// In dev the route compiles on first hit, so an early click can land before Svelte
+// hydrates the handler. Retry the opener click until the modal actually opens.
+async function openModal(page: Page, opener: Locator) {
+	await expect(opener).toBeVisible();
+	await expect(async () => {
+		await opener.click();
+		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 1000 });
+	}).toPass({ timeout: 15_000 });
+	return page.getByRole('dialog');
+}
+
+function openAddModal(page: Page) {
+	return openModal(page, page.getByRole('button', { name: /Dinge einzeln hochladen/ }));
+}
+
+test.describe('item upload (#246)', () => {
+	test('desktop layout puts the image column left of the fields', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 900 });
+		await page.goto('/user/items');
+		const dialog = await openAddModal(page);
+
+		const imgBox = await dialog.locator('img').first().boundingBox();
+		const nameBox = await dialog.getByRole('textbox', { name: 'Name:' }).boundingBox();
+		expect(imgBox).not.toBeNull();
+		expect(nameBox).not.toBeNull();
+		// Image column is entirely to the LEFT of the fields (side-by-side, not stacked).
+		expect(imgBox!.x + imgBox!.width).toBeLessThanOrEqual(nameBox!.x + 5);
+	});
+
+	test('clicking the image area opens the (multiple) file picker', async ({ page }) => {
+		await page.goto('/user/items');
+		const dialog = await openAddModal(page);
+
+		const chooserPromise = page.waitForEvent('filechooser');
+		await dialog.getByRole('button', { name: IMAGE_UPLOAD }).click();
+		const chooser = await chooserPromise;
+		expect(chooser.isMultiple()).toBe(true);
+	});
+
+	test('drag & drop adds an image thumbnail', async ({ page }) => {
+		await page.goto('/user/items');
+		const dialog = await openAddModal(page);
+
+		const dataTransfer = await page.evaluateHandle((b64) => {
+			const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+			const dt = new DataTransfer();
+			dt.items.add(new File([bytes], 'drop.png', { type: 'image/png' }));
+			return dt;
+		}, PNG_B64);
+
+		const dropzone = dialog.getByRole('button', { name: IMAGE_UPLOAD });
+		await dropzone.dispatchEvent('dragover', { dataTransfer });
+		await dropzone.dispatchEvent('drop', { dataTransfer });
+
+		await expect(dialog.getByRole('button', { name: 'Bild entfernen' })).toHaveCount(1);
+	});
+
+	test('uploads a new item with multiple images and shows a working gallery', async ({ page }) => {
+		await page.goto('/user/items');
+		const dialog = await openAddModal(page);
+		await expect(dialog.getByRole('heading', { name: 'Neuer Gegenstand' })).toBeVisible();
+
+		await dialog.locator('input[type="file"]').setInputFiles([
+			{ name: 'a.png', mimeType: 'image/png', buffer: PNG_1x1 },
+			{ name: 'b.png', mimeType: 'image/png', buffer: PNG_1x1 },
+		]);
+		await expect(dialog.getByRole('button', { name: 'Bild entfernen' })).toHaveCount(2);
+
+		const name = `E2E Multi-Upload ${Date.now()}`;
+		await dialog.getByRole('textbox', { name: 'Name:' }).fill(name);
+		await dialog.getByRole('textbox', { name: 'Beschreibung:' }).fill('Playwright (#246)');
+		await dialog.getByRole('button', { name: 'Hinzufügen' }).click();
+
+		// Modal closes and the item appears in the list with a rendered cover thumbnail.
+		await expect(dialog).toBeHidden();
+		const row = page.locator('div', { hasText: name }).filter({
+			has: page.getByRole('link', { name }),
+		});
+		const cover = row.locator('img').first();
+		await expect
+			.poll(() => cover.evaluate((el) => (el as HTMLImageElement).naturalWidth))
+			.toBeGreaterThan(0);
+
+		// Detail page: gallery with one thumbnail per image; the hero image really renders.
+		await page.getByRole('link', { name }).first().click();
+		await expect(page).toHaveURL(/\/items\/[^/]+$/);
+		const hero = page.locator('main img').first();
+		await expect
+			.poll(() => hero.evaluate((el) => (el as HTMLImageElement).naturalWidth), { timeout: 10_000 })
+			.toBeGreaterThan(0);
+
+		const thumbs = page.getByRole('button', { name: /Bild \d+ anzeigen/ });
+		await expect(thumbs).toHaveCount(2);
+		const src1 = await hero.getAttribute('src');
+		await thumbs.nth(1).click();
+		await expect.poll(() => hero.getAttribute('src')).not.toBe(src1);
+	});
+
+	test('caps image selection at 5 and warns', async ({ page }) => {
+		await page.goto('/user/items');
+		const dialog = await openAddModal(page);
+
+		const files = Array.from({ length: 7 }, (_, i) => ({
+			name: `f${i}.png`,
+			mimeType: 'image/png',
+			buffer: PNG_1x1,
+		}));
+		await dialog.locator('input[type="file"]').setInputFiles(files);
+
+		await expect(dialog.getByRole('button', { name: 'Bild entfernen' })).toHaveCount(5);
+		await expect(dialog.getByText(/Maximal 5 Bilder/)).toBeVisible();
+	});
+
+	test('removing a selected image drops its thumbnail', async ({ page }) => {
+		await page.goto('/user/items');
+		const dialog = await openAddModal(page);
+
+		await dialog.locator('input[type="file"]').setInputFiles([
+			{ name: 'a.png', mimeType: 'image/png', buffer: PNG_1x1 },
+			{ name: 'b.png', mimeType: 'image/png', buffer: PNG_1x1 },
+		]);
+		const removeButtons = dialog.getByRole('button', { name: 'Bild entfernen' });
+		await expect(removeButtons).toHaveCount(2);
+		await removeButtons.first().click();
+		await expect(removeButtons).toHaveCount(1);
+	});
+
+	test('warns before discarding unsaved changes on ESC', async ({ page }) => {
+		await page.goto('/user/items');
+		const dialog = await openAddModal(page);
+		await dialog.getByRole('textbox', { name: 'Name:' }).fill('Halbfertig');
+
+		page.once('dialog', (d) => d.dismiss());
+		await page.keyboard.press('Escape');
+		await expect(dialog).toBeVisible();
+
+		page.once('dialog', (d) => d.accept());
+		await page.keyboard.press('Escape');
+		await expect(dialog).toBeHidden();
+	});
+
+	test('warns before discarding unsaved changes via the close (X) button', async ({ page }) => {
+		await page.goto('/user/items');
+		const dialog = await openAddModal(page);
+		await dialog.getByRole('textbox', { name: 'Name:' }).fill('Halbfertig');
+
+		page.once('dialog', (d) => d.dismiss());
+		await dialog.getByRole('button', { name: 'Close' }).click();
+		await expect(dialog).toBeVisible();
+	});
+
+	test('the trustees info button shows help without toggling the visibility switch', async ({
+		page,
+	}) => {
+		await page.goto('/user/items');
+		const dialog = await openAddModal(page);
+
+		const toggle = dialog.getByRole('checkbox', { name: 'Nur für Vertraute sichtbar' });
+		await expect(toggle).toBeChecked(); // on by default
+		await dialog.getByRole('button', { name: 'Erkläre mir das' }).first().click();
+		await expect(toggle).toBeChecked();
+		await expect(dialog.getByText('Vertrauensfunktion')).toBeVisible();
+	});
+
+	test('the edit modal shows the existing image and its availability info does not toggle', async ({
+		page,
+	}) => {
+		await page.goto('/user/items');
+		const row = page.locator('div.flex.items-center', { hasText: 'E2E Bohrmaschine' }).first();
+		const dialog = await openModal(page, row.getByRole('button', { name: 'Bearbeiten' }));
+
+		await expect(dialog.getByRole('heading', { name: 'Gegenstand bearbeiten' })).toBeVisible();
+		await expect
+			.poll(() => dialog.locator('img').first().evaluate((el) => (el as HTMLImageElement).naturalWidth))
+			.toBeGreaterThan(0);
+
+		const avail = dialog.getByRole('checkbox', { name: /Verfügbar|Nicht verfügbar/ });
+		const before = await avail.isChecked();
+		// Availability info button is the second "Erkläre mir das" (after the trustees one).
+		await dialog.getByRole('button', { name: 'Erkläre mir das' }).nth(1).click();
+		expect(await avail.isChecked()).toBe(before);
+	});
+
+	test('shows a clear error for an image the browser cannot decode', async ({ page }) => {
+		await page.goto('/user/items');
+		const dialog = await openAddModal(page);
+
+		await dialog.locator('input[type="file"]').setInputFiles({
+			name: 'photo.heic',
+			mimeType: 'image/heic',
+			buffer: Buffer.from('this is not a decodable image'),
+		});
+		await dialog.getByRole('textbox', { name: 'Name:' }).fill('HEIC Test');
+		await dialog.getByRole('textbox', { name: 'Beschreibung:' }).fill('sollte fehlschlagen');
+		await dialog.getByRole('button', { name: 'Hinzufügen' }).click();
+
+		await expect(dialog.getByText(/konnte nicht verarbeitet werden/)).toBeVisible();
+		await expect(dialog).toBeVisible(); // stays open; nothing submitted
+	});
+
+	test('the AI-upload dropzone is transparent', async ({ page }) => {
+		await page.goto('/user/items/bulk-add');
+		const dropzone = page.getByRole('region', { name: 'Foto-Upload-Bereich' });
+		await expect(dropzone).toBeVisible();
+		const bg = await dropzone.evaluate((el) => getComputedStyle(el).backgroundColor);
+		expect(bg).toBe('rgba(0, 0, 0, 0)');
+	});
+});

--- a/e2e/tests/item-upload.spec.ts
+++ b/e2e/tests/item-upload.spec.ts
@@ -46,7 +46,7 @@ test.describe('item modal', () => {
 		await dialog
 			.getByRole('textbox', { name: 'Beschreibung:' })
 			.fill('Playwright-Testgegenstand');
-		await dialog.locator('input[name="itemImage"]').setInputFiles({
+		await dialog.locator('input#itemImage').setInputFiles({
 			name: 'item.png',
 			mimeType: 'image/png',
 			buffer: PNG_1x1,

--- a/e2e/tests/item-upload.spec.ts
+++ b/e2e/tests/item-upload.spec.ts
@@ -1,220 +1,90 @@
 import { test, expect, type Page, type Locator } from '@playwright/test';
 
 /**
- * Item upload improvements (#246): the single-item modal on /user/items and the
- * AI-upload dropzone. Runs with the seeded owner's storage state (auth.setup.ts).
+ * The single-item add/edit modal on /user/items and the AI bulk-add dropzone. Runs with
+ * the seeded owner's storage state (authenticated project).
+ *
+ * NB: this codebase's item modal is a single-image upload — the older multi-image #246
+ * gallery/drag-and-drop design an earlier version of this spec targeted is not present
+ * here, so the spec covers the current modal instead.
  */
 
-const PNG_B64 =
-	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
-const PNG_1x1 = Buffer.from(PNG_B64, 'base64');
-const IMAGE_UPLOAD = 'Bilder hochladen oder hierher ziehen'; // dropzone aria-label
+// 1×1 PNG for the (image-required) create flow.
+const PNG_1x1 = Buffer.from(
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+	'base64'
+);
 
-// In dev the route compiles on first hit, so an early click can land before Svelte
-// hydrates the handler. Retry the opener click until the modal actually opens.
-async function openModal(page: Page, opener: Locator) {
-	await expect(opener).toBeVisible();
+// In dev a route compiles on first hit, so an early click can land before Svelte hydrates
+// the handler. Retry the opener until the modal opens.
+async function openModalVia(page: Page, opener: Locator): Promise<Locator> {
+	const dialog = page.getByRole('dialog');
 	await expect(async () => {
-		await opener.click();
-		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 1000 });
+		if (!(await dialog.isVisible())) await opener.click();
+		await expect(dialog).toBeVisible({ timeout: 1000 });
 	}).toPass({ timeout: 15_000 });
-	return page.getByRole('dialog');
+	return dialog;
 }
 
-function openAddModal(page: Page) {
-	return openModal(page, page.getByRole('button', { name: /Dinge einzeln hochladen/ }));
-}
+const openAddModal = (page: Page) =>
+	openModalVia(page, page.getByRole('button', { name: 'Dinge einzeln hochladen' }));
 
-test.describe('item upload (#246)', () => {
-	test('desktop layout puts the image column left of the fields', async ({ page }) => {
-		await page.setViewportSize({ width: 1280, height: 900 });
+test.describe('item modal', () => {
+	test('opens the add-item modal with the create form', async ({ page }) => {
 		await page.goto('/user/items');
 		const dialog = await openAddModal(page);
-
-		const imgBox = await dialog.locator('img').first().boundingBox();
-		const nameBox = await dialog.getByRole('textbox', { name: 'Name:' }).boundingBox();
-		expect(imgBox).not.toBeNull();
-		expect(nameBox).not.toBeNull();
-		// Image column is entirely to the LEFT of the fields (side-by-side, not stacked).
-		expect(imgBox!.x + imgBox!.width).toBeLessThanOrEqual(nameBox!.x + 5);
+		await expect(dialog.getByRole('textbox', { name: 'Name:' })).toBeVisible();
+		await expect(dialog.getByRole('button', { name: 'Hinzufügen' })).toBeVisible();
 	});
 
-	test('clicking the image area opens the (multiple) file picker', async ({ page }) => {
+	test('creates an item with an image and lists it', async ({ page }) => {
 		await page.goto('/user/items');
 		const dialog = await openAddModal(page);
 
-		const chooserPromise = page.waitForEvent('filechooser');
-		await dialog.getByRole('button', { name: IMAGE_UPLOAD }).click();
-		const chooser = await chooserPromise;
-		expect(chooser.isMultiple()).toBe(true);
-	});
-
-	test('drag & drop adds an image thumbnail', async ({ page }) => {
-		await page.goto('/user/items');
-		const dialog = await openAddModal(page);
-
-		const dataTransfer = await page.evaluateHandle((b64) => {
-			const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
-			const dt = new DataTransfer();
-			dt.items.add(new File([bytes], 'drop.png', { type: 'image/png' }));
-			return dt;
-		}, PNG_B64);
-
-		const dropzone = dialog.getByRole('button', { name: IMAGE_UPLOAD });
-		await dropzone.dispatchEvent('dragover', { dataTransfer });
-		await dropzone.dispatchEvent('drop', { dataTransfer });
-
-		await expect(dialog.getByRole('button', { name: 'Bild entfernen' })).toHaveCount(1);
-	});
-
-	test('uploads a new item with multiple images and shows a working gallery', async ({ page }) => {
-		await page.goto('/user/items');
-		const dialog = await openAddModal(page);
-		await expect(dialog.getByRole('heading', { name: 'Neuer Gegenstand' })).toBeVisible();
-
-		await dialog.locator('input[type="file"]').setInputFiles([
-			{ name: 'a.png', mimeType: 'image/png', buffer: PNG_1x1 },
-			{ name: 'b.png', mimeType: 'image/png', buffer: PNG_1x1 },
-		]);
-		await expect(dialog.getByRole('button', { name: 'Bild entfernen' })).toHaveCount(2);
-
-		const name = `E2E Multi-Upload ${Date.now()}`;
+		const name = `E2E Neuware ${Date.now()}`;
 		await dialog.getByRole('textbox', { name: 'Name:' }).fill(name);
-		await dialog.getByRole('textbox', { name: 'Beschreibung:' }).fill('Playwright (#246)');
-		await dialog.getByRole('button', { name: 'Hinzufügen' }).click();
-
-		// Modal closes and the item appears in the list with a rendered cover thumbnail.
-		await expect(dialog).toBeHidden();
-		const row = page.locator('div', { hasText: name }).filter({
-			has: page.getByRole('link', { name }),
-		});
-		const cover = row.locator('img').first();
-		await expect
-			.poll(() => cover.evaluate((el) => (el as HTMLImageElement).naturalWidth))
-			.toBeGreaterThan(0);
-
-		// Detail page: gallery with one thumbnail per image; the hero image really renders.
-		await page.getByRole('link', { name }).first().click();
-		await expect(page).toHaveURL(/\/items\/[^/]+$/);
-		const hero = page.locator('main img').first();
-		await expect
-			.poll(() => hero.evaluate((el) => (el as HTMLImageElement).naturalWidth), { timeout: 10_000 })
-			.toBeGreaterThan(0);
-
-		const thumbs = page.getByRole('button', { name: /Bild \d+ anzeigen/ });
-		await expect(thumbs).toHaveCount(2);
-		const src1 = await hero.getAttribute('src');
-		await thumbs.nth(1).click();
-		await expect.poll(() => hero.getAttribute('src')).not.toBe(src1);
-	});
-
-	test('caps image selection at 5 and warns', async ({ page }) => {
-		await page.goto('/user/items');
-		const dialog = await openAddModal(page);
-
-		const files = Array.from({ length: 7 }, (_, i) => ({
-			name: `f${i}.png`,
+		await dialog
+			.getByRole('textbox', { name: 'Beschreibung:' })
+			.fill('Playwright-Testgegenstand');
+		await dialog.locator('input[name="itemImage"]').setInputFiles({
+			name: 'item.png',
 			mimeType: 'image/png',
 			buffer: PNG_1x1,
-		}));
-		await dialog.locator('input[type="file"]').setInputFiles(files);
+		});
+		await dialog.getByRole('button', { name: 'Hinzufügen' }).click();
 
-		await expect(dialog.getByRole('button', { name: 'Bild entfernen' })).toHaveCount(5);
-		await expect(dialog.getByText(/Maximal 5 Bilder/)).toBeVisible();
-	});
-
-	test('removing a selected image drops its thumbnail', async ({ page }) => {
-		await page.goto('/user/items');
-		const dialog = await openAddModal(page);
-
-		await dialog.locator('input[type="file"]').setInputFiles([
-			{ name: 'a.png', mimeType: 'image/png', buffer: PNG_1x1 },
-			{ name: 'b.png', mimeType: 'image/png', buffer: PNG_1x1 },
-		]);
-		const removeButtons = dialog.getByRole('button', { name: 'Bild entfernen' });
-		await expect(removeButtons).toHaveCount(2);
-		await removeButtons.first().click();
-		await expect(removeButtons).toHaveCount(1);
-	});
-
-	test('warns before discarding unsaved changes on ESC', async ({ page }) => {
-		await page.goto('/user/items');
-		const dialog = await openAddModal(page);
-		await dialog.getByRole('textbox', { name: 'Name:' }).fill('Halbfertig');
-
-		page.once('dialog', (d) => d.dismiss());
-		await page.keyboard.press('Escape');
-		await expect(dialog).toBeVisible();
-
-		page.once('dialog', (d) => d.accept());
-		await page.keyboard.press('Escape');
+		// Modal closes and the item shows in the list, linking to its detail page.
 		await expect(dialog).toBeHidden();
+		const link = page.getByRole('link', { name });
+		await expect(link).toBeVisible();
+		await link.click();
+		await expect(page).toHaveURL(/\/items\/[^/]+$/);
 	});
 
-	test('warns before discarding unsaved changes via the close (X) button', async ({ page }) => {
-		await page.goto('/user/items');
-		const dialog = await openAddModal(page);
-		await dialog.getByRole('textbox', { name: 'Name:' }).fill('Halbfertig');
-
-		page.once('dialog', (d) => d.dismiss());
-		await dialog.getByRole('button', { name: 'Close' }).click();
-		await expect(dialog).toBeVisible();
-	});
-
-	test('the trustees info button shows help without toggling the visibility switch', async ({
-		page,
-	}) => {
+	test('the trustees info button reveals help without toggling the switch', async ({ page }) => {
 		await page.goto('/user/items');
 		const dialog = await openAddModal(page);
 
 		const toggle = dialog.getByRole('checkbox', { name: 'Nur für Vertraute sichtbar' });
-		await expect(toggle).toBeChecked(); // on by default
+		await expect(toggle).toBeChecked(); // trustees-only is on by default
 		await dialog.getByRole('button', { name: 'Erkläre mir das' }).first().click();
-		await expect(toggle).toBeChecked();
 		await expect(dialog.getByText('Vertrauensfunktion')).toBeVisible();
+		await expect(toggle).toBeChecked();
 	});
 
-	test('the edit modal shows the existing image and its availability info does not toggle', async ({
-		page,
-	}) => {
+	test('the edit modal pre-fills the item and offers save + delete', async ({ page }) => {
 		await page.goto('/user/items');
-		const row = page.locator('div.flex.items-center', { hasText: 'E2E Bohrmaschine' }).first();
-		const dialog = await openModal(page, row.getByRole('button', { name: 'Bearbeiten' }));
-
-		await expect(dialog.getByRole('heading', { name: 'Gegenstand bearbeiten' })).toBeVisible();
-		await expect
-			.poll(() => dialog.locator('img').first().evaluate((el) => (el as HTMLImageElement).naturalWidth))
-			.toBeGreaterThan(0);
-
-		const avail = dialog.getByRole('checkbox', { name: /Verfügbar|Nicht verfügbar/ });
-		const before = await avail.isChecked();
-		// Availability info button is the second "Erkläre mir das" (after the trustees one).
-		await dialog.getByRole('button', { name: 'Erkläre mir das' }).nth(1).click();
-		expect(await avail.isChecked()).toBe(before);
+		const dialog = await openModalVia(
+			page,
+			page.getByRole('button', { name: 'Bearbeiten' }).first()
+		);
+		await expect(dialog.getByRole('textbox', { name: 'Name:' })).toHaveValue(/.+/);
+		await expect(dialog.getByRole('button', { name: 'Speichern' })).toBeVisible();
+		await expect(dialog.getByRole('button', { name: 'Löschen' })).toBeVisible();
 	});
 
-	test('shows a clear error for an image the browser cannot decode', async ({ page }) => {
-		await page.goto('/user/items');
-		const dialog = await openAddModal(page);
-
-		await dialog.locator('input[type="file"]').setInputFiles({
-			name: 'photo.heic',
-			mimeType: 'image/heic',
-			buffer: Buffer.from('this is not a decodable image'),
-		});
-		await dialog.getByRole('textbox', { name: 'Name:' }).fill('HEIC Test');
-		await dialog.getByRole('textbox', { name: 'Beschreibung:' }).fill('sollte fehlschlagen');
-		await dialog.getByRole('button', { name: 'Hinzufügen' }).click();
-
-		await expect(dialog.getByText(/konnte nicht verarbeitet werden/)).toBeVisible();
-		await expect(dialog).toBeVisible(); // stays open; nothing submitted
-	});
-
-	test('the AI-upload dropzone is transparent', async ({ page }) => {
+	test('the bulk-add photo-upload area renders', async ({ page }) => {
 		await page.goto('/user/items/bulk-add');
-		const dropzone = page.getByRole('region', { name: 'Foto-Upload-Bereich' });
-		await expect(dropzone).toBeVisible();
-		const bg = await dropzone.evaluate((el) => getComputedStyle(el).backgroundColor);
-		expect(bg).toBe('rgba(0, 0, 0, 0)');
+		await expect(page.getByRole('region', { name: 'Foto-Upload-Bereich' })).toBeVisible();
 	});
 });

--- a/e2e/tests/legal.spec.ts
+++ b/e2e/tests/legal.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+import { LOCKED_STORAGE_STATE } from '../fixtures/users';
+
+/**
+ * Legal-consent gate (Issue #399) — a locked account (declined the current terms) is
+ * redirected to /legal/locked on any protected navigation. Runs as the seeded locked
+ * user in the `multiuser` project.
+ *
+ * The accept/decline flow itself is not covered here: it requires an active
+ * `legal_documents` row, but that collection is a backend-wide singleton (unique per
+ * docType), so toggling it active for a test would gate every other user. Left for a
+ * dedicated, isolated legal fixture.
+ */
+
+test.describe('legal', () => {
+	test('a locked account is routed to the locked page', async ({ browser }) => {
+		const ctx = await browser.newContext({ storageState: LOCKED_STORAGE_STATE });
+		const page = await ctx.newPage();
+		try {
+			await page.goto('/');
+			await expect(page).toHaveURL(/\/legal\/locked/);
+			await expect(page.getByRole('heading', { name: 'Konto gesperrt' })).toBeVisible();
+		} finally {
+			await ctx.close();
+		}
+	});
+});

--- a/e2e/tests/lending.spec.ts
+++ b/e2e/tests/lending.spec.ts
@@ -1,0 +1,82 @@
+import {
+	test,
+	expect,
+	type BrowserContext,
+	type Page,
+} from '@playwright/test';
+import { STORAGE_STATE, VIEWER_STORAGE_STATE } from '../fixtures/users';
+
+/**
+ * The lending lifecycle — the core end-to-end flow — driven across two logged-in
+ * sessions at once: the borrower (viewer) requests the owner's public item, then the
+ * two parties walk it through accept → handover → return-report → return-confirm.
+ *
+ * The `e2e` seed is re-created fresh before every run (global-setup), so there is no
+ * prior conversation for this owner/viewer/item pair: requesting yields a fresh
+ * `pending` conversation. Both actors open the SAME conversation URL and re-navigate
+ * to observe the other party's state changes (rather than relying on realtime).
+ */
+
+const ITEM = 'E2E Bohrmaschine';
+
+test.describe('lending lifecycle', () => {
+	let ownerCtx: BrowserContext;
+	let viewerCtx: BrowserContext;
+	let owner: Page;
+	let viewer: Page;
+
+	test.beforeEach(async ({ browser }) => {
+		ownerCtx = await browser.newContext({ storageState: STORAGE_STATE });
+		viewerCtx = await browser.newContext({ storageState: VIEWER_STORAGE_STATE });
+		owner = await ownerCtx.newPage();
+		viewer = await viewerCtx.newPage();
+	});
+
+	test.afterEach(async () => {
+		await ownerCtx.close();
+		await viewerCtx.close();
+	});
+
+	test('request → accept → handover → return → complete', async () => {
+		// Borrower finds the owner's public item in search and requests it. Query by name
+		// so the result is on the first page regardless of how many other items exist.
+		await viewer.goto('/search?q=' + encodeURIComponent(ITEM));
+		await viewer.getByRole('link', { name: ITEM }).first().click();
+		await expect(viewer).toHaveURL(/\/items\/[^/]+$/);
+		await viewer.getByRole('button', { name: 'Anfragen' }).click();
+
+		// Requesting lands the borrower in the fresh conversation (pending).
+		await expect(viewer).toHaveURL(/\/conversations\/[^/]+$/);
+		const conversationUrl = viewer.url();
+
+		// Owner opens the same conversation, sees the pending request, and accepts it.
+		await owner.goto(conversationUrl);
+		await owner.getByRole('button', { name: 'Annehmen' }).click();
+
+		// After accepting, the owner confirms the handover → active loan.
+		const handover = owner.getByRole('button', { name: 'Übergabe bestätigen' });
+		await expect(handover).toBeVisible();
+		await handover.click();
+		await expect(handover).toBeHidden();
+
+		// Borrower reports the return.
+		await viewer.goto(conversationUrl);
+		const reportReturn = viewer.getByRole('button', { name: 'Rückgabe melden' });
+		await expect(reportReturn).toBeVisible();
+		await reportReturn.click();
+
+		// Owner confirms the return → completed.
+		await owner.goto(conversationUrl);
+		const confirmReturn = owner.getByRole('button', {
+			name: 'Rückgabe bestätigen',
+		});
+		await expect(confirmReturn).toBeVisible();
+		await confirmReturn.click();
+
+		// Completed: the closing description shows and no action buttons remain.
+		await expect(owner.getByText('Die Ausleihe ist abgeschlossen.')).toBeVisible();
+		await expect(
+			owner.getByRole('button', { name: 'Rückgabe bestätigen' })
+		).toHaveCount(0);
+	});
+});

--- a/e2e/tests/messages.spec.ts
+++ b/e2e/tests/messages.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import { VIEWER_STORAGE_STATE } from '../fixtures/users';
+
+/**
+ * Messaging — a borrower opens a conversation (by requesting an item) and sends a chat
+ * message. Uses "E2E Kochbuch", a public item reserved for this spec so its conversation
+ * doesn't collide with lending.spec (Bohrmaschine). Runs as the viewer in the `multiuser`
+ * project.
+ */
+
+const ITEM = 'E2E Kochbuch';
+
+test.describe('messages', () => {
+	test('borrower sends a chat message in a conversation', async ({ browser }) => {
+		const ctx = await browser.newContext({ storageState: VIEWER_STORAGE_STATE });
+		const page = await ctx.newPage();
+		try {
+			// Start a conversation by requesting the item.
+			await page.goto('/search?q=' + encodeURIComponent(ITEM));
+			await page.getByRole('link', { name: ITEM }).first().click();
+			await page.getByRole('button', { name: 'Anfragen' }).click();
+			await expect(page).toHaveURL(/\/conversations\/[^/]+$/);
+
+			// Send a message; it appears in the thread.
+			const text = `E2E Nachricht ${Date.now()}`;
+			await page.locator('input[name="messageContent"]').fill(text);
+			await page.locator('form[action="?/sendMessage"] button[type="submit"]').click();
+			await expect(page.getByText(text)).toBeVisible();
+		} finally {
+			await ctx.close();
+		}
+	});
+});

--- a/e2e/tests/misc.spec.ts
+++ b/e2e/tests/misc.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Public content pages + sitemap — logged-out smoke (runs in the `public` project).
+ * These routes are in the auth hook's unprotected-prefix list, so a guest reaches them
+ * without a redirect to /auth/login.
+ */
+
+const PUBLIC_PAGES = ['/misc/about', '/misc/contact', '/misc/guide', '/misc/imprint'];
+
+test.describe('public pages (smoke)', () => {
+	for (const path of PUBLIC_PAGES) {
+		test(`${path} renders for logged-out visitors`, async ({ page }) => {
+			await page.goto(path);
+			// Not redirected to login, and real content rendered.
+			await expect(page).toHaveURL(new RegExp(path + '$'));
+			await expect(page.getByRole('heading').first()).toBeVisible();
+		});
+	}
+
+	test('sitemap.xml lists items', async ({ page }) => {
+		const res = await page.request.get('/sitemap.xml');
+		expect(res.ok()).toBeTruthy();
+		const body = await res.text();
+		expect(body).toContain('<urlset');
+		expect(body).toContain('/items/');
+	});
+});

--- a/e2e/tests/notifications.spec.ts
+++ b/e2e/tests/notifications.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+import { STRANGER_STORAGE_STATE } from '../fixtures/users';
+
+/**
+ * Notifications list — render + read-toggle. Uses the stranger's single seeded
+ * notification (see e2e.js); nothing else notifies the stranger, so the list is
+ * deterministic under fullyParallel. Runs in the `multiuser` project.
+ */
+
+const BODY = 'e2e_owner_seed vertraut dir jetzt';
+
+test.describe('notifications', () => {
+	test('the list shows a notification and toggles its read state', async ({ browser }) => {
+		const ctx = await browser.newContext({ storageState: STRANGER_STORAGE_STATE });
+		const page = await ctx.newPage();
+		try {
+			await page.goto('/notifications');
+			const item = page.getByRole('listitem').filter({ hasText: BODY });
+			await expect(item).toBeVisible();
+
+			// Seeded unread → mark read; the toggle's label flips.
+			await item.getByRole('button', { name: 'Als gelesen markieren' }).click();
+			await expect(
+				item.getByRole('button', { name: 'Als ungelesen markieren' })
+			).toBeVisible();
+		} finally {
+			await ctx.close();
+		}
+	});
+});

--- a/e2e/tests/onboarding.spec.ts
+++ b/e2e/tests/onboarding.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+import { NEWBIE_STORAGE_STATE } from '../fixtures/users';
+
+/**
+ * Onboarding — a fresh (hasOnboarded:false) user reaches the wizard and the client-side
+ * stepper advances. The wizard is a purely client-side stepper (Welcome → How-it-works →
+ * Survey → …), so this drives the first steps to confirm it renders, hydrates, and steps.
+ * Runs as the newbie in the `multiuser` project.
+ */
+
+test.describe('onboarding', () => {
+	test('an un-onboarded user can step through the wizard', async ({ browser }) => {
+		const ctx = await browser.newContext({ storageState: NEWBIE_STORAGE_STATE });
+		const page = await ctx.newPage();
+		try {
+			await page.goto('/onboarding');
+
+			// Step 1 (welcome) → step 2. Retry the first click (dev hydration race); only
+			// click while still on the welcome step (the start button is gone afterwards).
+			const startBtn = page.getByRole('button', { name: /Kurzes Onboarding/ });
+			const weiter = page.getByRole('button', { name: /Weiter/ });
+			await expect(async () => {
+				if (!(await weiter.isVisible())) await startBtn.click();
+				await expect(weiter).toBeVisible({ timeout: 1000 });
+			}).toPass({ timeout: 15_000 });
+
+			// Step 2 (how it works) → step 3 (survey).
+			await weiter.click();
+			await expect(page.getByText('Eine ganz kurze Umfrage')).toBeVisible();
+		} finally {
+			await ctx.close();
+		}
+	});
+});

--- a/e2e/tests/profile.spec.ts
+++ b/e2e/tests/profile.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { STRANGER_STORAGE_STATE } from '../fixtures/users';
+
+/**
+ * Profile — saveProfile persists a changed bio. Uses the stranger (owns nothing, not
+ * referenced by other tests' assertions) so a concurrent run can't be disturbed. Only the
+ * bio is changed; the pre-filled username is submitted unchanged. Runs in `multiuser`.
+ *
+ * Locators are page-level: the profile fields and the sticky "Speichern" save bar are not
+ * all inside one <form> element, so scoping to the form would miss them.
+ */
+
+test.describe('profile', () => {
+	test('saving a new bio persists it', async ({ browser }) => {
+		const ctx = await browser.newContext({ storageState: STRANGER_STORAGE_STATE });
+		const page = await ctx.newPage();
+		try {
+			const bio = `E2E Bio ${Date.now()}`;
+			await page.goto('/user/profile');
+
+			// Retry the fill until it sticks — under load, hydration can reset a too-early
+			// input. Once it holds, the form is hydrated, so Speichern runs through use:enhance
+			// (a fetch, not a native navigation that would race the reload below).
+			const bioField = page.locator('textarea[name="bio"]');
+			await expect(async () => {
+				await bioField.fill(bio);
+				await expect(bioField).toHaveValue(bio, { timeout: 500 });
+			}).toPass({ timeout: 15_000 });
+
+			await page.getByRole('button', { name: 'Speichern' }).first().click();
+			// Wait for the save to complete (success toast) before navigating away.
+			await expect(
+				page.getByText('Daten wurden erfolgreich aktualisiert.')
+			).toBeVisible({ timeout: 10_000 });
+
+			// Reload and confirm the value stuck.
+			await page.goto('/user/profile');
+			await expect(page.locator('textarea[name="bio"]')).toHaveValue(bio);
+		} finally {
+			await ctx.close();
+		}
+	});
+});

--- a/e2e/tests/search.spec.ts
+++ b/e2e/tests/search.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect, type Browser } from '@playwright/test';
+import { VIEWER_STORAGE_STATE, STRANGER_STORAGE_STATE } from '../fixtures/users';
+
+/**
+ * Search + trust visibility — the data-layer trust rule enforced through the real
+ * `items_searchable` view. The owner's trustees-only "E2E Geheimwerkzeug" must be
+ * visible to a trusted viewer but never to an untrusted user. Runs in the `multiuser`
+ * project with a per-role context (search is server-rendered, so results are in the
+ * initial HTML — no client fetch to wait on).
+ */
+
+const SECRET_ITEM = 'E2E Geheimwerkzeug'; // trustees-only, owned by e2e_owner_seed
+const PUBLIC_ITEM = 'E2E Campingzelt'; // public, not touched by any other spec
+
+async function searchAs(browser: Browser, storageState: string, query: string) {
+	const ctx = await browser.newContext({ storageState });
+	const page = await ctx.newPage();
+	await page.goto('/search?q=' + encodeURIComponent(query));
+	return { ctx, page };
+}
+
+test.describe('search & trust visibility', () => {
+	test('a trusted user sees the owner’s trustees-only item', async ({ browser }) => {
+		const { ctx, page } = await searchAs(browser, VIEWER_STORAGE_STATE, 'Geheimwerkzeug');
+		try {
+			await expect(page.getByRole('link', { name: SECRET_ITEM }).first()).toBeVisible();
+		} finally {
+			await ctx.close();
+		}
+	});
+
+	test('an untrusted user does not see the trustees-only item', async ({ browser }) => {
+		const { ctx, page } = await searchAs(browser, STRANGER_STORAGE_STATE, 'Geheimwerkzeug');
+		try {
+			await expect(page.getByRole('link', { name: SECRET_ITEM })).toHaveCount(0);
+		} finally {
+			await ctx.close();
+		}
+	});
+
+	test('search renders a public item', async ({ browser }) => {
+		const { ctx, page } = await searchAs(browser, VIEWER_STORAGE_STATE, PUBLIC_ITEM);
+		try {
+			await expect(page.getByRole('link', { name: PUBLIC_ITEM }).first()).toBeVisible();
+		} finally {
+			await ctx.close();
+		}
+	});
+});

--- a/e2e/tests/trust.spec.ts
+++ b/e2e/tests/trust.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import { THIRD } from '../fixtures/users';
+
+/**
+ * Trust graph via /social — validates the backend `trusts` join collection end-to-end.
+ * Runs in the `authenticated` project, so `page` is logged in as the owner
+ * (e2e_owner_seed). The seed leaves e2e_third_seed untrusted, so we can grant then
+ * revoke trust from a clean slate.
+ */
+
+test.describe('trust', () => {
+	test('owner grants then revokes trust to a user via /social', async ({ page }) => {
+		await page.goto('/social');
+
+		// Type the third user's name and open the "add someone new" dropdown. Retry the
+		// fill until the toggle appears — in dev a route compiles on first hit and hydration
+		// can reset an input typed too early.
+		const toggle = page.getByRole('button', { name: /Noch nicht im Netzwerk/ });
+		await expect(async () => {
+			await page.getByPlaceholder('Netzwerk durchsuchen...').fill(THIRD.username);
+			await expect(toggle).toBeVisible({ timeout: 1000 });
+		}).toPass({ timeout: 15_000 });
+		await toggle.click();
+
+		const addForm = page.locator('form[action="?/addTrustee"]');
+		await expect(addForm).toBeVisible();
+		await addForm.getByRole('button').click();
+
+		// Third now appears in the trust network with the "you trust them" box checked.
+		const row = page.getByRole('row', { name: new RegExp(THIRD.username) });
+		await expect(row).toBeVisible();
+		await expect(row.getByRole('checkbox')).toBeChecked();
+
+		// Revoke: unchecking submits removeTrustee; third then leaves the network entirely.
+		await row.getByRole('checkbox').uncheck();
+		await expect(
+			page.getByRole('row', { name: new RegExp(THIRD.username) })
+		).toHaveCount(0);
+	});
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,13 +40,38 @@ export default defineConfig({
 		{
 			name: 'public',
 			use: { browserName: 'chromium' },
-			testMatch: ['tests/smoke.spec.ts', 'tests/auth.spec.ts'],
+			testMatch: ['tests/smoke.spec.ts', 'tests/auth.spec.ts', 'tests/misc.spec.ts'],
 		},
 		{
 			name: 'authenticated',
 			use: { browserName: 'chromium', storageState: STORAGE_STATE },
 			dependencies: ['setup'],
-			testMatch: ['tests/authenticated.spec.ts'],
+			testMatch: [
+				'tests/authenticated.spec.ts',
+				'tests/item-upload.spec.ts',
+				'tests/trust.spec.ts',
+				'tests/feedback.spec.ts',
+			],
+		},
+		{
+			// Cross-actor flows (lending, group join) open their own per-role contexts,
+			// so no project-level storageState — just ensure the states exist (setup).
+			name: 'multiuser',
+			use: { browserName: 'chromium' },
+			dependencies: ['setup'],
+			testMatch: [
+				'tests/lending.spec.ts',
+				'tests/groups.spec.ts',
+				'tests/search.spec.ts',
+				'tests/messages.spec.ts',
+				'tests/notifications.spec.ts',
+				'tests/profile.spec.ts',
+				'tests/onboarding.spec.ts',
+				'tests/account.spec.ts',
+				'tests/external-fallbacks.spec.ts',
+				'tests/legal.spec.ts',
+				'tests/import.spec.ts',
+			],
 		},
 	],
 

--- a/scripts/seed/lib.js
+++ b/scripts/seed/lib.js
@@ -46,9 +46,32 @@ export async function teardown(pb) {
 	const ids = seedUsers.map((u) => u.id);
 	const anyOf = (field) => '(' + ids.map((id) => `${field} = "${id}"`).join(' || ') + ')';
 
+	// Groups owned by seed users: clear their invites + memberships before the groups.
+	const seedGroups = await pb
+		.collection('groups')
+		.getFullList({ filter: anyOf('owner') })
+		.catch(() => []);
+	if (seedGroups.length > 0) {
+		const byGroup =
+			'(' + seedGroups.map((g) => `group = "${g.id}"`).join(' || ') + ')';
+		await deleteWhere(pb, 'group_invites', byGroup);
+		await deleteWhere(pb, 'group_members', byGroup);
+	}
+	// Memberships the seed users hold in any (incl. non-seed) group.
+	await deleteWhere(pb, 'group_members', anyOf('user'));
+
+	// Records keyed to seed users. deleteWhere swallows unknown-collection errors, so
+	// naming a collection that a given schema lacks is harmless.
+	await deleteWhere(pb, 'notifications', `${anyOf('recipient')} || ${anyOf('sender')}`);
+	await deleteWhere(pb, 'trusts', `${anyOf('truster')} || ${anyOf('trustee')}`);
+	await deleteWhere(pb, 'term_acceptances', anyOf('user'));
+	await deleteWhere(pb, 'user_legal_acceptances', anyOf('user'));
+	await deleteWhere(pb, 'lending_requirements', anyOf('owner'));
+	await deleteWhere(pb, 'lending_terms', anyOf('owner'));
 	await deleteWhere(pb, 'messages', `${anyOf('from')} || ${anyOf('to')}`);
 	await deleteWhere(pb, 'conversations', `${anyOf('requester')} || ${anyOf('itemOwner')}`);
 	await deleteWhere(pb, 'items', anyOf('owner'));
+	for (const g of seedGroups) await pb.collection('groups').delete(g.id).catch(() => {});
 	for (const u of seedUsers) await pb.collection('users').delete(u.id).catch(() => {});
 	return seedUsers.length;
 }

--- a/scripts/seed/lib.js
+++ b/scripts/seed/lib.js
@@ -59,6 +59,10 @@ export async function teardown(pb) {
 	}
 	// Memberships the seed users hold in any (incl. non-seed) group.
 	await deleteWhere(pb, 'group_members', anyOf('user'));
+	// Invites authored by a seed user that the by-group sweep above missed — e.g. an
+	// orphaned invite whose group was already deleted. `group_invites.createdBy` does not
+	// cascade on user delete, so any leftover would pin the user row and break re-seeding.
+	await deleteWhere(pb, 'group_invites', anyOf('createdBy'));
 
 	// Records keyed to seed users. deleteWhere swallows unknown-collection errors, so
 	// naming a collection that a given schema lacks is harmless.

--- a/scripts/seed/scenarios/e2e.js
+++ b/scripts/seed/scenarios/e2e.js
@@ -1,32 +1,111 @@
 /**
- * Scenario: end-to-end test fixtures.
+ * Scenario: end-to-end test fixtures (Playwright, e2e/).
  *
- * Deterministic, minimal data owned by the Playwright suite (e2e/) so the tests do
- * not depend on any feature scenario's internals. The seed runner tears down all
- * `@seed.test` users before seeding, so running this yields a known clean state.
+ * Deterministic data owned by the Playwright suite. The seed runner tears down all
+ * `@seed.test` data before seeding, so every run yields a known clean state.
  *
- *  - e2e_owner_seed  — an ordinary owner with one public item, used as the login user.
- *  - e2e_viewer_seed — a second account for viewer-side flows.
+ *  - e2e_owner_seed  — login/owner. Owns public items, a trustees-only item, and two
+ *                      groups (one public, one private with a fixed invite token).
+ *  - e2e_viewer_seed — borrower/viewer. Trusted by the owner; member of the private group.
+ *  - e2e_third_seed  — a third party. NOT trusted and not a group member (used to drive
+ *                      "grant trust" and "join via invite token" flows from a clean slate).
+ *  - e2e_stranger_seed — a pure bystander that NO test ever mutates. Used for assertions
+ *                      that require a stably-untrusted user under `fullyParallel` (so a
+ *                      concurrent trust test can't transiently flip the state).
  *
- * Login for both: password from lib.js (`password123`), email `<username>@seed.test`.
+ * "E2E Bohrmaschine" is reserved for lending.spec, which drives a fresh request against it.
+ * Login for all: password from lib.js (`password123`), email `<username>@seed.test`.
  */
-import { createUser, createItem, USER_PASSWORD, SEED_DOMAIN } from '../lib.js';
+import { createUser, createItem, setTrust, USER_PASSWORD, SEED_DOMAIN } from '../lib.js';
 
 export const description =
-	'End-to-end test fixtures (Playwright): a login user with one public item.';
+	'End-to-end test fixtures (Playwright): owner + viewer + third user, a trust edge, public + trustees-only items, and a public and a private (invite-token) group.';
+
+// Fixed so `/groups/join/<token>` is a stable URL for the invite-join test.
+// Backend requires exactly 24 chars. Kept in sync with e2e/tests/groups.spec.ts.
+const INVITE_TOKEN = 'e2ejointoken000000000000';
 
 export async function run(pb) {
 	const owner = await createUser(pb, 'e2e_owner_seed');
-	await createUser(pb, 'e2e_viewer_seed');
+	const viewer = await createUser(pb, 'e2e_viewer_seed');
+	await createUser(pb, 'e2e_third_seed');
+	const stranger = await createUser(pb, 'e2e_stranger_seed');
+	// Fresh un-onboarded user for onboarding.spec (seed users are hasOnboarded:true by default).
+	await createUser(pb, 'e2e_newbie_seed', { hasOnboarded: false });
+	// Legal-consent gate (Issue #399): a locked (declined-terms) account is redirected to
+	// /legal/locked. The accept/decline flow itself needs toggling the backend's singleton
+	// legal_documents active, which is too invasive for the shared local backend, so only
+	// this non-invasive locked case is seeded. `legalLocked` is only settable via a
+	// superuser update (create ignores it), so lock the account in a second step.
+	const locked = await createUser(pb, 'e2e_locked_seed');
+	await pb.collection('users').update(locked.id, { legalLocked: true });
+	// Institutional account (unlocks the CSV bulk-import UI) for import.spec.
+	await createUser(pb, 'e2e_institution_seed', { isInstitution: true });
 
+	// Owner trusts viewer (viewer may see the owner's trustees-only items); third stays untrusted.
+	await setTrust(pb, owner.id, [viewer.id]);
+
+	// One notification for the stranger — its only one, so /notifications is deterministic
+	// for notifications.spec even under fullyParallel (nothing else notifies the stranger).
+	await pb.collection('notifications').create({
+		recipient: stranger.id,
+		sender: owner.id,
+		type: 'trust_added',
+		relatedId: owner.id,
+		body: 'e2e_owner_seed vertraut dir jetzt',
+		read: false,
+	});
+
+	// Reserved for lending.spec (driven fresh: search → request → …). Keep it public.
 	const bohrmaschine = await createItem(pb, owner.id, 'E2E Bohrmaschine', [
 		'Werkzeug und Garten',
 	]);
+	// Extra public items across categories for search render / filter / pagination.
+	await createItem(pb, owner.id, 'E2E Campingzelt', ['Reisen und Outdoor']);
+	await createItem(pb, owner.id, 'E2E Kochbuch', ['Bücher']);
+	await createItem(pb, owner.id, 'E2E Beamer', ['Ton und Licht']);
+	// Trustees-only: visible to the owner's trustees (viewer), masked for third / strangers.
+	const geheim = await createItem(pb, owner.id, 'E2E Geheimwerkzeug', ['Werkzeug und Garten'], {
+		trusteesOnly: true,
+	});
+
+	// Public group — self-join surface (/groups/[id]).
+	const publicGroup = await pb.collection('groups').create({
+		name: 'E2E Öffentliche Gruppe',
+		description: 'Öffentliche Gruppe zum Selbst-Beitreten.',
+		owner: owner.id,
+		isPublic: true,
+	});
+	// Private group — invite-token join, member management, and a shared item. The owner's
+	// admin membership is created automatically by the backend group-create hook.
+	const privateGroup = await pb.collection('groups').create({
+		name: 'E2E Werkzeuggruppe',
+		description: 'Private Gruppe mit geteilten Gegenständen.',
+		owner: owner.id,
+		isPublic: false,
+	});
+	await pb.collection('group_members').create({ group: privateGroup.id, user: viewer.id });
+	await pb.collection('group_invites').create({
+		group: privateGroup.id,
+		token: INVITE_TOKEN,
+		createdBy: owner.id,
+	});
+	// A shared item for the private group's detail page.
+	const saege = await createItem(pb, owner.id, 'E2E Gruppen-Säge', ['Werkzeug und Garten']);
+	await pb.collection('items').update(saege.id, { groups: [privateGroup.id] });
 
 	return `  Login (password for all: "${USER_PASSWORD}"):
-    e2e_owner_seed${SEED_DOMAIN}   (owner of the item below)
-    e2e_viewer_seed${SEED_DOMAIN}  (second account)
+    e2e_owner_seed${SEED_DOMAIN}   (owner; trusts viewer; owns the groups below)
+    e2e_viewer_seed${SEED_DOMAIN}  (trusted borrower; member of the private group)
+    e2e_third_seed${SEED_DOMAIN}   (untrusted, no group — for grant-trust / join-token flows)
+    e2e_stranger_seed${SEED_DOMAIN} (stable bystander — never mutated by any test)
 
-  Items:
-    E2E Bohrmaschine (public, owner) → /items/${bohrmaschine.id}`;
+  Items (owner):
+    E2E Bohrmaschine (public)          → /items/${bohrmaschine.id}   [reserved for lending.spec]
+    E2E Campingzelt / Kochbuch / Beamer (public, various categories)
+    E2E Geheimwerkzeug (trustees-only) → /items/${geheim.id}   [viewer sees it, third does not]
+
+  Groups (owner):
+    E2E Öffentliche Gruppe (public)    → /groups/${publicGroup.id}
+    E2E Werkzeuggruppe (private)       → invite: /groups/join/${INVITE_TOKEN}`;
 }


### PR DESCRIPTION
Re-lands the end-to-end test suite from #497 against the correct base branch.

## ⚠️ Please re-review — the previous merge slipped

#497 was accidentally merged with the **wrong base branch**: it targeted `424-trust-join-table` (an already-merged, now-stale feature branch) instead of `main`, so the suite never actually reached `main`. I've reset `424-trust-join-table` back to its pre-merge state, and this PR re-applies the **exact same two commits** cleanly on top of `main`.

Sorry for the mix-up — this needs a fresh approval.

## What's in it (identical to #497)

Builds on the Playwright harness already merged via #486 and adds the full coverage layer:

- **Harness / fixtures**: `playwright.config.ts` projects, per-role login in `e2e/auth.setup.ts`, user fixtures, and an expanded deterministic `e2e` seed scenario (`scripts/seed/lib.js`, `scripts/seed/scenarios/e2e.js`).
- **Coverage — 16 feature areas**: smoke, auth, authenticated nav, item upload/edit, lending lifecycle, trust grant/revoke, groups + invite tokens, search visibility, messages, notifications, profile, feedback, onboarding, account export, legal lock routing, institutional import, external fallbacks.

## Notes

- The Playwright suite is **local-only** — CI runs lint + typecheck; e2e is not executed in CI (see `e2e/README.md`).
- `npm run lint` ✓ and `npm run check` ✓ for these changes (the only local typecheck errors are the known `$env/static/private` integration-sync vars — `PB_SUPERUSER_*`, `SYNC_SECRET` — which CI supplies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
