### PR TITLE
In-app pages for email verification & email-change confirmation (#447)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -85,7 +85,8 @@ These prevent the most common bugs/security issues here — follow them without 
   `src/hooks.server.ts` runs `sequence(authentication, authorization)`; `/` requires auth.
   Authentication loads PocketBase auth from cookies and refreshes the token. Authorization
   redirects unauthenticated users to `/auth/login` (preserving `redirectTo`). Unprotected
-  prefixes: `/auth/login`, `/auth/register`, `/auth/reset`, `/search`, `/items`, `/users`,
+  prefixes: `/auth/login`, `/auth/register`, `/auth/reset`, `/auth/confirm-verification`,
+  `/auth/confirm-email-change`, `/search`, `/items`, `/users`,
   `/misc`, `/invite`, `/sitemap.xml`, `/api/redirect`, `/api/diagnostics`,
   `/auth/account-deleted`. Everything else — including `/` (home) — requires authentication.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,7 +46,7 @@ For client-side PocketBase WebSocket subscriptions (live chat), the auth token i
 
 | Group | Routes | Auth required |
 |---|---|---|
-| Auth | `/auth/login`, `/auth/register`, `/auth/reset`, `/auth/logout` | No |
+| Auth | `/auth/login`, `/auth/register`, `/auth/reset`, `/auth/reset/confirm`, `/auth/confirm-verification`, `/auth/confirm-email-change`, `/auth/logout` | No |
 | Core pages | `/search`, `/items/[id]`, `/items/[id]/terms`, `/conversations`, `/conversations/[conversationId]`, `/notifications`, `/social` | Partial (search/items public) |
 | User management | `/user/profile`, `/user/items`, `/user/items/bulk-add`, `/user/import`, `/users/[id]`, `/onboarding`, `/invite/[slug]` | Yes (except `/users/[id]`, `/invite/*`) |
 | API endpoints | `/api/analyze-item`, `/api/geocode`, `/api/travel-times/search`, `/api/travel-times/item`, `/api/push-subscribe`, `/api/redirect`, `/api/diagnostics`, `/api/sync`, `/api/refresh` | Varies |

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -12,6 +12,8 @@ const unprotectedPrefix = [
 	'/auth/login',
 	'/auth/register',
 	'/auth/reset',
+	'/auth/confirm-verification',
+	'/auth/confirm-email-change',
 	'/auth/account-deleted',
 	'/search',
 	'/items',

--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -103,6 +103,13 @@ export const texts = {
 		passwordsDoNotMatch: 'Die Passwörter stimmen nicht überein.',
 		invalidOrExpiredResetToken:
 			'Dieser Link ist ungültig oder abgelaufen. Bitte fordere einen neuen Link zum Zurücksetzen des Passworts an.',
+		invalidOrExpiredVerificationToken:
+			'Dieser Bestätigungslink ist ungültig oder abgelaufen. Bitte fordere eine neue Bestätigungs-E-Mail an.',
+		invalidOrExpiredEmailChangeToken:
+			'Dieser Link zur Änderung der E-Mail-Adresse ist ungültig oder abgelaufen.',
+		emailChangeFailed:
+			'Die E-Mail-Adresse konnte nicht geändert werden. Der Link ist ungültig oder abgelaufen, oder das Passwort ist falsch.',
+		passwordRequired: 'Bitte gib dein aktuelles Passwort ein.',
 		invalidTelegramUsername: 'Ungültiger Telegram-Nutzername. Bitte gib nur den Namen ohne Sonderzeichen ein.',
 		invalidSignalLink: 'Ungültiger Signal-Link. Signal-Links sollten mit "signal.me/" beginnen.',
 		contactEmailRequired:
@@ -130,6 +137,9 @@ export const texts = {
 			'Falls diese E-Mail zu einem Account passt, wurde eine E-Mail zum Zurücksetzen des Passworts gesendet!',
 		passwordResetConfirmed:
 			'Dein Passwort wurde erfolgreich geändert. Du kannst dich jetzt anmelden.',
+		emailVerified: 'Deine E-Mail-Adresse wurde bestätigt. Du kannst dich jetzt anmelden.',
+		emailChanged:
+			'Deine E-Mail-Adresse wurde geändert. Bitte melde dich mit deiner neuen E-Mail-Adresse an.',
 		dataUpdated: 'Daten wurden erfolgreich aktualisiert.',
 		feedbackSent: 'Feedback erfolgreich gesendet. Vielen Dank!',
 		trusteeAdded: (username: string) => `${username} wurde deinem Netzwerk hinzugefügt.`,
@@ -696,6 +706,17 @@ export const texts = {
 				backToReset: 'Neuen Link anfordern',
 			},
 		},
+		confirmVerification: {
+			title: 'E-Mail-Adresse bestätigen',
+			submitButton: 'E-Mail-Adresse bestätigen',
+			backToLogin: 'Zurück zur Anmeldung',
+		},
+		confirmEmailChange: {
+			title: 'Neue E-Mail-Adresse bestätigen',
+			passwordLabel: 'Aktuelles Passwort',
+			submitButton: 'E-Mail-Adresse bestätigen',
+			backToLogin: 'Zurück zur Anmeldung',
+		},
 		updatemail: {
 			title: 'Mailadresse ändern',
 			newEmailLabel: 'Deine neue E-Mail Adresse:',
@@ -1166,6 +1187,14 @@ export const texts = {
 		resetConfirm: {
 			title: 'Neues Passwort festlegen – AllerLeih',
 			description: 'Lege ein neues Passwort für dein AllerLeih-Konto fest.',
+		},
+		confirmVerification: {
+			title: 'E-Mail-Adresse bestätigen – AllerLeih',
+			description: 'Bestätige deine E-Mail-Adresse, um dein AllerLeih-Konto zu aktivieren.',
+		},
+		confirmEmailChange: {
+			title: 'Neue E-Mail-Adresse bestätigen – AllerLeih',
+			description: 'Bestätige die Änderung deiner E-Mail-Adresse für dein AllerLeih-Konto.',
 		},
 		itemDetail: (name: string, owner: string) => `${name} leihen bei ${owner} – AllerLeih`,
 		itemDetailDescription: (name: string, owner: string) =>

--- a/src/routes/auth/confirm-email-change/+page.server.ts
+++ b/src/routes/auth/confirm-email-change/+page.server.ts
@@ -1,0 +1,47 @@
+import { fail, redirect } from '@sveltejs/kit';
+import type { ClientResponseError } from 'pocketbase';
+import { texts } from '$lib/texts';
+
+export async function load({ url }) {
+	return { token: url.searchParams.get('token') };
+}
+
+export const actions = {
+	confirm: async ({ locals, request, cookies }) => {
+		const data = await request.formData();
+		const token = data.get('token');
+		const password = data.get('password');
+
+		if (!token) {
+			return fail(400, { fail: true, message: texts.errors.invalidOrExpiredEmailChangeToken });
+		}
+
+		if (!password) {
+			return fail(400, { fail: true, message: texts.errors.passwordRequired });
+		}
+
+		try {
+			await locals.pb
+				.collection('users')
+				.confirmEmailChange(token.toString(), password.toString());
+		} catch (error) {
+			const errorObj = error as ClientResponseError;
+			console.error('Email change confirmation error:', errorObj);
+			return fail(400, { fail: true, message: texts.errors.emailChangeFailed });
+		}
+
+		// universal flash pattern:
+		cookies.set(
+			'flash',
+			JSON.stringify({
+				type: 'success',
+				message: texts.success.emailChanged,
+			}),
+			{
+				path: '/',
+				maxAge: 60, // seconds
+			}
+		);
+		redirect(303, '/auth/login');
+	},
+};

--- a/src/routes/auth/confirm-email-change/+page.svelte
+++ b/src/routes/auth/confirm-email-change/+page.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	import type { ActionData, PageData } from './$types';
+	import { Section, Register } from 'flowbite-svelte-blocks';
+	import { Button, A } from 'flowbite-svelte';
+	import { resolve } from '$app/paths';
+	import { texts } from '$lib/texts';
+	import CustomAlert from '$lib/components/CustomAlert.svelte';
+	import PasswordInput from '$lib/components/PasswordInput.svelte';
+	import SeoHead from '$lib/components/SeoHead.svelte';
+
+	let { data, form }: { data: PageData; form: ActionData } = $props();
+</script>
+
+<SeoHead
+	title={texts.seo.confirmEmailChange.title}
+	description={texts.seo.confirmEmailChange.description}
+	robots="noindex"
+/>
+
+<Section name="reset">
+	{#if form?.fail}
+		<div class="variant-soft-error rounded-token mb-2 px-4 py-2">
+			<CustomAlert type="error" message={form?.message} />
+		</div>
+	{/if}
+
+	<Register href={resolve('/')} class="w-full sm:max-w-md">
+		{#snippet top()}
+			{texts.pages.confirmEmailChange.title}
+		{/snippet}
+		<div class="space-y-4 p-6 sm:p-8 md:space-y-6">
+			{#if data.token}
+				<!-- Keep ?token in the action target so a failed submit re-renders with data.token
+				     still set — otherwise the query is replaced by ?/confirm, data.token becomes null,
+				     and the {:else} "no token" alert would show ON TOP of the form.fail alert. -->
+				<form class="flex flex-col space-y-5" action="?/confirm&token={data.token}" method="post">
+					<input type="hidden" name="token" value={data.token} />
+					<PasswordInput
+						name="password"
+						label={texts.pages.confirmEmailChange.passwordLabel}
+						autocomplete="current-password"
+					/>
+					<Button
+						type="submit"
+						class="min-button bg-primary-200 hover:bg-primary cursor-pointer w-full"
+						>{texts.pages.confirmEmailChange.submitButton}</Button
+					>
+				</form>
+			{:else}
+				<CustomAlert type="error" message={texts.errors.invalidOrExpiredEmailChangeToken} />
+				<A href={resolve('/auth/login')} class="block text-center"
+					>{texts.pages.confirmEmailChange.backToLogin}</A
+				>
+			{/if}
+		</div>
+	</Register>
+</Section>

--- a/src/routes/auth/confirm-email-change/page.server.test.ts
+++ b/src/routes/auth/confirm-email-change/page.server.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { isRedirect } from '@sveltejs/kit';
+import { actions, load } from './+page.server';
+import { texts } from '$lib/texts';
+
+type ActionEvent = Parameters<typeof actions.confirm>[0];
+
+describe('Confirm email change page', () => {
+	let mockLocals: { pb: { collection: ReturnType<typeof vi.fn> } };
+	let mockCookies: { set: ReturnType<typeof vi.fn> };
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		mockCookies = { set: vi.fn() };
+
+		mockLocals = {
+			pb: {
+				collection: vi.fn(() => ({
+					confirmEmailChange: vi.fn().mockResolvedValue(undefined),
+				})),
+			},
+		};
+	});
+
+	function buildRequest(fields: Record<string, string>) {
+		const data = new FormData();
+		for (const [key, value] of Object.entries(fields)) {
+			data.append(key, value);
+		}
+		return { formData: vi.fn().mockResolvedValue(data) };
+	}
+
+	function callConfirm(request: ReturnType<typeof buildRequest>) {
+		return actions.confirm({
+			locals: mockLocals,
+			request,
+			cookies: mockCookies,
+		} as unknown as ActionEvent);
+	}
+
+	describe('load', () => {
+		it('returns the token from the URL', async () => {
+			const url = new URL('https://allerleih.org/auth/confirm-email-change?token=abc123');
+			expect(await load({ url } as Parameters<typeof load>[0])).toEqual({ token: 'abc123' });
+		});
+
+		it('returns null when no token is present', async () => {
+			const url = new URL('https://allerleih.org/auth/confirm-email-change');
+			expect(await load({ url } as Parameters<typeof load>[0])).toEqual({ token: null });
+		});
+
+		it('still returns the token after a failed-submit round-trip (action target keeps ?token)', async () => {
+			// The form posts to `?/confirm&token=…`, so on re-render the URL still carries the token —
+			// keeping data.token set means only the form.fail alert shows, not the {:else} no-token one.
+			const url = new URL('https://allerleih.org/auth/confirm-email-change?/confirm&token=abc123');
+			expect(await load({ url } as Parameters<typeof load>[0])).toEqual({ token: 'abc123' });
+		});
+	});
+
+	describe('actions.confirm', () => {
+		it('fails when the token is missing', async () => {
+			const request = buildRequest({ password: 'password123' });
+
+			const result = await callConfirm(request);
+
+			expect(result?.status).toBe(400);
+			expect(result?.data?.message).toBe(texts.errors.invalidOrExpiredEmailChangeToken);
+		});
+
+		it('fails when the password is missing', async () => {
+			const request = buildRequest({ token: 'tok' });
+
+			const result = await callConfirm(request);
+
+			expect(result?.status).toBe(400);
+			expect(result?.data?.message).toBe(texts.errors.passwordRequired);
+		});
+
+		it('fails with an email-change-failed message when PocketBase rejects the request', async () => {
+			const confirmEmailChange = vi.fn().mockRejectedValue(new Error('invalid token or password'));
+			mockLocals.pb.collection = vi.fn(() => ({ confirmEmailChange }));
+
+			const request = buildRequest({ token: 'expired-token', password: 'password123' });
+
+			const result = await callConfirm(request);
+
+			expect(result?.status).toBe(400);
+			expect(result?.data?.message).toBe(texts.errors.emailChangeFailed);
+		});
+
+		it('confirms the email change, sets a flash cookie and redirects to login', async () => {
+			const confirmEmailChange = vi.fn().mockResolvedValue(undefined);
+			mockLocals.pb.collection = vi.fn(() => ({ confirmEmailChange }));
+
+			const request = buildRequest({ token: 'valid-token', password: 'password123' });
+
+			try {
+				await callConfirm(request);
+				expect.unreachable('expected redirect to be thrown');
+			} catch (error) {
+				if (!isRedirect(error)) throw error;
+				expect(error.status).toBe(303);
+				expect(error.location).toBe('/auth/login');
+			}
+
+			expect(mockLocals.pb.collection).toHaveBeenCalledWith('users');
+			expect(confirmEmailChange).toHaveBeenCalledWith('valid-token', 'password123');
+			expect(mockCookies.set).toHaveBeenCalledWith(
+				'flash',
+				JSON.stringify({ type: 'success', message: texts.success.emailChanged }),
+				{ path: '/', maxAge: 60 }
+			);
+		});
+	});
+});

--- a/src/routes/auth/confirm-verification/+page.server.ts
+++ b/src/routes/auth/confirm-verification/+page.server.ts
@@ -1,0 +1,40 @@
+import { fail, redirect } from '@sveltejs/kit';
+import type { ClientResponseError } from 'pocketbase';
+import { texts } from '$lib/texts';
+
+export async function load({ url }) {
+	return { token: url.searchParams.get('token') };
+}
+
+export const actions = {
+	confirm: async ({ locals, request, cookies }) => {
+		const data = await request.formData();
+		const token = data.get('token');
+
+		if (!token) {
+			return fail(400, { fail: true, message: texts.errors.invalidOrExpiredVerificationToken });
+		}
+
+		try {
+			await locals.pb.collection('users').confirmVerification(token.toString());
+		} catch (error) {
+			const errorObj = error as ClientResponseError;
+			console.error('Email verification confirmation error:', errorObj);
+			return fail(400, { fail: true, message: texts.errors.invalidOrExpiredVerificationToken });
+		}
+
+		// universal flash pattern:
+		cookies.set(
+			'flash',
+			JSON.stringify({
+				type: 'success',
+				message: texts.success.emailVerified,
+			}),
+			{
+				path: '/',
+				maxAge: 60, // seconds
+			}
+		);
+		redirect(303, '/auth/login');
+	},
+};

--- a/src/routes/auth/confirm-verification/+page.svelte
+++ b/src/routes/auth/confirm-verification/+page.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import type { ActionData, PageData } from './$types';
+	import { Section, Register } from 'flowbite-svelte-blocks';
+	import { Button, A } from 'flowbite-svelte';
+	import { resolve } from '$app/paths';
+	import { texts } from '$lib/texts';
+	import CustomAlert from '$lib/components/CustomAlert.svelte';
+	import SeoHead from '$lib/components/SeoHead.svelte';
+
+	let { data, form }: { data: PageData; form: ActionData } = $props();
+</script>
+
+<SeoHead
+	title={texts.seo.confirmVerification.title}
+	description={texts.seo.confirmVerification.description}
+	robots="noindex"
+/>
+
+<Section name="reset">
+	{#if form?.fail}
+		<div class="variant-soft-error rounded-token mb-2 px-4 py-2">
+			<CustomAlert type="error" message={form?.message} />
+		</div>
+	{/if}
+
+	<Register href={resolve('/')} class="w-full sm:max-w-md">
+		{#snippet top()}
+			{texts.pages.confirmVerification.title}
+		{/snippet}
+		<div class="space-y-4 p-6 sm:p-8 md:space-y-6">
+			{#if data.token}
+				<!-- Keep ?token in the action target so a failed submit re-renders with data.token
+				     still set — otherwise the query is replaced by ?/confirm, data.token becomes null,
+				     and the {:else} "no token" alert would show ON TOP of the form.fail alert. -->
+				<form class="flex flex-col space-y-5" action="?/confirm&token={data.token}" method="post">
+					<input type="hidden" name="token" value={data.token} />
+					<Button
+						type="submit"
+						class="min-button bg-primary-200 hover:bg-primary cursor-pointer w-full"
+						>{texts.pages.confirmVerification.submitButton}</Button
+					>
+				</form>
+			{:else}
+				<CustomAlert type="error" message={texts.errors.invalidOrExpiredVerificationToken} />
+				<A href={resolve('/auth/login')} class="block text-center"
+					>{texts.pages.confirmVerification.backToLogin}</A
+				>
+			{/if}
+		</div>
+	</Register>
+</Section>

--- a/src/routes/auth/confirm-verification/page.server.test.ts
+++ b/src/routes/auth/confirm-verification/page.server.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { isRedirect } from '@sveltejs/kit';
+import { actions, load } from './+page.server';
+import { texts } from '$lib/texts';
+
+type ActionEvent = Parameters<typeof actions.confirm>[0];
+
+describe('Confirm verification page', () => {
+	let mockLocals: { pb: { collection: ReturnType<typeof vi.fn> } };
+	let mockCookies: { set: ReturnType<typeof vi.fn> };
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		mockCookies = { set: vi.fn() };
+
+		mockLocals = {
+			pb: {
+				collection: vi.fn(() => ({
+					confirmVerification: vi.fn().mockResolvedValue(undefined),
+				})),
+			},
+		};
+	});
+
+	function buildRequest(fields: Record<string, string>) {
+		const data = new FormData();
+		for (const [key, value] of Object.entries(fields)) {
+			data.append(key, value);
+		}
+		return { formData: vi.fn().mockResolvedValue(data) };
+	}
+
+	function callConfirm(request: ReturnType<typeof buildRequest>) {
+		return actions.confirm({
+			locals: mockLocals,
+			request,
+			cookies: mockCookies,
+		} as unknown as ActionEvent);
+	}
+
+	describe('load', () => {
+		it('returns the token from the URL', async () => {
+			const url = new URL('https://allerleih.org/auth/confirm-verification?token=abc123');
+			expect(await load({ url } as Parameters<typeof load>[0])).toEqual({ token: 'abc123' });
+		});
+
+		it('returns null when no token is present', async () => {
+			const url = new URL('https://allerleih.org/auth/confirm-verification');
+			expect(await load({ url } as Parameters<typeof load>[0])).toEqual({ token: null });
+		});
+
+		it('still returns the token after a failed-submit round-trip (action target keeps ?token)', async () => {
+			// The form posts to `?/confirm&token=…`, so on re-render the URL still carries the token —
+			// keeping data.token set means only the form.fail alert shows, not the {:else} no-token one.
+			const url = new URL('https://allerleih.org/auth/confirm-verification?/confirm&token=abc123');
+			expect(await load({ url } as Parameters<typeof load>[0])).toEqual({ token: 'abc123' });
+		});
+	});
+
+	describe('actions.confirm', () => {
+		it('fails when the token is missing', async () => {
+			const request = buildRequest({});
+
+			const result = await callConfirm(request);
+
+			expect(result?.status).toBe(400);
+			expect(result?.data?.message).toBe(texts.errors.invalidOrExpiredVerificationToken);
+		});
+
+		it('fails with an invalid-token message when PocketBase rejects the token', async () => {
+			const confirmVerification = vi.fn().mockRejectedValue(new Error('invalid token'));
+			mockLocals.pb.collection = vi.fn(() => ({ confirmVerification }));
+
+			const request = buildRequest({ token: 'expired-token' });
+
+			const result = await callConfirm(request);
+
+			expect(result?.status).toBe(400);
+			expect(result?.data?.message).toBe(texts.errors.invalidOrExpiredVerificationToken);
+		});
+
+		it('confirms the verification, sets a flash cookie and redirects to login', async () => {
+			const confirmVerification = vi.fn().mockResolvedValue(undefined);
+			mockLocals.pb.collection = vi.fn(() => ({ confirmVerification }));
+
+			const request = buildRequest({ token: 'valid-token' });
+
+			try {
+				await callConfirm(request);
+				expect.unreachable('expected redirect to be thrown');
+			} catch (error) {
+				if (!isRedirect(error)) throw error;
+				expect(error.status).toBe(303);
+				expect(error.location).toBe('/auth/login');
+			}
+
+			expect(mockLocals.pb.collection).toHaveBeenCalledWith('users');
+			expect(confirmVerification).toHaveBeenCalledWith('valid-token');
+			expect(mockCookies.set).toHaveBeenCalledWith(
+				'flash',
+				JSON.stringify({ type: 'success', message: texts.success.emailVerified }),
+				{ path: '/', maxAge: 60 }
+			);
+		});
+	});
+});


### PR DESCRIPTION
## What & why

Closes #447 (frontend side). Email **verification** and email **change** confirmations previously bounced users to PocketBase's built-in admin UI on the backend host — the same UX/host-switch problem #367 already fixed for password reset. This adds the two missing in-app pages, analogous to `/auth/reset/confirm`.

## Changes

- **New route `/auth/confirm-verification`** — `+page.server.ts` (load reads `?token`, `confirm` action calls `pb.collection('users').confirmVerification(token)`), `+page.svelte`, co-located Vitest.
- **New route `/auth/confirm-email-change`** — same shape plus a current-password field → `confirmEmailChange(token, password)`.
- Both use **server-side form actions** (not client-side pb), redirect to `/auth/login` with a success flash on completion, and `fail(400)` with a German message on invalid/expired token — mirroring the reset page.
- The action target keeps the token (`action="?/confirm&token={data.token}"`) so a failed submit shows exactly **one** error alert and the form stays resubmittable.
- **`src/hooks.server.ts`** — both paths added to `unprotectedPrefix` (must be reachable without login).
- **`src/lib/texts.ts`** — all new German strings (titles, buttons, errors, success, SEO).
- Docs: `docs/architecture.md` route table + `.claude/CLAUDE.md` unprotected-prefix line kept in sync.

## Test notes

- `npm run lint`: clean. `npx vitest run`: **556/556** (incl. 13 new route tests).
- `npm run check` / `npm run build`: only the 6 pre-existing `$env` sync-var errors (present on `main`, CI has the vars) — none in the changed files.
- Manual smoke (stack up): both routes reachable without login (no redirect to `/auth/login`), invalid-token submit shows a single error, backend mail templates resolve to `127.0.0.1:5173/auth/...`.

Backend counterpart (the migration + bootstrap hook that point the mail templates here): **share-open-sharing-infrastructure/allerleih-backend#34**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
