### PR TITLE
fix(conversations): stabilize mobile chat height on cold load (#529)

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -2,7 +2,7 @@
 <html lang="de">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content" />
 		<link rel="icon" href="/favicon.ico" type="image/x-icon" />
 		<link rel="manifest" href="/manifest.webmanifest" />
 		<meta name="theme-color" content="#fb4a03" />

--- a/src/routes/conversations/+layout.svelte
+++ b/src/routes/conversations/+layout.svelte
@@ -54,6 +54,13 @@
 	// and the input bar rides up just above the keyboard, matching native chat apps.
 	// The scroll-lock above keeps the page itself from scrolling, so the keyboard only
 	// reflows this container.
+	// On a cold load (push/share link, reload) the mobile visual viewport isn't settled
+	// yet — the browser toolbar is still expanded, so a single mount-time measurement
+	// fixes too small a height and the scroll-lock stops a correcting event from firing.
+	// So we re-measure across the settle window: after first paint (rAF), after the
+	// toolbar collapses (timeout), and on window `load` / `orientationchange`, on top of
+	// the live resize/scroll listeners. On internal navigation the viewport is already
+	// settled → the extra passes are harmless no-ops.
 	$effect(() => {
 		if (!outerEl) return;
 
@@ -66,10 +73,18 @@
 		};
 
 		update();
+		const rafId = requestAnimationFrame(update);
+		const timeoutId = setTimeout(update, 250);
+		window.addEventListener('load', update);
+		window.addEventListener('orientationchange', update);
 		window.addEventListener('resize', update);
 		vv?.addEventListener('resize', update);
 		vv?.addEventListener('scroll', update);
 		return () => {
+			cancelAnimationFrame(rafId);
+			clearTimeout(timeoutId);
+			window.removeEventListener('load', update);
+			window.removeEventListener('orientationchange', update);
 			window.removeEventListener('resize', update);
 			vv?.removeEventListener('resize', update);
 			vv?.removeEventListener('scroll', update);
@@ -113,8 +128,11 @@
 	});
 </script>
 
-<!-- Height is set dynamically via $effect to fill viewport below the navbar -->
-<div bind:this={outerEl} class="flex flex-col">
+<!-- Height is set dynamically via $effect to fill viewport below the navbar; the
+	100dvh inline baseline covers the JS-lag window on cold load (before the $effect
+	measures) so the footer never blitzes through — the $effect then overwrites
+	style.height with the exact px value. -->
+<div bind:this={outerEl} class="flex flex-col" style="height: 100dvh">
 	<div class="flex-1 min-h-0 mx-auto w-full max-w-5xl flex gap-3 px-3 py-3">
 		<!-- SIDEBAR — full width on mobile when no conversation open, fixed width on desktop -->
 		<div

--- a/src/routes/conversations/[conversationId]/+page.svelte
+++ b/src/routes/conversations/[conversationId]/+page.svelte
@@ -102,6 +102,10 @@
 		// and leave the latest messages hidden below the raised input bar. Defer with rAF
 		// so we scroll after the resize + reflow, then once more after the open/close
 		// animation settles.
+		// Also re-scroll after the layout's cold-load height correction (push/share link,
+		// reload): that correction fires on window `load` / `orientationchange` — not
+		// necessarily via a vv resize — so mirror those triggers here to land at the bottom
+		// once the container has grown to its settled height.
 		const vv = window.visualViewport;
 		let settleTimer: ReturnType<typeof setTimeout>;
 		const keepAtBottom = () => {
@@ -110,8 +114,12 @@
 			settleTimer = setTimeout(() => scrollToBottom(false), 150);
 		};
 		vv?.addEventListener('resize', keepAtBottom);
+		window.addEventListener('load', keepAtBottom);
+		window.addEventListener('orientationchange', keepAtBottom);
 		return () => {
 			vv?.removeEventListener('resize', keepAtBottom);
+			window.removeEventListener('load', keepAtBottom);
+			window.removeEventListener('orientationchange', keepAtBottom);
 			clearTimeout(settleTimer);
 		};
 	});


### PR DESCRIPTION
## What & why

Fixes #529. On mobile, the conversation view sometimes loaded with a broken
height: the footer showed through, the view couldn't be scrolled up, and neither
pull-to-refresh nor a hard reload recovered it. It reproduced when a conversation
was opened **directly from outside the app** (push notification / shared link)
rather than via in-app navigation.

**Root cause:** the chat container height was derived from a *single*
`visualViewport.height` measurement taken at mount (`height = viewportHeight − top`).
On a cold load the mobile visual viewport isn't settled yet — the browser toolbar
is still expanded — so the measured height is too small and gets fixed in place.
The scroll-lock that keeps the page from scrolling then prevents any correcting
`resize`/`scroll` event from firing, so the wrong height is never corrected. On
internal navigation the viewport is already settled, which is why that path worked
and why tapping the logo → back into the conversation "healed" it.

## Changes

- **`conversations/+layout.svelte`** — re-measure the height across the settle
  window: after first paint (`requestAnimationFrame`), after the toolbar collapses
  (`setTimeout`), and on `window` `load` / `orientationchange`, on top of the
  existing `resize`/`scroll` listeners; all torn down in the effect cleanup. Added a
  `height: 100dvh` inline baseline so no footer blitzes through during the JS-lag
  window before the effect measures.
- **`conversations/[conversationId]/+page.svelte`** — mirror the `load` /
  `orientationchange` triggers in the `keepAtBottom` handler so the message list
  lands at the bottom after the cold-load height correction.
- **`app.html`** — `interactive-widget=resizes-content` in the viewport meta for
  deterministic Android on-screen-keyboard behavior.

No data-layer changes (no PocketBase/filter/trust/public-view surface touched);
Svelte 5 runes throughout, no new user-facing strings.

## Test notes

Preflight (all green): `npm run lint`, `npm run check` (0 errors), `npx vitest run`
(543 passed), `npm run build`.

Reviewed by the project `sveltekit-pb-reviewer` (no findings) and verified via the
Chrome-DevTools MCP in mobile emulation (cold load / reload / keyboard shrink /
internal navigation — container height exact, footer below the fold, input bar
visible, list at bottom). **Manually confirmed on a real phone** over the LAN dev
instance by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
