### PR TITLE
Default search to show all items, not only available

### DIFF
--- a/src/routes/search/searchFilter.ts
+++ b/src/routes/search/searchFilter.ts
@@ -42,7 +42,8 @@ export function buildSearchFilter(raw: string): string | null {
 /**
  * Parses and validates all search-related URL parameters into a typed `SearchParams` object.
  * Invalid or missing values fall back to safe defaults; unrecognised category values are silently dropped.
- * @param url the request URL containing search parameters (`q`, `page`, `perPage`, `cats`, `op`, `onlyAvailable`, `ownerType`)
+ * @param url the request URL containing search parameters (`q`, `page`, `perPage`, `cats`, `op`, `onlyAvailable`, `ownerType`).
+ *   `onlyAvailable` defaults to `false` (show all items) unless explicitly set to `true`.
  * @returns a fully typed `SearchParams` object with all fields guaranteed to be valid
  */
 export function parseSearchParameters(url: URL): SearchParameters {
@@ -57,7 +58,7 @@ export function parseSearchParameters(url: URL): SearchParameters {
 		.filter((s): s is ItemCategory => ITEM_CATEGORIES.includes(s as ItemCategory));
 
 	const op: 'or' | 'and' = url.searchParams.get('op') === 'and' ? 'and' : 'or';
-	const onlyAvailable = url.searchParams.get('onlyAvailable') !== 'false';
+	const onlyAvailable = url.searchParams.get('onlyAvailable') === 'true';
 
 	const ownerTypeParam = url.searchParams.get('ownerType') ?? 'all';
 	const ownerType: 'all' | 'institution' | 'private' =


### PR DESCRIPTION
## What
Flips the default of the search page's availability filter: previously search defaulted to showing only available items (`onlyAvailable` defaulted to `true` unless `onlyAvailable=false` was explicitly passed). Now it defaults to showing all items regardless of status, and only filters to available items when `onlyAvailable=true` is explicitly requested.

## Why
Requested change to surface all listings by default rather than hiding currently-unavailable items. Users didn't find things they searched for and concluded that they weren't on the platform.

## Where
- `src/routes/search/searchFilter.ts`: `parseSearchParameters` now parses `onlyAvailable` as `=== 'true'` instead of `!== 'false'`.

The existing toggle button/link in `+page.svelte` and the filter-building logic in `buildItemFilter` are unchanged — they already read from the parsed `onlyAvailable` value.

## Test notes
- `npm run lint` — clean
- `npm run check` — 0 errors (pre-existing unrelated warnings only)
- `npx vitest run` — 543 tests passed
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)