### PR TITLE
feat: explain the lending process on external institution items (#368)

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -24,6 +24,7 @@ erDiagram
         string contactEmail "dedicated contact address (contactMethod=email) — raw value never in a *_public view"
         string contactUrl "external lending-form link (contactMethod=link) — raw value never in a *_public view"
         bool contactPublic "issue #438 — when true the contact CTA is shown to unauthenticated browsing too"
+        string externalLendingInfo "issue #368 — per-institution 'how borrowing works' text for external items (max 1000); public help text surfaced via items_public.ownerExternalLendingInfo"
         string inviteCode
         string invitedBy FK
         string leihbackendUrl "leihbackend instance origin, for institutional sync"
@@ -453,6 +454,14 @@ account. Each is `NULL` unless the owner set `contactPublic = true` **and** the 
 `*_public`/`items_searchable` view, so the members-only case (`contactPublic = false`) never
 leaks — logged-in viewers read those from the base `users` record instead.
 
+For issue #368 the view also surfaces the owner's per-institution **lending explanation** as
+`ownerExternalLendingInfo` (from `users.externalLendingInfo`) — the item-detail page shows it in
+a permanent "how borrowing works" box on external/institution items. Unlike the `ownerContact*`
+columns there is **no** `contactPublic` gate (it is a public help text, no PII); it is masked to
+`NULL` with the same condition as the item's own content columns, so a restricted item's help
+text never rides along. `externalLendingInfo` is **not** added to `users_public` or
+`items_searchable`.
+
 ### `items_searchable` — audience-filtered, unmasked
 
 Used by the search page (and the profile and sitemap, to stay leak-free). Its
@@ -474,6 +483,7 @@ conversation access never leaks an item into search/profile/sitemap.
 | userId, username, isInstitution, bio, verified, profileImage, userCreated | users | Joined from owner (no trust data is exposed — trust lives in the separate `trusts` collection) |
 | ownerHasLocation | SQL expression on `user_geolocations` | 1 if the owner has a non-(0,0) location, else 0 |
 | ownerContactMethod, ownerContactEmail, ownerContactUrl | SQL expression on `users` | `items_public` only — the owner's off-platform contact (#438), NULL unless `contactPublic` **and** the item is unmasked; raw contact fields never selected |
+| ownerExternalLendingInfo | SQL expression on `users` | `items_public` only — the owner's per-institution lending explanation (#368), masked to `NULL` for restricted items (no `contactPublic` gate; public help text); not in `users_public`/`items_searchable` |
 
 > **A view returns only the columns in its `viewQuery` SELECT — nothing else.** The TS
 > `ItemPublic` type extends `PocketBaseEntity`, so it *declares* `id`, `created` and `updated`,

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -99,6 +99,12 @@ The **core never imports a concrete integration.** Concrete integrations import 
 | `owner` | `owner` | The institution's `users` id. |
 | `trusteesOnly` | `trusteesOnly` | Synced items are typically `false`. |
 
+> **Lending explanation is per institution, not per item (#368).** The "how borrowing works"
+> text shown on an external item's detail page lives on the owner's `users` record
+> (`externalLendingInfo`), maintained by the institution in its profile — it is **not** part of
+> `MappedItem`, so importing/refresh never carries it. When empty, the item page shows a shared
+> default text.
+
 ---
 
 ## Triggering & operations

--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -1218,6 +1218,14 @@ export const texts = {
 		availabilityHintExternal: 'Aktuelle Verfügbarkeit beim Anbieter prüfen.',
 		availabilityHintUnknown: 'Verfügbarkeit unbekannt',
 		archivedBanner: 'Dieses Angebot ist nicht mehr Teil des Bestandes.',
+		// Issue #368 — permanent "how the lending works" box on external/institution items.
+		externalLendingInfoTitle: 'So funktioniert die Ausleihe',
+		externalLendingInfoDefault:
+			'Dieser Gegenstand wird von einer Partner-Institution bereitgestellt und kann nicht direkt über AllerLeih reserviert oder gebucht werden. Für die Ausleihe wendest du dich direkt an die Institution — meist brauchst du dort ein eigenes Konto, und die Abholung erfolgt vor Ort. Über den Button gelangst du zum Angebot der Institution mit allen Details.',
+		// Self-service editor (profile form, institutions only).
+		externalLendingInfoEditLabel: 'Ausleih-Hinweis',
+		externalLendingInfoEditHint:
+			'Erkläre, wie Interessierte einen deiner externen Gegenstände ausleihen können (z. B. eigenes Konto nötig, Abholung vor Ort). Dieser Text ist für alle öffentlich sichtbar – gib hier keine vertraulichen Daten ein. Bleibt das Feld leer, zeigen wir einen allgemeinen Standardtext. Max. 1000 Zeichen.',
 		imagePlaceholder: 'Foto folgt',
 		importNavLabel: 'Bestand importieren',
 		importTitle: 'Bestand als CSV importieren',

--- a/src/lib/types/models.ts
+++ b/src/lib/types/models.ts
@@ -100,6 +100,16 @@ export interface User extends PocketBaseEntity {
 	contactPublic?: boolean;
 
 	/**
+	 * Issue #368: per-institution free-text explanation of how to borrow this owner's
+	 * external/integrated items (owner has `isInstitution = true`, item carries an
+	 * `externalUrl`). Belongs to the institution (one process explanation, not per item),
+	 * self-maintained via the profile form. Public help text (no PII); reaches
+	 * unauthenticated browsing via `items_public.ownerExternalLendingInfo` (masked like the
+	 * item's content columns). Empty → the UI shows a shared default text. Max 1000 chars.
+	 */
+	externalLendingInfo?: string;
+
+	/**
 	 * Geographic coordinates. PocketBase GeoPoint: {"lon": 12.34, "lat": 56.78}.
 	 * Zero value {"lon":0,"lat":0} means no location set (Null Island).
 	 */
@@ -338,6 +348,14 @@ export interface ItemPublic extends PocketBaseEntity {
 	ownerContactMethod?: '' | 'email' | 'link' | null;
 	ownerContactEmail?: string | null;
 	ownerContactUrl?: string | null;
+	/**
+	 * Issue #368 — the owner's per-institution "how the lending works" explanation
+	 * (`users.externalLendingInfo`), surfaced to UNauthenticated browsing. Bound to the
+	 * view SELECT: masked to NULL for restricted (trustees-only/group-shared) items, like
+	 * the item's own content columns. No `contactPublic` gate (public help text, no PII).
+	 * NULL when the owner set no text.
+	 */
+	ownerExternalLendingInfo?: string | null;
 }
 
 // --- GROUPS ---

--- a/src/routes/items/[id]/+page.server.ts
+++ b/src/routes/items/[id]/+page.server.ts
@@ -180,6 +180,12 @@ export async function load({ params, locals }) {
 		unmetRequirements,
 		ownerContact,
 		ownerHasLocation: !!item.ownerHasLocation,
+		// Issue #368 — the institution's process explanation for external items, read from the
+		// already-loaded items_public row (masked to NULL for restricted items, so no extra
+		// query and no leak). Empty/NULL → the component falls back to the shared default text.
+		externalLendingInfo:
+			(typeof item.ownerExternalLendingInfo === 'string' && item.ownerExternalLendingInfo) ||
+			null,
 	};
 }
 

--- a/src/routes/items/[id]/+page.svelte
+++ b/src/routes/items/[id]/+page.svelte
@@ -2,7 +2,7 @@
 	import { Badge, Alert, Tooltip } from 'flowbite-svelte';
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
-	import { HeartSolid } from 'flowbite-svelte-icons';
+	import { HeartSolid, InfoCircleOutline } from 'flowbite-svelte-icons';
 	import { texts } from '$lib/texts';
 	import { getCategoryPlaceholder } from '$lib/utils/categoryPlaceholder';
 	import { itemImageUrl, itemImageUrls } from '$lib/utils/utils';
@@ -114,6 +114,18 @@
 	<!-- Request error feedback (e.g. lender requirements not met on submit) -->
 	{#if form?.fail && form?.message}
 		<CustomAlert type="error" message={form.message} />
+	{/if}
+
+	<!-- Issue #368: permanent explanation of how borrowing works for external/institution
+	     items. Owner-provided text (data.externalLendingInfo) or a shared default fallback. -->
+	{#if isExternal}
+		<Alert color="blue" class="items-start">
+			{#snippet icon()}<InfoCircleOutline class="h-5 w-5 shrink-0" />{/snippet}
+			<p class="font-semibold">{texts.institutional.externalLendingInfoTitle}</p>
+			<p class="mt-1 whitespace-pre-line font-normal">
+				{data.externalLendingInfo ?? texts.institutional.externalLendingInfoDefault}
+			</p>
+		</Alert>
 	{/if}
 
 	<!-- Travel Time + CTA -->

--- a/src/routes/items/[id]/+page.svelte
+++ b/src/routes/items/[id]/+page.svelte
@@ -30,6 +30,12 @@
 	const isTrustRestricted = $derived(data.isTrustRestricted);
 	const isOwnItem = $derived(data.isOwnItem);
 	const isExternal = $derived(!!item.externalUrl);
+	// Issue #368 (review): the "how the lending works" box must appear whenever the
+	// borrower is sent off-platform — not only for externalUrl deep-links, but also when
+	// an institution routes requests to an off-platform contact (#438: mailto / external
+	// link, no externalUrl). Scoped to institutions, since the box and its override text
+	// are institution-specific.
+	const showLendingInfo = $derived(isExternal || (!!data.ownerContact && item.isInstitution));
 	const categoryPlaceholder = $derived(getCategoryPlaceholder(item.categories));
 	const isArchived = $derived(item.description?.startsWith('[Nicht mehr im Bestand]') ?? false);
 
@@ -117,8 +123,10 @@
 	{/if}
 
 	<!-- Issue #368: permanent explanation of how borrowing works for external/institution
-	     items. Owner-provided text (data.externalLendingInfo) or a shared default fallback. -->
-	{#if isExternal}
+	     items. Shown for externalUrl deep-links AND institutions that route requests to an
+	     off-platform contact (#438). Owner-provided text (data.externalLendingInfo) or a
+	     shared default fallback. -->
+	{#if showLendingInfo}
 		<Alert color="blue" class="items-start">
 			{#snippet icon()}<InfoCircleOutline class="h-5 w-5 shrink-0" />{/snippet}
 			<p class="font-semibold">{texts.institutional.externalLendingInfoTitle}</p>

--- a/src/routes/items/[id]/page.server.test.ts
+++ b/src/routes/items/[id]/page.server.test.ts
@@ -252,6 +252,59 @@ describe('items/[id] load — off-platform-contact owners (#438)', () => {
 	});
 });
 
+describe('items/[id] load — externalLendingInfo pass-through (#368)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		getActiveTerms.mockResolvedValue(null);
+		hasAcceptedActiveTerms.mockResolvedValue(true);
+		evaluateUnmetRequirements.mockResolvedValue([]);
+	});
+
+	it('passes the owner explanation through from the items_public row (authenticated)', async () => {
+		const { pb } = makePb({
+			itemExtra: { ownerExternalLendingInfo: 'Abholung vor Ort im Rathaus.' },
+		});
+
+		const data = await callLoad(pb);
+
+		expect(data.externalLendingInfo).toBe('Abholung vor Ort im Rathaus.');
+	});
+
+	it('passes the owner explanation through for an anonymous viewer too', async () => {
+		const { pb } = makePb({
+			itemExtra: { ownerExternalLendingInfo: 'Abholung vor Ort im Rathaus.' },
+		});
+
+		const data = await callLoad(pb, null);
+
+		expect(data.externalLendingInfo).toBe('Abholung vor Ort im Rathaus.');
+	});
+
+	it('falls back to null when the column is NULL (masked / no override)', async () => {
+		const { pb } = makePb({ itemExtra: { ownerExternalLendingInfo: null } });
+
+		const data = await callLoad(pb);
+
+		expect(data.externalLendingInfo).toBeNull();
+	});
+
+	it('falls back to null when the column is an empty string', async () => {
+		const { pb } = makePb({ itemExtra: { ownerExternalLendingInfo: '' } });
+
+		const data = await callLoad(pb);
+
+		expect(data.externalLendingInfo).toBeNull();
+	});
+
+	it('falls back to null when the column is absent from the row', async () => {
+		const { pb } = makePb({});
+
+		const data = await callLoad(pb);
+
+		expect(data.externalLendingInfo).toBeNull();
+	});
+});
+
 describe('items/[id] load — preferred transport mode (#426, from user_preferences)', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();

--- a/src/routes/user/profile/+page.server.ts
+++ b/src/routes/user/profile/+page.server.ts
@@ -189,6 +189,17 @@ export const actions = {
 			updateData['bio'] = bio.trim();
 		}
 
+		// External-item lending explanation (#368) → institutions only. Always written for
+		// an institution (so clearing the override works and falls back to the default text);
+		// capped at 1000 to mirror the DB field. Non-institutions never see the editor and
+		// their save must not touch the field.
+		if (locals.user?.isInstitution) {
+			const externalLendingInfo = (formData?.get('externalLendingInfo')?.toString() ?? '')
+				.trim()
+				.slice(0, 1000);
+			updateData['externalLendingInfo'] = externalLendingInfo;
+		}
+
 		// Handle profileImage file upload
 		const profileImageFile = formData?.get('profileImage');
 		const hasProfileImage = profileImageFile instanceof File && profileImageFile.size > 0;

--- a/src/routes/user/profile/+page.svelte
+++ b/src/routes/user/profile/+page.svelte
@@ -9,6 +9,7 @@
 	import EmailSection from './EmailSection.svelte';
 	import MessengerField from './MessengerField.svelte';
 	import ContactSection from './ContactSection.svelte';
+	import ExternalLendingInfoSection from './ExternalLendingInfoSection.svelte';
 	import NotificationSettings from './NotificationSettings.svelte';
 	import LendingRequirementsSection from './LendingRequirementsSection.svelte';
 	import InviteLink from './InviteLink.svelte';
@@ -336,6 +337,14 @@
 							contactUrl={data.currentUser.contactUrl ?? ''}
 							contactPublic={data.currentUser.contactPublic ?? false}
 						/>
+
+						<!-- Ausleih-Hinweis for external items (#368): institutions only. Saves via
+						     the shared save bar. -->
+						{#if data.currentUser.isInstitution}
+							<ExternalLendingInfoSection
+								externalLendingInfo={data.currentUser.externalLendingInfo ?? ''}
+							/>
+						{/if}
 					</section>
 
 					<!-- VERLEIH-VORAUSSETZUNGEN: lender-defined borrower requirements (#443).

--- a/src/routes/user/profile/ExternalLendingInfoSection.svelte
+++ b/src/routes/user/profile/ExternalLendingInfoSection.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import { texts } from '$lib/texts';
+
+	// Issue #368: institutions maintain a free-text explanation of how borrowing their
+	// external items works. Only rendered for institutional accounts (gated by the parent).
+	// Submits with the surrounding ?/saveProfile form via its name; empty clears the override
+	// and the item page falls back to the shared default text.
+	let { externalLendingInfo = '' }: { externalLendingInfo?: string } = $props();
+
+	// Seed the editable textarea from the loaded value (it won't change during the page's life).
+	// svelte-ignore state_referenced_locally
+	let value = $state(externalLendingInfo);
+</script>
+
+<div class="border-t pt-6 space-y-4">
+	<!-- h3: sub-block of the "Kontakt" section card (which owns the h2). -->
+	<h3 class="text-lg font-semibold text-tinte-900 dark:text-white">
+		{texts.institutional.externalLendingInfoEditLabel}
+	</h3>
+	<p class="text-sm text-tinte-600 dark:text-tinte-400">
+		{texts.institutional.externalLendingInfoEditHint}
+	</p>
+
+	<div class="flex flex-col sm:flex-row sm:items-start gap-2 sm:gap-4">
+		<label
+			for="externalLendingInfo"
+			class="sm:w-36 sm:shrink-0 sm:pt-2 text-sm font-medium text-tinte-900 dark:text-white"
+		>
+			{texts.institutional.externalLendingInfoEditLabel}
+		</label>
+		<div class="sm:flex-1">
+			<textarea
+				name="externalLendingInfo"
+				id="externalLendingInfo"
+				rows="4"
+				maxlength="1000"
+				bind:value
+				class="w-full px-3 py-2 bg-gray-50 border border-gray-300 rounded-lg text-gray-900 focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white resize-y"
+			></textarea>
+		</div>
+	</div>
+</div>

--- a/src/routes/user/profile/page.server.test.ts
+++ b/src/routes/user/profile/page.server.test.ts
@@ -38,13 +38,13 @@ type SaveEvent = Parameters<typeof actions.saveProfile>[0];
 
 const USER_ID = 'u1';
 
-function callSave(fields: Record<string, string>) {
+function callSave(fields: Record<string, string>, opts: { isInstitution?: boolean } = {}) {
 	const fd = new FormData();
 	for (const [k, v] of Object.entries(fields)) fd.set(k, v);
 	const update = vi.fn().mockResolvedValue({});
 	const pb = { collection: vi.fn(() => ({ update })) };
 	const result = actions.saveProfile({
-		locals: { pb, user: { id: USER_ID } },
+		locals: { pb, user: { id: USER_ID, isInstitution: opts.isInstitution ?? false } },
 		request: { formData: vi.fn().mockResolvedValue(fd) },
 	} as unknown as SaveEvent);
 	return { result, update, pb };
@@ -267,5 +267,50 @@ describe('profile saveProfile — off-platform-contact opt-in (#438)', () => {
 		expect(sent.get('contactEmail')).toBe('');
 		expect(sent.get('contactUrl')).toBe('');
 		expect(sent.get('contactPublic')).toBe('false');
+	});
+});
+
+describe('profile saveProfile — external-item lending info (#368)', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('persists a trimmed externalLendingInfo for an institution', async () => {
+		const { result, update } = callSave(
+			{ externalLendingInfo: '  Abholung vor Ort im Rathaus.  ' },
+			{ isInstitution: true }
+		);
+
+		expect(await result).toMatchObject({ success: true });
+		const sent = (update.mock.calls[0] as unknown[])[1] as FormData;
+		expect(sent.get('externalLendingInfo')).toBe('Abholung vor Ort im Rathaus.');
+	});
+
+	it('writes an empty string when an institution clears the field (falls back to default)', async () => {
+		const { result, update } = callSave({ externalLendingInfo: '   ' }, { isInstitution: true });
+
+		expect(await result).toMatchObject({ success: true });
+		const sent = (update.mock.calls[0] as unknown[])[1] as FormData;
+		expect(sent.get('externalLendingInfo')).toBe('');
+	});
+
+	it('caps the stored text at 1000 characters', async () => {
+		const { result, update } = callSave(
+			{ externalLendingInfo: 'x'.repeat(1500) },
+			{ isInstitution: true }
+		);
+
+		expect(await result).toMatchObject({ success: true });
+		const sent = (update.mock.calls[0] as unknown[])[1] as FormData;
+		expect((sent.get('externalLendingInfo') as string).length).toBe(1000);
+	});
+
+	it('never writes externalLendingInfo for a non-institution account', async () => {
+		const { result, update } = callSave(
+			{ externalLendingInfo: 'sollte ignoriert werden' },
+			{ isInstitution: false }
+		);
+
+		expect(await result).toMatchObject({ success: true });
+		const sent = (update.mock.calls[0] as unknown[])[1] as FormData;
+		expect(sent.get('externalLendingInfo')).toBeNull();
 	});
 });


### PR DESCRIPTION
## What & why

Closes share-open-sharing-infrastructure/share-mvp#368.

External items from partner institutions can't be booked through AllerLeih, and users had no idea **how** to actually borrow such an item — the process was described neither on AllerLeih nor on the external page.

This change shows a persistent info box **"So funktioniert die Ausleihe"** on the detail page of every external item:

- a **general default text** that applies immediately to all external items, **plus**
- an **optional per-institution override** (`users.externalLendingInfo`) that the institution maintains itself in its profile.

So the explanation does **not** have to be set per item on import (explicitly undesired in the issue) — it lives on the institution instead.

## Changes (frontend)

- **Item detail** (`items/[id]/+page.svelte` / `+page.server.ts`): always-visible info box for external items; content = institution override **or** default. The value comes from the already-loaded `items_public` row (`ownerExternalLendingInfo`) with no extra query.
- **Profile editor** (`ExternalLendingInfoSection.svelte`, `user/profile/+page.*`): a "Ausleih-Hinweis" textarea, visible **only to institutions**, saved through the existing `saveProfile` form action (trimmed, capped at 1000 chars, mass-assignment gated on `isInstitution`).
- **Texts** (`texts.ts`): default text, box title, editor label/hint (including a note that the text is publicly visible).
- `models.ts` + `docs/data-model.md` + `docs/integrations.md` updated.

## 📝 The default text can still be changed

The general default text ("Dieser Gegenstand wird von einer Partner-Institution bereitgestellt …") is intentionally a placeholder/starting value — **I may still want to adjust the wording.** It lives centrally in `src/lib/texts.ts` (`institutional.externalLendingInfoDefault`) and can be changed there at any time without further code changes.

## Tests

- Frontend unit (Vitest): **45/45 green** — loader pass-through (value / NULL / empty→null) and profile save (trim, clear, 1000 cap, never writes for non-institution).
- Browser smoke (Chrome DevTools MCP): anonymous default vs. override box correct, non-external item shows no box, profile editor institution-only, no console/network errors.

## Related backend PR

Schema (field + `items_public` column): https://github.com/share-open-sharing-infrastructure/allerleih-backend/pull/35

🤖 Generated with [Claude Code](https://claude.com/claude-code)
