### PR TITLE
fix(conversations): recover chat realtime after silent SSE freeze (#528)

### DIFF
--- a/src/lib/client-pb.test.ts
+++ b/src/lib/client-pb.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// client-pb.ts reads PUBLIC_PB_URL from here at import time.
+vi.mock('$env/static/public', () => ({ PUBLIC_PB_URL: 'http://localhost:8090' }));
+
+// A hoisted holder collects every PocketBase instance the module constructs, so
+// a test can reach the singleton created lazily by getClientPB().
+const hoisted = vi.hoisted(() => ({ instances: [] as MockPB[] }));
+
+// Minimal mock of the PocketBase client surface client-pb.ts touches: authStore
+// (for the onChange reset registered in getClientPB), realtime.isConnected /
+// unsubscribe (the watchdog + reestablishAll), and collection().subscribe.
+class MockPB {
+	authStore = { record: null as unknown, onChange: vi.fn(), save: vi.fn(), clear: vi.fn() };
+	realtime = { isConnected: true, unsubscribe: vi.fn() };
+	// Every wrapped handler passed to subscribe, newest last — a test fires the
+	// last one to simulate an incoming realtime event (which marks activity).
+	handlers: Array<(event: unknown) => void> = [];
+	subscribe = vi.fn(async (_topic: string, handler: (event: unknown) => void) => {
+		this.handlers.push(handler);
+		return vi.fn(async () => {});
+	});
+	collection = vi.fn(() => ({ subscribe: this.subscribe }));
+	constructor() {
+		hoisted.instances.push(this);
+	}
+}
+
+vi.mock('pocketbase', () => ({ default: MockPB }));
+
+// Mirror the module's own constants so assertions read intently (kept in sync
+// with client-pb.ts by hand — they are private there).
+const WATCHDOG_INTERVAL_MS = 15_000;
+const REALTIME_STALE_MS = 40_000;
+const RECONNECT_AFTER_HIDDEN_MS = 3_000;
+
+// Captured window/document event listeners, keyed by event type.
+let listeners: Record<string, Array<(event?: unknown) => void>>;
+
+function fire(type: string, event?: unknown): void {
+	(listeners[type] ?? []).forEach((cb) => cb(event));
+}
+
+// Drain the microtask chain of an event-triggered reestablishAll (which awaits
+// attemptSubscribe → subscribe). Microtasks run even under fake timers.
+async function flush(): Promise<void> {
+	for (let i = 0; i < 10; i++) await Promise.resolve();
+}
+
+async function importModule() {
+	return import('./client-pb');
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.resetModules();
+	hoisted.instances.length = 0;
+	listeners = {};
+	const addEventListener = (type: string, cb: (event?: unknown) => void) => {
+		(listeners[type] ??= []).push(cb);
+	};
+	vi.stubGlobal('window', { addEventListener });
+	vi.stubGlobal('document', { addEventListener, visibilityState: 'visible' });
+	vi.stubGlobal('console', { ...console, error: vi.fn() });
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.unstubAllGlobals();
+});
+
+/** Subscribe once, resolve the initial connect, and return the live instance. */
+async function subscribeAndSettle(
+	mod: Awaited<ReturnType<typeof importModule>>,
+	opts: { expectsHeartbeat?: boolean } = {}
+): Promise<{ pb: MockPB; cleanup: () => void }> {
+	const cleanup = mod.subscribeRealtime({
+		collection: 'conversations',
+		topic: 'conv1',
+		handler: () => {},
+		expectsHeartbeat: opts.expectsHeartbeat
+	});
+	await flush();
+	const pb = hoisted.instances[0];
+	return { pb, cleanup };
+}
+
+describe('client-pb realtime watchdog', () => {
+	it('reconnects when the SDK reports the socket is down', async () => {
+		const mod = await importModule();
+		const { pb } = await subscribeAndSettle(mod, { expectsHeartbeat: true });
+		pb.realtime.unsubscribe.mockClear();
+
+		pb.realtime.isConnected = false;
+		await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+		await flush();
+
+		expect(pb.realtime.unsubscribe).toHaveBeenCalled();
+	});
+
+	it('reconnects on a disconnected socket even without a heartbeat sub', async () => {
+		const mod = await importModule();
+		const { pb } = await subscribeAndSettle(mod); // no expectsHeartbeat
+		pb.realtime.unsubscribe.mockClear();
+
+		pb.realtime.isConnected = false;
+		await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+		await flush();
+
+		expect(pb.realtime.unsubscribe).toHaveBeenCalled();
+	});
+
+	it('reconnects on staleness when a heartbeat sub is active', async () => {
+		const mod = await importModule();
+		const { pb } = await subscribeAndSettle(mod, { expectsHeartbeat: true });
+		pb.realtime.unsubscribe.mockClear();
+		pb.realtime.isConnected = true;
+
+		// No events for longer than the stale threshold → frozen stream.
+		await vi.advanceTimersByTimeAsync(REALTIME_STALE_MS + WATCHDOG_INTERVAL_MS);
+		await flush();
+
+		expect(pb.realtime.unsubscribe).toHaveBeenCalled();
+	});
+
+	it('does NOT reconnect on staleness without a heartbeat sub', async () => {
+		const mod = await importModule();
+		const { pb } = await subscribeAndSettle(mod); // no expectsHeartbeat
+		pb.realtime.unsubscribe.mockClear();
+		pb.realtime.isConnected = true;
+
+		await vi.advanceTimersByTimeAsync(REALTIME_STALE_MS + WATCHDOG_INTERVAL_MS);
+		await flush();
+
+		expect(pb.realtime.unsubscribe).not.toHaveBeenCalled();
+	});
+
+	it('does NOT reconnect while events keep the connection fresh', async () => {
+		const mod = await importModule();
+		const { pb } = await subscribeAndSettle(mod, { expectsHeartbeat: true });
+		pb.realtime.unsubscribe.mockClear();
+		pb.realtime.isConnected = true;
+
+		// Deliver an event just before each stale threshold would elapse.
+		for (let elapsed = 0; elapsed < REALTIME_STALE_MS * 2; elapsed += WATCHDOG_INTERVAL_MS) {
+			await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+			pb.handlers[pb.handlers.length - 1]?.({ action: 'update' });
+			await flush();
+		}
+
+		expect(pb.realtime.unsubscribe).not.toHaveBeenCalled();
+	});
+
+	it('does NOT reconnect when there are no active subscriptions', async () => {
+		const mod = await importModule();
+		const { pb, cleanup } = await subscribeAndSettle(mod, { expectsHeartbeat: true });
+		cleanup(); // registry now empty; listeners + interval remain installed
+		pb.realtime.isConnected = false;
+		pb.realtime.unsubscribe.mockClear();
+
+		await vi.advanceTimersByTimeAsync(REALTIME_STALE_MS + WATCHDOG_INTERVAL_MS);
+		await flush();
+
+		expect(pb.realtime.unsubscribe).not.toHaveBeenCalled();
+	});
+
+	it('does NOT reconnect while the tab is hidden', async () => {
+		const mod = await importModule();
+		const { pb } = await subscribeAndSettle(mod, { expectsHeartbeat: true });
+		pb.realtime.unsubscribe.mockClear();
+		pb.realtime.isConnected = false;
+		(globalThis.document as unknown as { visibilityState: string }).visibilityState = 'hidden';
+
+		await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS * 2);
+		await flush();
+
+		expect(pb.realtime.unsubscribe).not.toHaveBeenCalled();
+	});
+
+	it('resets the activity clock after a reconnect so it does not immediately re-fire', async () => {
+		const mod = await importModule();
+		const { pb } = await subscribeAndSettle(mod, { expectsHeartbeat: true });
+		pb.realtime.isConnected = true;
+		pb.realtime.unsubscribe.mockClear();
+
+		// First staleness reconnect.
+		await vi.advanceTimersByTimeAsync(REALTIME_STALE_MS + WATCHDOG_INTERVAL_MS);
+		await flush();
+		expect(pb.realtime.unsubscribe).toHaveBeenCalledTimes(1);
+
+		// The reconnect reset the activity clock: another short interval that stays
+		// below the stale threshold must not trigger a second reconnect.
+		await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+		await flush();
+		expect(pb.realtime.unsubscribe).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('client-pb recovery listeners', () => {
+	it('reconnects on pageshow when restored from bfcache (persisted)', async () => {
+		const mod = await importModule();
+		const { pb } = await subscribeAndSettle(mod, { expectsHeartbeat: true });
+		pb.realtime.unsubscribe.mockClear();
+
+		fire('pageshow', { persisted: true });
+		await flush();
+
+		expect(pb.realtime.unsubscribe).toHaveBeenCalled();
+	});
+
+	it('does NOT reconnect on a normal (non-persisted) pageshow', async () => {
+		const mod = await importModule();
+		const { pb } = await subscribeAndSettle(mod, { expectsHeartbeat: true });
+		pb.realtime.unsubscribe.mockClear();
+
+		fire('pageshow', { persisted: false });
+		await flush();
+
+		expect(pb.realtime.unsubscribe).not.toHaveBeenCalled();
+	});
+
+	it('reconnects when the network comes back online', async () => {
+		const mod = await importModule();
+		const { pb } = await subscribeAndSettle(mod, { expectsHeartbeat: true });
+		pb.realtime.unsubscribe.mockClear();
+
+		fire('online');
+		await flush();
+
+		expect(pb.realtime.unsubscribe).toHaveBeenCalled();
+	});
+
+	it('reconnects on foreground only after the hidden threshold is exceeded', async () => {
+		const mod = await importModule();
+		const { pb } = await subscribeAndSettle(mod, { expectsHeartbeat: true });
+		pb.realtime.unsubscribe.mockClear();
+		const doc = globalThis.document as unknown as { visibilityState: string };
+
+		// Brief hide (< threshold): no reconnect on return.
+		doc.visibilityState = 'hidden';
+		fire('visibilitychange');
+		await vi.advanceTimersByTimeAsync(RECONNECT_AFTER_HIDDEN_MS - 500);
+		doc.visibilityState = 'visible';
+		fire('visibilitychange');
+		await flush();
+		expect(pb.realtime.unsubscribe).not.toHaveBeenCalled();
+
+		// Long hide (>= threshold): reconnect on return.
+		doc.visibilityState = 'hidden';
+		fire('visibilitychange');
+		await vi.advanceTimersByTimeAsync(RECONNECT_AFTER_HIDDEN_MS + 500);
+		doc.visibilityState = 'visible';
+		fire('visibilitychange');
+		await flush();
+		expect(pb.realtime.unsubscribe).toHaveBeenCalled();
+	});
+});

--- a/src/lib/client-pb.ts
+++ b/src/lib/client-pb.ts
@@ -75,9 +75,26 @@ const RETRY_BACKOFF_MS = [200, 500, 1000, 2000, 4000];
 // Only force a reconnect on tab-foreground if the tab was backgrounded at least
 // this long. Short hidden spells (alt-tabbing on desktop) don't kill the SSE
 // stream, so reconnecting then would just thrash the connection and trigger
-// needless onReconnect refetches. The mobile background-freeze we care about
-// lasts far longer than this.
-const RECONNECT_AFTER_HIDDEN_MS = 10_000;
+// needless onReconnect refetches. Lowered (#528) because on mobile the stream
+// dies far more readily than the old 10 s window assumed — a phone can freeze
+// the SSE within a couple of seconds of being backgrounded.
+const RECONNECT_AFTER_HIDDEN_MS = 3_000;
+
+// Foreground liveness watchdog (#528). The `online` / `visibilitychange` /
+// `pageshow` listeners below only recover when the browser *tells* us something
+// changed. On mobile the SSE connection can freeze silently (WLAN↔cellular
+// handover, carrier idle timeout) WITHOUT firing any of those, so a chat stops
+// updating with no event to hang recovery off. This interval polls the
+// connection while the tab is visible and force-reconnects when it is provably
+// dead — either the SDK reports the socket is down, or no realtime traffic has
+// arrived for REALTIME_STALE_MS on a subscription that expects a steady stream.
+const WATCHDOG_INTERVAL_MS = 15_000;
+// A subscription flagged `expectsHeartbeat` is on a page that pushes a periodic
+// self-update echoed back over SSE (the chat-detail 15 s presence ping), so a
+// healthy stream produces an event at least every ~15 s. If none has arrived in
+// this long, the stream is almost certainly frozen. Must comfortably exceed the
+// heartbeat period so a single missed echo doesn't trigger a needless reconnect.
+const REALTIME_STALE_MS = 40_000;
 
 export interface RealtimeSubscription<T = RecordModel> {
 	/** Collection to subscribe to, e.g. 'notifications'. */
@@ -90,6 +107,14 @@ export interface RealtimeSubscription<T = RecordModel> {
 	 * refetch anything that may have changed while the realtime stream was down.
 	 */
 	onReconnect?: () => void;
+	/**
+	 * Set true for subscriptions whose page emits a periodic self-update that is
+	 * echoed back over SSE (e.g. the chat-detail presence heartbeat). Only such a
+	 * subscription enables the watchdog's staleness check — on a page without a
+	 * heartbeat (sidebar/notifications only) a quiet stream is normal, not frozen,
+	 * so the staleness path would thrash. See the watchdog block above.
+	 */
+	expectsHeartbeat?: boolean;
 }
 
 interface ActiveSub {
@@ -97,6 +122,7 @@ interface ActiveSub {
 	topic: string;
 	handler: (event: RecordSubscription<unknown>) => void;
 	onReconnect?: () => void;
+	expectsHeartbeat?: boolean;
 	unsub?: UnsubscribeFunc;
 	cancelled: boolean;
 }
@@ -105,6 +131,14 @@ const activeSubs = new Set<ActiveSub>();
 let recoveryListenersInstalled = false;
 let hiddenSince: number | null = null;
 let reestablishing = false;
+// Timestamp (ms) of the last realtime activity: an incoming event or a
+// successful (re)connect. The watchdog compares this against REALTIME_STALE_MS
+// to detect a silently frozen SSE stream. Seeded on every successful subscribe.
+let lastRealtimeActivityAt = 0;
+
+function markRealtimeActivity(): void {
+	lastRealtimeActivityAt = Date.now();
+}
 
 async function attemptSubscribe(sub: ActiveSub, attempt = 0): Promise<void> {
 	if (sub.cancelled) return;
@@ -116,6 +150,9 @@ async function attemptSubscribe(sub: ActiveSub, attempt = 0): Promise<void> {
 			return;
 		}
 		sub.unsub = unsub;
+		// A fresh connection is itself activity — seed the watchdog clock so a
+		// just-opened subscription isn't judged stale before its first event.
+		markRealtimeActivity();
 	} catch (err) {
 		if (sub.cancelled) return;
 		if (attempt < MAX_SUBSCRIBE_RETRIES) {
@@ -138,11 +175,22 @@ async function reestablishAll(): Promise<void> {
 		} catch {
 			// Nothing connected — fine, we'll connect below.
 		}
-		for (const sub of activeSubs) {
+		// Iterate over a snapshot: navigating between conversations during an
+		// `await` below mutates `activeSubs` (a cancelled sub is removed, a new one
+		// added), which would otherwise disrupt live-set iteration.
+		const subs = [...activeSubs];
+		for (const sub of subs) {
 			sub.unsub = undefined;
 			await attemptSubscribe(sub);
 		}
-		for (const sub of activeSubs) {
+		// A successful reconnect counts as activity — reset the watchdog clock so
+		// it doesn't immediately fire again on the same staleness it just cleared.
+		markRealtimeActivity();
+		for (const sub of subs) {
+			// A sub cancelled while the reconnect was in flight (component unmounted /
+			// navigated away) must not run its onReconnect — a stale invalidateAll()
+			// would refetch data nothing is showing. Same skip as attemptSubscribe.
+			if (sub.cancelled) continue;
 			try {
 				sub.onReconnect?.();
 			} catch (err) {
@@ -161,6 +209,13 @@ function installRecoveryListeners(): void {
 	// Network came back after an outage — always a reason to re-establish.
 	window.addEventListener('online', () => void reestablishAll());
 
+	// bfcache restore (back/forward navigation) resumes a page whose SSE stream
+	// was torn down while it was in the cache; `persisted` marks that path. It
+	// does not always fire `visibilitychange`, so recover explicitly here (#528).
+	window.addEventListener('pageshow', (e) => {
+		if (e.persisted) void reestablishAll();
+	});
+
 	document.addEventListener('visibilitychange', () => {
 		if (document.visibilityState === 'hidden') {
 			hiddenSince = Date.now();
@@ -175,6 +230,26 @@ function installRecoveryListeners(): void {
 			if (hiddenFor >= RECONNECT_AFTER_HIDDEN_MS) void reestablishAll();
 		}
 	});
+
+	// Liveness watchdog (#528): the listeners above only fire when the browser
+	// reports a change, but a mobile SSE stream can freeze silently. Poll while
+	// the tab is visible and force a reconnect when the connection is provably
+	// dead. Runs once (guarded by recoveryListenersInstalled) so the interval is
+	// never duplicated.
+	setInterval(() => {
+		if (document.visibilityState !== 'visible' || activeSubs.size === 0) return;
+		// Always trust the SDK when it says the socket is down.
+		if (getClientPB().realtime.isConnected === false) {
+			void reestablishAll();
+			return;
+		}
+		// Otherwise fall back to staleness — but only for a subscription that
+		// expects a steady heartbeat, so quiet-by-design pages don't thrash.
+		const stale = Date.now() - lastRealtimeActivityAt > REALTIME_STALE_MS;
+		if (stale && [...activeSubs].some((s) => s.expectsHeartbeat)) {
+			void reestablishAll();
+		}
+	}, WATCHDOG_INTERVAL_MS);
 }
 
 /**
@@ -183,11 +258,18 @@ function installRecoveryListeners(): void {
  * comment above). Returns a cleanup function suitable for `$effect`/`onMount`.
  */
 export function subscribeRealtime<T = RecordModel>(options: RealtimeSubscription<T>): () => void {
+	const userHandler = options.handler as unknown as (event: RecordSubscription<unknown>) => void;
 	const sub: ActiveSub = {
 		collection: options.collection,
 		topic: options.topic ?? '*',
-		handler: options.handler as unknown as (event: RecordSubscription<unknown>) => void,
+		// Wrap the caller's handler so every incoming event refreshes the watchdog
+		// clock — a live event is the strongest possible proof the stream is alive.
+		handler: (event) => {
+			markRealtimeActivity();
+			userHandler(event);
+		},
 		onReconnect: options.onReconnect,
+		expectsHeartbeat: options.expectsHeartbeat,
 		cancelled: false
 	};
 	activeSubs.add(sub);

--- a/src/routes/conversations/[conversationId]/+page.svelte
+++ b/src/routes/conversations/[conversationId]/+page.svelte
@@ -164,6 +164,11 @@
 			// so the missing messages appear. Fixes the "doesn't update for one
 			// party" symptom in #435.
 			onReconnect: () => invalidateAll(),
+			// The 15 s presence ping below (conversations.update on lastSeenAt) is
+			// echoed back over SSE, so a healthy stream delivers an event at least
+			// every ~15 s while this chat is open. That lets the client-pb watchdog
+			// treat a longer silence as a silently frozen connection and reconnect (#528).
+			expectsHeartbeat: true,
 		});
 	});
 


### PR DESCRIPTION
## What & why

Real-time chat updates could stop after a number of exchanged messages, especially on mobile (issue #528). The chat detail page subscribes to the `conversations` collection over PocketBase realtime (SSE). That SSE connection can freeze **silently** — WLAN↔cellular handover, carrier/NAT idle timeout on a long-lived HTTP connection — **without** firing `online`, `visibilitychange`, or `EventSource.onerror`. The existing (event-driven) recovery from #435 therefore never re-established the stream, and new messages stopped arriving live.

## Changes (frontend only — backend untouched)

In `src/lib/client-pb.ts`:
- **Liveness clock** (`lastRealtimeActivityAt`): every incoming realtime event marks activity; also marked after a successful (re)subscribe/reconnect.
- **Foreground watchdog** (`setInterval`, installed once in `installRecoveryListeners`, SSR-safe): while the tab is visible and subscriptions are active, it calls `reestablishAll()` when `pb.realtime.isConnected === false`, or when no event has arrived within the stale window **and** a heartbeat-bearing subscription is active. The chat's existing 15 s presence ping is echoed back over SSE, so it doubles as the liveness signal; the `expectsHeartbeat` flag gates the staleness path so traffic-light pages (sidebar/notifications) can't cause reconnect thrash.
- **bfcache/`pageshow`** reconnect (mobile back/forward & app-switch restore).
- Lowered `RECONNECT_AFTER_HIDDEN_MS` 10 s → 3 s.
- Hardened `reestablishAll` to iterate a snapshot copy and skip `cancelled` subs in the `onReconnect` loop (avoids a stale `invalidateAll()` on a page the user already left).

In `src/routes/conversations/[conversationId]/+page.svelte`: set `expectsHeartbeat: true` on the chat-detail subscription.

## Test notes

- **New unit suite** `src/lib/client-pb.test.ts` (12 cases, Vitest + fake timers): watchdog reconnects on `isConnected === false` and on staleness-with-heartbeat; does **not** fire on fresh activity, empty registry, hidden tab, or staleness-without-heartbeat; `pageshow(persisted)` and `online` reconnect; `visibilitychange` only past the threshold; activity clock resets after reconnect.
- Preflight: `npm run lint` ✅ · `npx vitest run` ✅ **528 passed** · `npm run check` / `npm run build` are green for the changed files (they only fail locally on the prod-only `$env/static/private` vars `PB_SUPERUSER_EMAIL` / `PB_SUPERUSER_PASSWORD` / `SYNC_SECRET`, which are absent from the local env but present in CI — verified the build passes exit 0 when they are supplied).
- **Interactive smoke** (Chrome DevTools MCP): live delivery works, the watchdog does **not** thrash on a healthy visible connection (only the ~15 s heartbeat PATCH, single stable EventSource), and `online`→`reestablishAll` re-subscribes cleanly and keeps delivering.
- Manual two-party / mobile verification signed off by the maintainer.

**Reviewer note:** the SSE-freeze itself isn't reliably reproducible in an automated e2e; the recovery *logic* is covered by the unit suite. A pre-existing, unrelated broken `e2e` seed (dirty `pb_data`; `teardown()` doesn't clear `notifications`/`group_invites` referencing seed users) currently blocks `npm run test:e2e` — tracked separately, not part of this change.

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)