### PR TITLE
fix(conversations): prevent autofocus scroll trapping mobile chat on deep link (#529)

### DIFF
--- a/src/routes/conversations/+layout.svelte
+++ b/src/routes/conversations/+layout.svelte
@@ -40,6 +40,11 @@
 		const body = document.body;
 		const prevHtml = html.style.overflow;
 		const prevBody = body.style.overflow;
+		// Reset to the top before locking: on a cold load the document can already be
+		// scrolled down (e.g. the input focus dragging the too-tall page into view), and
+		// locking `overflow: hidden` would otherwise freeze it there — footer showing,
+		// view trapped (#529). The input now focuses with preventScroll, this is the belt.
+		window.scrollTo(0, 0);
 		html.style.overflow = 'hidden';
 		body.style.overflow = 'hidden';
 		return () => {

--- a/src/routes/conversations/[conversationId]/MessageForm.svelte
+++ b/src/routes/conversations/[conversationId]/MessageForm.svelte
@@ -2,6 +2,7 @@
 	import { enhance } from '$app/forms';
 	import { texts } from '$lib/texts';
 	import { PaperPlaneSolid } from 'flowbite-svelte-icons';
+	import { onMount } from 'svelte';
 
 	let {
 		chatPartner,
@@ -12,6 +13,18 @@
 		isSubmitting: boolean;
 		messageText: string;
 	} = $props();
+
+	let inputEl: HTMLInputElement | undefined = $state();
+
+	// Focus the input on mount WITHOUT scrolling it into view. The HTML `autofocus`
+	// attribute always scrolls the focused element into the viewport; on a mobile cold
+	// load (deep link / reload) the document is taller than the visual viewport
+	// (min-h-screen root shell + footer), so that scroll drags the whole page down —
+	// and the conversation layout's scroll-lock then freezes it there, revealing the
+	// footer and trapping the view (#529). `preventScroll` keeps focus without scrolling.
+	onMount(() => {
+		inputEl?.focus({ preventScroll: true });
+	});
 </script>
 
 <form
@@ -28,15 +41,14 @@
 	}}
 >
 	<input name="chatPartnerId" value={chatPartner.id} hidden />
-	<!-- svelte-ignore a11y_autofocus -->
 	<input
+		bind:this={inputEl}
 		name="messageContent"
 		type="text"
 		placeholder={texts.forms.messagePlaceholder}
 		class="flex-1 rounded-full border border-tinte-200 dark:border-tinte-700 bg-papier dark:bg-tinte-800 px-4 py-2 text-sm outline-none focus:ring-2 focus:ring-primary-300 dark:focus:ring-primary-700 transition"
 		required
 		autocomplete="off"
-		autofocus={true}
 		bind:value={messageText}
 	/>
 	<!-- preventDefault on mousedown keeps focus in the input so tapping send doesn't blur


### PR DESCRIPTION
## What & why

Follow-up to #534, which did **not** resolve #529 on prod. The real trigger, confirmed on a
real Android device: opening a conversation via a **direct URL / deep link** (push notification,
shared link, reload) — not via in-app navigation.

**Root cause:** the message input used the HTML `autofocus` attribute, which always scrolls the
focused element into view. On a mobile cold load the document is taller than the visual viewport
(the `min-h-screen` root shell + footer), so that autofocus scroll dragged the whole page down,
and the conversation layout's scroll-lock (`overflow: hidden`) then froze it there — the footer
showed and the view was trapped, with no way to scroll up. Internal navigation was unaffected
because the layout was already mounted and locked at the top, so autofocus had nothing to scroll.

#534's re-measuring of `visualViewport` targeted the wrong mechanism, which is why the bug
survived. This change fixes the actual cause.

## Changes

- **`MessageForm.svelte`** — replace the HTML `autofocus` attribute with a programmatic
  `inputEl.focus({ preventScroll: true })` on mount, so the input still focuses without scrolling
  the document into a trapped state.
- **`conversations/+layout.svelte`** — reset the document to the top (`window.scrollTo(0, 0)`)
  before engaging the scroll-lock, so a cold-load scroll can't be frozen in place.

Conversations-only, CSS/behavior; Svelte 5 runes; no data-layer or string changes.

## Test notes

Preflight (all green): `npm run lint`, `npm run check` (0 errors), `npx vitest run` (543 passed),
`npm run build`. **Verified on a real Android phone** against a LAN dev instance: opening a
conversation by direct URL now loads cleanly and is fully operable (previously the footer showed
and the page was locked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
