### PR TITLE
feat(conversations): abort a request from either side (#373)

### DIFF
--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -139,8 +139,11 @@ stateDiagram-v2
     active --> return_requested : Borrower signals return
     active --> completed : Owner confirms return directly
     return_requested --> completed : Owner confirms return
+    pending --> aborted : Either party aborts
+    accepted --> aborted : Either party aborts
     rejected --> [*]
     completed --> [*]
+    aborted --> [*]
 ```
 
 | Transition | Triggered by | Side effects |
@@ -151,6 +154,9 @@ stateDiagram-v2
 | accepted → active | Owner | Sends `handover_confirmed` notification |
 | active → return_requested | Borrower | Sends `return_requested` notification |
 | active or return_requested → completed | Owner | Sets item `status = available`; sends `return_confirmed` notification; ~33% chance triggers counterfactual impact survey |
+| pending or accepted → aborted | Either party | Terminal cancellation. Item is reset to `status = available` when aborting from `accepted` (the reset runs server-side in the `conversations` `onRecordUpdateRequest` hook so the non-owner requester can free it too). Sends a neutral `request_aborted` notification to the counterparty (does not name who aborted). Enforced authoritatively by the hook (`allerleih-backend/pb_hooks/lending.pb.js`), which restricts the transition to participants and to the `pending`/`accepted` source states. |
+
+**Abort vs. Delete affordance:** while a request is abortable (`pending`/`accepted`) the conversation UI hides the "Anfrage löschen" (delete) control and shows "Anfrage abbrechen" instead (in `pending` only to the requester — the owner keeps "Ablehnen"; in `accepted` to both parties). Delete stays available in the terminal states (`rejected`/`completed`/`aborted`) to clear history.
 
 ---
 

--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -920,6 +920,7 @@ export const texts = {
 		handoverConfirmed: (item: string) => `Übergabe von „${item}" wurde bestätigt`,
 		returnRequested: (from: string, item: string) => `${from} hat „${item}" zurückgegeben`,
 		returnConfirmed: (item: string) => `Rückgabe von „${item}" wurde bestätigt`,
+		requestAborted: (item: string) => `Die Anfrage für „${item}" wurde abgebrochen`,
 	},
 
 	// Lending process
@@ -931,6 +932,7 @@ export const texts = {
 			active: 'Unterwegs',
 			return_requested: 'Rückgabe gemeldet',
 			completed: 'Abgeschlossen',
+			aborted: 'Abgebrochen',
 		},
 		actions: {
 			accept: 'Annehmen',
@@ -938,6 +940,13 @@ export const texts = {
 			confirmHandover: 'Übergabe bestätigen',
 			requestReturn: 'Rückgabe melden',
 			confirmReturn: 'Rückgabe bestätigen',
+			abort: 'Anfrage abbrechen',
+		},
+		// Confirmation modal shown before aborting (mirrors the delete modal).
+		confirmAbort: {
+			title: 'Anfrage abbrechen',
+			body: 'Willst du diese Anfrage wirklich abbrechen? Die andere Person wird benachrichtigt und der Gegenstand wird wieder freigegeben.',
+			confirm: 'Anfrage abbrechen',
 		},
 		statusDescription: {
 			pending: {
@@ -960,6 +969,7 @@ export const texts = {
 			},
 			completed: 'Die Ausleihe ist abgeschlossen.',
 			rejected: 'Diese Anfrage wurde abgelehnt.',
+			aborted: 'Diese Anfrage wurde abgebrochen.',
 		},
 		goToConversation: 'Zur laufenden Anfrage →',
 		errors: {

--- a/src/lib/types/models.ts
+++ b/src/lib/types/models.ts
@@ -431,7 +431,7 @@ export interface Conversation extends PocketBaseEntity {
 	messages: Message[];
 	readByRequester: boolean;
 	readByOwner: boolean;
-	lendingStatus?: 'pending' | 'accepted' | 'rejected' | 'active' | 'return_requested' | 'completed';
+	lendingStatus?: 'pending' | 'accepted' | 'rejected' | 'active' | 'return_requested' | 'completed' | 'aborted';
 	counterfactual?: CounterfactualAnswer;
 	lastMessageAt?: string;
 	requesterLastSeenAt?: string;
@@ -449,7 +449,8 @@ export type NotificationType =
 	| 'request_rejected'
 	| 'handover_confirmed'
 	| 'return_requested'
-	| 'return_confirmed';
+	| 'return_confirmed'
+	| 'request_aborted';
 
 export interface Notification extends PocketBaseEntity {
 	/** Foreign key: recipient user id */

--- a/src/routes/conversations/ConversationListItem.svelte
+++ b/src/routes/conversations/ConversationListItem.svelte
@@ -81,7 +81,7 @@
 			{#if lendingStatusLabel}
 				<span class="inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium mt-0.5
 					{conversation.lendingStatus === 'completed' ? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400'
-					: conversation.lendingStatus === 'rejected' ? 'bg-gray-100 dark:bg-tinte-800 text-tinte-400 dark:text-tinte-500'
+					: conversation.lendingStatus === 'rejected' || conversation.lendingStatus === 'aborted' ? 'bg-gray-100 dark:bg-tinte-800 text-tinte-400 dark:text-tinte-500'
 					: 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-400'}">
 					{lendingStatusLabel}
 				</span>

--- a/src/routes/conversations/[conversationId]/+page.server.ts
+++ b/src/routes/conversations/[conversationId]/+page.server.ts
@@ -133,6 +133,11 @@ export const actions = {
 		return lending.rejectRequest(locals.pb, params.conversationId, locals.user.id);
 	},
 
+	abortRequest: async ({ locals, params }) => {
+		if (!locals.user) return fail(401, { fail: true, message: texts.lending.errors.noPermission });
+		return lending.abortRequest(locals.pb, params.conversationId, locals.user.id);
+	},
+
 	confirmHandover: async ({ locals, params }) => {
 		if (!locals.user) return fail(401, { fail: true, message: texts.lending.errors.noPermission });
 		return lending.confirmHandover(locals.pb, params.conversationId, locals.user.id);

--- a/src/routes/conversations/[conversationId]/+page.svelte
+++ b/src/routes/conversations/[conversationId]/+page.svelte
@@ -3,6 +3,7 @@
 	import type PocketBase from 'pocketbase';
 	import type { RecordSubscription } from 'pocketbase';
 	import { onMount } from 'svelte';
+	import { enhance } from '$app/forms';
 	import { invalidateAll } from '$app/navigation';
 	import { PUBLIC_PB_URL } from '$env/static/public';
 	import { getClientPB, subscribeRealtime } from '$lib/client-pb';
@@ -68,6 +69,20 @@
 
 	// UI state variables
 	let deleteConversationModal = $state(false);
+	let abortRequestModal = $state(false);
+
+	// #373 decision 1: while a request is abortable (pending/accepted) the Delete
+	// affordance is replaced by "Anfrage abbrechen". Delete is available ONLY in the
+	// terminal lending states (rejected/completed/aborted, to clear history) and for
+	// plain chats with no lending status at all. It stays hidden for pending/accepted
+	// (abortable) AND for active/return_requested (a loan in progress).
+	const isAbortable = $derived(
+		lendingStatus === 'pending' || lendingStatus === 'accepted'
+	);
+	const isLoanInProgress = $derived(
+		lendingStatus === 'active' || lendingStatus === 'return_requested'
+	);
+	const canDelete = $derived(!isAbortable && !isLoanInProgress);
 	let showCounterfactualModal = $derived(
 		counterfactual === 'pending' && !loggedInUserIsItemOwner
 	);
@@ -193,7 +208,7 @@
 	{chatPartner}
 	conversation={data.conversation}
 	PB_URL={PUBLIC_PB_URL}
-	onDelete={() => (deleteConversationModal = true)}
+	onDelete={canDelete ? () => (deleteConversationModal = true) : undefined}
 	{loggedInUserIsItemOwner}
 	partnerContact={data.partnerContact}
 />
@@ -202,6 +217,7 @@
 	{lendingStatus}
 	isOwner={loggedInUserIsItemOwner}
 	itemOwnerUsername={displayName(data.conversation.itemOwner)}
+	onAbort={() => (abortRequestModal = true)}
 />
 
 <!-- Messages list -->
@@ -247,5 +263,23 @@
 	>
 		<Input name="conversationId" value={data.conversation.id} hidden></Input>
 		<Button class="bg-danger min-button" type="submit">Anfrage löschen</Button>
+	</form>
+</Modal>
+
+<Modal title={texts.lending.confirmAbort.title} form bind:open={abortRequestModal}>
+	{texts.lending.confirmAbort.body}
+
+	<form
+		class="flex justify-end gap-2 ml-2"
+		method="POST"
+		action="?/abortRequest"
+		use:enhance={() =>
+			async ({ update }) => {
+				abortRequestModal = false;
+				await update();
+			}}
+	>
+		<Input name="conversationId" value={data.conversation.id} hidden></Input>
+		<Button class="bg-danger min-button" type="submit">{texts.lending.confirmAbort.confirm}</Button>
 	</form>
 </Modal>

--- a/src/routes/conversations/[conversationId]/LendingStatusBar.svelte
+++ b/src/routes/conversations/[conversationId]/LendingStatusBar.svelte
@@ -8,12 +8,33 @@
 		isOwner: boolean;
 		/** Username of the item owner — shown in the borrower-facing pending description. */
 		itemOwnerUsername: string;
+		/** Opens the abort-confirmation modal (owned by the parent). */
+		onAbort?: () => void;
 	}
 
-	let { lendingStatus, isOwner, itemOwnerUsername }: Props = $props();
+	let { lendingStatus, isOwner, itemOwnerUsername, onAbort }: Props = $props();
 
 	// Short alias used throughout this file; keeps template expressions concise.
 	const status = $derived(lendingStatus);
+
+	// `rejected` and `aborted` are both terminal dead-ends: no progress bar, just a
+	// gray badge + description. Values are resolved here to keep the template's type
+	// narrowing simple.
+	const isDeadEnd = $derived(status === 'rejected' || status === 'aborted');
+	const deadEndLabel = $derived(
+		status === 'aborted' ? texts.lending.statusLabel.aborted : texts.lending.statusLabel.rejected
+	);
+	const deadEndDescription = $derived(
+		status === 'aborted'
+			? texts.lending.statusDescription.aborted
+			: texts.lending.statusDescription.rejected
+	);
+
+	// Who may abort, per the approved role/state rules (#373): in `pending` only the
+	// requester (the owner uses Ablehnen); in `accepted` either party.
+	const showAbort = $derived(
+		!!onAbort && ((status === 'pending' && !isOwner) || status === 'accepted')
+	);
 
 	// The five forward-progress steps. `rejected` is a dead-end handled separately below.
 	const steps: Array<NonNullable<Conversation['lendingStatus']>> = [
@@ -28,7 +49,7 @@
 
 	// States where the bar is filled up to and including this step
 	function isStepReached(idx: number): boolean {
-		return idx <= currentStepIndex && status !== 'rejected';
+		return idx <= currentStepIndex && !isDeadEnd;
 	}
 
 	// Description text differs by role. `pending` is handled first because its borrower
@@ -39,6 +60,7 @@
 		if (!status) return '';
 		if (status === 'completed') return texts.lending.statusDescription.completed;
 		if (status === 'rejected') return texts.lending.statusDescription.rejected;
+		if (status === 'aborted') return texts.lending.statusDescription.aborted;
 		if (status === 'pending') {
 			const pendingDesc = texts.lending.statusDescription.pending;
 			return isOwner ? pendingDesc.owner : pendingDesc.requester(itemOwnerUsername);
@@ -55,13 +77,13 @@
 
 {#if status}
 	<div class="border-b border-tinte-100 dark:border-tinte-800 bg-papier dark:bg-tinte-900 px-4 sm:py-3 space-y-3 shrink-0">
-		{#if status === 'rejected'}
+		{#if isDeadEnd}
 			<div class="flex items-center gap-2">
 				<span class="inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold bg-gray-100 dark:bg-tinte-800 text-tinte-500 dark:text-tinte-400 border border-gray-200 dark:border-tinte-700">
-					{texts.lending.statusLabel.rejected}
+					{deadEndLabel}
 				</span>
 				<span class="text-xs text-tinte-500 dark:text-tinte-400">
-					{texts.lending.statusDescription.rejected}
+					{deadEndDescription}
 				</span>
 			</div>
 		{:else}
@@ -129,6 +151,13 @@
 								{texts.lending.actions.confirmReturn}
 							</button>
 						</form>
+					{/if}
+					{#if showAbort}
+						<!-- Opens the confirmation modal in the parent; the actual mutation
+						     is the parent's ?/abortRequest form. -->
+						<button type="button" class={secondaryBtnClass} onclick={() => onAbort?.()}>
+							{texts.lending.actions.abort}
+						</button>
 					{/if}
 				</div>
 			</div>

--- a/src/routes/conversations/[conversationId]/lending.server.test.ts
+++ b/src/routes/conversations/[conversationId]/lending.server.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type PocketBase from 'pocketbase';
+import { texts } from '$lib/texts';
+
+// Avoid loading the real notifications module (web-push + VAPID env) at import time.
+vi.mock('$lib/server/notifications.js', () => ({
+	createNotification: vi.fn(),
+	sendPushToUser: vi.fn(),
+	isMessageNotificationThrottled: vi.fn(),
+}));
+
+import { abortRequest } from './lending.server';
+import { createNotification, sendPushToUser } from '$lib/server/notifications.js';
+
+function mockFilter(raw: string, params?: Record<string, unknown>): string {
+	if (!params) return raw;
+	let result = raw;
+	for (const [key, value] of Object.entries(params)) {
+		const escaped = typeof value === 'string' ? `'${value.replace(/'/g, "\\'")}'` : `${value}`;
+		result = result.replaceAll(`{:${key}}`, escaped);
+	}
+	return result;
+}
+
+function makeMockPb(impls: Record<string, Record<string, ReturnType<typeof vi.fn>>>): PocketBase {
+	return {
+		collection: vi.fn((name: string) => impls[name]),
+		filter: vi.fn(mockFilter),
+	} as unknown as PocketBase;
+}
+
+// A conversation between userA (requester) and userB (owner) for item1.
+function conversation(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'conv1',
+		requester: 'userA',
+		itemOwner: 'userB',
+		requestedItem: 'item1',
+		lendingStatus: 'pending',
+		...overrides,
+	};
+}
+
+/** pb wired for a successful abort; `itemUpdate` lets tests assert the item is untouched. */
+function pbForAbort(conv: Record<string, unknown>) {
+	const convUpdate = vi.fn().mockResolvedValue(true);
+	const itemUpdate = vi.fn().mockResolvedValue(true);
+	const pb = makeMockPb({
+		conversations: { getOne: vi.fn().mockResolvedValue(conv), update: convUpdate },
+		items: { getOne: vi.fn().mockResolvedValue({ id: 'item1', name: 'Bohrmaschine' }), update: itemUpdate },
+	});
+	return { pb, convUpdate, itemUpdate };
+}
+
+describe('abortRequest', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('requester aborts a pending request: status → aborted, notifies the owner, no item update', async () => {
+		const { pb, convUpdate, itemUpdate } = pbForAbort(conversation({ lendingStatus: 'pending' }));
+
+		const result = await abortRequest(pb, 'conv1', 'userA');
+
+		expect(result).toBeUndefined(); // void on success
+		expect(convUpdate).toHaveBeenCalledWith('conv1', { lendingStatus: 'aborted' });
+		// The frontend must NOT touch the item — the backend hook frees it.
+		expect(itemUpdate).not.toHaveBeenCalled();
+
+		const body = texts.notifications.requestAborted('Bohrmaschine');
+		// Counterparty of the requester (userA) is the owner (userB).
+		expect(createNotification).toHaveBeenCalledWith(pb, 'userB', 'userA', 'request_aborted', 'conv1', body);
+		expect(sendPushToUser).toHaveBeenCalledWith(pb, 'userB', texts.notifications.pushTitle, body, '/conversations/conv1');
+	});
+
+	it('owner aborts an accepted request: status → aborted, notifies the requester', async () => {
+		const { pb, convUpdate, itemUpdate } = pbForAbort(conversation({ lendingStatus: 'accepted' }));
+
+		const result = await abortRequest(pb, 'conv1', 'userB');
+
+		expect(result).toBeUndefined();
+		expect(convUpdate).toHaveBeenCalledWith('conv1', { lendingStatus: 'aborted' });
+		expect(itemUpdate).not.toHaveBeenCalled();
+
+		const body = texts.notifications.requestAborted('Bohrmaschine');
+		// Counterparty of the owner (userB) is the requester (userA).
+		expect(createNotification).toHaveBeenCalledWith(pb, 'userA', 'userB', 'request_aborted', 'conv1', body);
+		expect(sendPushToUser).toHaveBeenCalledWith(pb, 'userA', texts.notifications.pushTitle, body, '/conversations/conv1');
+	});
+
+	it('rejects an abort from a non-abortable state with fail(400) and no writes', async () => {
+		const { pb, convUpdate } = pbForAbort(conversation({ lendingStatus: 'active' }));
+
+		const result = await abortRequest(pb, 'conv1', 'userA');
+
+		expect(result).toMatchObject({ status: 400 });
+		expect(convUpdate).not.toHaveBeenCalled();
+		expect(createNotification).not.toHaveBeenCalled();
+		expect(sendPushToUser).not.toHaveBeenCalled();
+	});
+
+	it('rejects an abort from a non-participant with fail(403) and no writes', async () => {
+		const { pb, convUpdate } = pbForAbort(conversation({ lendingStatus: 'pending' }));
+
+		const result = await abortRequest(pb, 'conv1', 'stranger');
+
+		expect(result).toMatchObject({ status: 403 });
+		expect(convUpdate).not.toHaveBeenCalled();
+		expect(createNotification).not.toHaveBeenCalled();
+	});
+});

--- a/src/routes/conversations/[conversationId]/lending.server.ts
+++ b/src/routes/conversations/[conversationId]/lending.server.ts
@@ -26,7 +26,7 @@ async function loadAndValidateConversation(
 	pb: PocketBase,
 	conversationId: string,
 	userId: string,
-	requiredRole: 'owner' | 'requester',
+	requiredRole: 'owner' | 'requester' | 'participant',
 	requiredStatus: string | string[]
 ): Promise<{ conv: Record<string, unknown> } | { error: FailResult }> {
 	let conversation: Record<string, unknown>;
@@ -36,8 +36,14 @@ async function loadAndValidateConversation(
 		const e = err as Partial<ClientResponseError>;
 		return { error: fail(e.status ?? 500, { fail: true, message: texts.lending.errors.notFound }) };
 	}
-	const roleField = requiredRole === 'owner' ? 'itemOwner' : 'requester';
-	if (conversation[roleField] !== userId) return { error: fail(403, { fail: true, message: texts.lending.errors.noPermission }) };
+	// `participant` passes for either side of the conversation; the role-specific
+	// checks pin exactly one side.
+	const isParticipant = conversation.itemOwner === userId || conversation.requester === userId;
+	const roleOk =
+		requiredRole === 'participant'
+			? isParticipant
+			: conversation[requiredRole === 'owner' ? 'itemOwner' : 'requester'] === userId;
+	if (!roleOk) return { error: fail(403, { fail: true, message: texts.lending.errors.noPermission }) };
 	const validStatuses = Array.isArray(requiredStatus) ? requiredStatus : [requiredStatus];
 	if (!validStatuses.includes(conversation.lendingStatus as string)) return { error: fail(400, { fail: true, message: texts.lending.errors.invalidState }) };
 	return { conv: conversation };
@@ -150,6 +156,34 @@ export async function confirmHandover(
 
 	const itemName = await getItemName(pb, conv.requestedItem as string);
 	await notifyUser(pb, conv.requester as string, userId, 'handover_confirmed', conversationId, texts.notifications.handoverConfirmed(itemName));
+}
+
+/**
+ * State transition: `pending` | `accepted` → `aborted` (called by EITHER party).
+ * The counterparty is notified (neutrally — the notification does not name who
+ * aborted). The requested item is NOT touched here: on `accepted → aborted` the
+ * backend `lending.pb.js` hook resets it to `available` in an elevated
+ * transaction (the aborting party may be the non-owner requester).
+ */
+export async function abortRequest(
+	pb: PocketBase,
+	conversationId: string,
+	userId: string
+): Promise<FailResult | void> {
+	const result = await loadAndValidateConversation(pb, conversationId, userId, 'participant', ['pending', 'accepted']);
+	if ('error' in result) return result.error;
+	const { conv } = result;
+
+	try {
+		await pb.collection('conversations').update(conversationId, { lendingStatus: 'aborted' });
+	} catch (err) {
+		const e = err as Partial<ClientResponseError>;
+		return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });
+	}
+
+	const itemName = await getItemName(pb, conv.requestedItem as string);
+	const counterpartyId = (conv.requester === userId ? conv.itemOwner : conv.requester) as string;
+	await notifyUser(pb, counterpartyId, userId, 'request_aborted', conversationId, texts.notifications.requestAborted(itemName));
 }
 
 /** State transition: `active` → `return_requested` (called by the borrower). */

--- a/src/routes/notifications/+page.svelte
+++ b/src/routes/notifications/+page.svelte
@@ -18,6 +18,7 @@
 		'handover_confirmed',
 		'return_requested',
 		'return_confirmed',
+		'request_aborted',
 	]);
 
 	function notificationHref(n: Notification): string {


### PR DESCRIPTION
Closes #373.

## What & why
Today a user can only **delete** a request (confusing to the counterparty, who already got a notification) or, as a lender, **reject** it — with no way to *abort* a request that is already underway. This adds an explicit **"Anfrage abbrechen"** for both sides, allowed only while the item is **not** actively lent out.

- New terminal `lendingStatus` value **`aborted`** and `NotificationType` **`request_aborted`**.
- Abort is allowed from **`pending`** (requester only — the owner keeps "Ablehnen") and from **`accepted`** (both parties). Forbidden from `active`/`return_requested`/`completed`/`rejected`.
- **"Anfrage abbrechen" replaces the delete affordance while abortable** (with a confirmation modal). "Anfrage löschen" now appears only in terminal states (`rejected`/`completed`/`aborted`) and in plain chats with no lending — never during a live loan.
- The counterparty is notified (`request_aborted`, links to the conversation). On `accepted → aborted` the item returns to `available` (enforced server-side in the backend hook).
- Status badge "Abgebrochen"; all strings in `texts.ts`; state machine updated in `docs/domain-model.md`.

Server authority for the transition + the item reset lives in the backend hook — see the companion PR: **share-open-sharing-infrastructure/allerleih-backend#33** (merge together).

## Test notes
- `npm run lint` ✓ · `npx vitest run` ✓ (520/520, incl. new `lending.server.test.ts` covering both roles, wrong-state `fail(400)`, non-participant `fail(403)`, and notification routing) · `npm run build` ✓.
- `npm run check`: the only errors are 6 **pre-existing** `$env/static/private` (`SYNC_SECRET`/`PB_SUPERUSER_*`) errors in the integration-sync files, caused by a local `.env` gap and present on `main`; none in files touched here. Same for the local `build` (passes once those prod-only vars are set, as in CI).
- Manual verification (browser, e2e seed): abort from `pending`/`accepted` by both roles, item reset to available on accepted→aborted, counterparty notification, delete-vs-abort visibility across all lending states, and no more HTTP 400 on routine "mark-seen" updates of an aborted conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)