### PR TITLE
fix(search): keep search bar focused across auto-search navigations

### DIFF
--- a/docs/search-discovery.md
+++ b/docs/search-discovery.md
@@ -70,3 +70,14 @@ All discovery state lives in the URL (deep-linkable, server-rendered). Defaults 
   already loaded for the current page, so pagination is hidden while that filter is active
   (see `durationFilter.paginationHidden` in `texts.ts`).
 - **All user-facing strings** belong in `src/lib/texts.ts` under `pages.search`.
+- **Search-bar focus & debounce** ([`SearchBar.svelte`](../src/routes/search/SearchBar.svelte)):
+  typing auto-searches after a `SEARCH_DELAY_MS` (1200 ms) pause. Every programmatic `goto` uses
+  `{ keepFocus: true, noScroll: true }` so the input keeps focus across the client-side
+  navigation (SvelteKit otherwise resets focus to `<body>`, dropping it mid-type) and the results
+  list doesn't jump to the top while typing. The debounced auto-search and the `<3`-char reset
+  additionally pass `replaceState: true` so a stream of keystrokes collapses into one history
+  entry; the explicit submit (Enter/button) and the clear (×) button keep their own entries
+  (no `replaceState`). Initial mount focus is applied **only on desktop** — gated behind
+  `window.matchMedia('(hover: hover) and (pointer: fine)')` in an `$effect`, not an `autofocus`
+  attribute — so touch devices don't pop the on-screen keyboard on page load (#429/#453).
+  Regression coverage: [`e2e/tests/search-focus.spec.ts`](../e2e/tests/search-focus.spec.ts).

--- a/e2e/tests/search-focus.mobile.spec.ts
+++ b/e2e/tests/search-focus.mobile.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect, devices } from '@playwright/test';
+
+/**
+ * Mobile (touch) counterpart to `search-focus.spec.ts` (#453). Split into its own file
+ * because the Pixel-5 preset sets `defaultBrowserType`, which Playwright only permits at
+ * the top level of a spec — not inside a `test.describe` group. `/search` is public, so
+ * this runs in the `public` project without auth setup.
+ */
+test.use({ ...devices['Pixel 5'] });
+
+test('search bar is NOT autofocused on load on touch devices (no keyboard pop)', async ({
+	page,
+}) => {
+	await page.goto('/search');
+
+	const input = page.getByRole('searchbox');
+	await expect(input).toBeVisible();
+	// Touch device (coarse pointer, no hover) → the mount-focus heuristic is skipped.
+	await expect(input).not.toBeFocused();
+});

--- a/e2e/tests/search-focus.spec.ts
+++ b/e2e/tests/search-focus.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Search-bar focus behaviour on desktop (#453). `/search` is a public route (reachable
+ * while logged out), so these run in the `public` project without any auth setup.
+ * The mobile (touch) counterpart lives in `search-focus.mobile.spec.ts` because the
+ * Pixel-5 device preset sets `defaultBrowserType`, which Playwright only allows top-level.
+ */
+
+test.describe('search bar focus (desktop)', () => {
+	test('autofocuses on load and keeps focus across the debounced auto-search', async ({
+		page,
+	}) => {
+		await page.goto('/search');
+
+		const input = page.getByRole('searchbox');
+		await expect(input).toBeVisible();
+		// Desktop (precise pointer / hover) → autofocus on mount.
+		await expect(input).toBeFocused();
+
+		// Typing ≥3 chars triggers a debounced client-side navigation …
+		await input.pressSequentially('lampe');
+		await expect(page).toHaveURL(/[?&]q=lampe(?:&|$)/);
+
+		// … and focus survives it (keepFocus), so the user can keep typing without re-clicking.
+		await expect(input).toBeFocused();
+	});
+
+	test('debounced auto-search replaces history instead of stacking entries', async ({
+		page,
+	}) => {
+		await page.goto('/search');
+
+		const input = page.getByRole('searchbox');
+		await expect(input).toBeVisible();
+		await expect(input).toBeFocused();
+
+		// The submit establishes the search baseline; the two debounce auto-searches below
+		// each replaceState, so they collapse into a single entry instead of stacking — a
+		// single goBack therefore skips the intermediate queries and returns to /search.
+		await input.press('Enter');
+		await expect(page).toHaveURL(/[?&]q=\*/);
+
+		// Two successive auto-searches, each awaited so both actually navigate.
+		await input.pressSequentially('lampe');
+		await expect(page).toHaveURL(/[?&]q=lampe(?:&|$)/);
+
+		await input.pressSequentially('x');
+		await expect(page).toHaveURL(/[?&]q=lampex(?:&|$)/);
+
+		// Both auto-searches used replaceState, so a single back step skips the
+		// intermediate queries and lands on the pre-search baseline (/search).
+		await page.goBack();
+		await expect(page).toHaveURL(/\/search$/);
+	});
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,7 +40,12 @@ export default defineConfig({
 		{
 			name: 'public',
 			use: { browserName: 'chromium' },
-			testMatch: ['tests/smoke.spec.ts', 'tests/auth.spec.ts'],
+			testMatch: [
+				'tests/smoke.spec.ts',
+				'tests/auth.spec.ts',
+				'tests/search-focus.spec.ts',
+				'tests/search-focus.mobile.spec.ts',
+			],
 		},
 		{
 			name: 'authenticated',

--- a/src/routes/search/SearchBar.svelte
+++ b/src/routes/search/SearchBar.svelte
@@ -34,6 +34,14 @@
 		}
 	});
 
+	$effect(() => {
+		// Initial autofocus only on devices with a precise pointer (desktop). On touch
+		// devices focusing would pop the on-screen keyboard on page load (#429/#453).
+		if (window.matchMedia('(hover: hover) and (pointer: fine)').matches) {
+			inputEl?.focus();
+		}
+	});
+
 	async function handleInput() {
 		if (debounceTimer) clearTimeout(debounceTimer);
 		debounceTimer = null;
@@ -43,7 +51,7 @@
 		if (value.length < MINIMAL_SEARCHSTRING_LENGTH) {
 			isDebouncing = false;
 			if (q) {
-				await goto(resolve('/search'));
+				await goto(resolve('/search'), { keepFocus: true, noScroll: true, replaceState: true });
 			}
 			return;
 		}
@@ -52,7 +60,11 @@
 		debounceTimer = setTimeout(async () => {
 			isDebouncing = false;
 			// eslint-disable-next-line svelte/no-navigation-without-resolve
-			await goto(`/search?q=${encodeURIComponent(value)}`);
+			await goto(`/search?q=${encodeURIComponent(value)}`, {
+				keepFocus: true,
+				noScroll: true,
+				replaceState: true
+			});
 		}, SEARCH_DELAY_MS);
 	}
 
@@ -65,7 +77,10 @@
 		isDebouncing = false;
 		const value = inputValue.trim();
 		// eslint-disable-next-line svelte/no-navigation-without-resolve
-		await goto(value ? `/search?q=${encodeURIComponent(value)}` : browseAllUrl);
+		await goto(value ? `/search?q=${encodeURIComponent(value)}` : browseAllUrl, {
+			keepFocus: true,
+			noScroll: true
+		});
 	}
 
 	async function clearSearch() {
@@ -75,7 +90,7 @@
 			debounceTimer = null;
 		}
 		isDebouncing = false;
-		await goto(resolve('/search'));
+		await goto(resolve('/search'), { keepFocus: true, noScroll: true });
 	}
 </script>
 


### PR DESCRIPTION
## What & why

On desktop the `/search` bar kept losing focus — often mid-type — and had to be re-clicked after every search. Root cause: PR #429 (which correctly removed the mount autofocus to stop the mobile keyboard popping up) also removed the `inputEl.focus()` that ran after every `goto`. Without it, each client-side navigation from the debounced auto-search resets focus to `<body>` (SvelteKit's a11y default), which is exactly the "focus lost mid-type" symptom.

## Changes

- **Focus continuity across navigations** (`SearchBar.svelte`): every programmatic `goto` now passes `{ keepFocus: true, noScroll: true }`. `keepFocus` preserves focus on the surviving input (same route, component stays mounted) without *forcing* focus, so it does not pop a keyboard on touch. `noScroll` stops the results list jumping to the top while typing.
- **History hygiene**: the debounced auto-search and the `<3`-char reset additionally pass `replaceState: true`, so a stream of keystrokes collapses into a single history entry (no "typed 3 chars → press Back 3 times"). The explicit submit (Enter/button) and the clear (×) button keep their own entries.
- **Desktop-only initial focus**: mount focus is reapplied but gated behind `window.matchMedia('(hover: hover) and (pointer: fine)')` inside an `$effect` (not the `autofocus` attribute), so touch devices don't pop the on-screen keyboard on page load — preserving the #429 fix.
- `SEARCH_DELAY_MS` (1200 ms) is intentionally left unchanged: the issue's debounce-lengthening suggestion was a workaround for the focus loss, and the root cause is now fixed.

## Test notes

- **Preflight:** `npm run lint` ✅, `npx vitest run` ✅ (543 tests). `npm run check` / `npm run build` fail locally only on the 6 pre-existing `$env/static/private` sync-var errors (`SYNC_SECRET`, `PB_SUPERUSER_EMAIL`, `PB_SUPERUSER_PASSWORD`) — unrelated to this diff; CI has those vars set.
- **New Playwright regression coverage** (auth-free `public` project): desktop autofocus + focus retained across the debounced auto-search; debounced search replaces history (single `goBack` returns to the baseline); mobile emulation (`Pixel 5`, coarse pointer) has **no** autofocus on load. All 3 green against a real stack.
- **Manual browser verification:** desktop autofocus, focus retention while typing with >1.2 s pauses, `replaceState` (no history stacking), `noScroll`, clear/submit, and the mobile no-autofocus path — all confirmed, no console or network errors.

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)
