### PR TITLE
refactor(conversations): stabilize realtime state handling (#469)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,6 +113,11 @@ AllerLeih uses PocketBase's built-in realtime (SSE) subscriptions for live chat 
 - Returns an unsubscribe function suitable for `$effect()` cleanup in Svelte 5
 - Auth token is synced server-to-client via `page.data.token` so the client-side PocketBase instance can authenticate the connection (the httpOnly cookie is inaccessible to JS)
 
-Domain-specific reconciliation (e.g. keeping the conversation sidebar list in sync) lives next to its route — see `src/routes/conversations/conversationListRealtime.ts` — rather than in the components themselves.
+Domain-specific reconciliation lives next to its route in rune-free helper modules rather than in the components themselves:
+
+- `src/routes/conversations/conversationListRealtime.ts` — keeps the conversation sidebar list in sync.
+- `src/routes/conversations/[conversationId]/conversationRealtime.ts` — keeps a single open conversation in sync (lending status, counterfactual, and the fetch/dedupe of newly appended messages). State is read/written through accessor closures so the page keeps ownership of the reactive state.
+
+Pages hold "server-load data that a realtime handler also writes to" in a `realtimeSynced()` box (`src/lib/stores/realtimeSynced.svelte.ts`) — a writable `$derived` that re-syncs from `load()` while staying directly assignable by the handler (issue #469).
 
 Push notifications (for events that happen when the user is not on the site) use the Web Push standard via the `web-push` npm package — these are one-way server → browser messages, not WebSocket connections.

--- a/src/lib/stores/realtimeSynced.svelte.ts
+++ b/src/lib/stores/realtimeSynced.svelte.ts
@@ -1,0 +1,30 @@
+/**
+ * Reactive box for "server-load data + local realtime writes".
+ *
+ * `value` follows `source()` — it re-syncs whenever the tracked dependencies of
+ * `source` change (e.g. after `invalidateAll()` / a `use:enhance` reload refreshes
+ * the `load()` data) — and is at the same time directly writable, so a realtime
+ * event handler can override it optimistically until the next server refresh.
+ *
+ * This is the canonical writable-`$derived` pattern (assignable deriveds since
+ * Svelte 5.25): a reassignment sticks until a dependency changes, then the
+ * expression recomputes = sync-from-load. It replaces the `$state` + sync-`$effect`
+ * pattern that previously required per-site `svelte/prefer-writable-derived`
+ * suppressions (issue #469).
+ *
+ * Must be called during component initialisation, like any `$derived`.
+ *
+ * @param source Reads the current server-load value (kept as a closure so the
+ *   dependency stays lazily tracked — do not destructure the `data` prop).
+ */
+export function realtimeSynced<T>(source: () => T) {
+	let value = $derived(source());
+	return {
+		get value() {
+			return value;
+		},
+		set value(v: T) {
+			value = v;
+		},
+	};
+}

--- a/src/routes/conversations/[conversationId]/+page.svelte
+++ b/src/routes/conversations/[conversationId]/+page.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
 	// Imports for pocketbase real-time subcription
 	import type PocketBase from 'pocketbase';
-	import type { RecordSubscription } from 'pocketbase';
 	import { onMount } from 'svelte';
 	import { invalidateAll } from '$app/navigation';
 	import { PUBLIC_PB_URL } from '$env/static/public';
-	import { getClientPB, subscribeRealtime } from '$lib/client-pb';
+	import { getClientPB } from '$lib/client-pb';
+	import { realtimeSynced } from '$lib/stores/realtimeSynced.svelte';
+	import { subscribeConversation } from './conversationRealtime';
 
 	// Other imports
 	import { Button, Modal, Input } from 'flowbite-svelte';
 	import MessageElement from './MessageElement.svelte';
 	import { displayName } from '$lib/utils/utils';
-	import type { Conversation, Message } from '$lib/types/models';
 	import { texts } from '$lib/texts';
 	import ConversationHeader from './ConversationHeader.svelte';
 	import MessageForm from './MessageForm.svelte';
@@ -22,38 +22,14 @@
 	// Props and state variables
 	let { data } = $props();
 
-	// eslint-disable-next-line svelte/prefer-writable-derived -- messages must stay $state; it is also written by the async real-time event handler (using $derived here caused an OOM infinite loop)
-	let messages: Message[] = $state(
-		// eslint-disable-next-line svelte/no-unused-svelte-ignore
-		// svelte-ignore state_referenced_locally
+	// Server-load data that the realtime event handler also writes to. `realtimeSynced`
+	// re-syncs from load() (e.g. after a use:enhance reload) while staying directly
+	// writable by the subscription handler below (issue #469).
+	const messages = realtimeSynced(() =>
 		data.conversation.messages ? [...data.conversation.messages] : []
 	);
-	// Sync messages when server data refreshes (e.g. after use:enhance reloads load())
-	$effect(() => {
-		messages = data.conversation.messages
-			? [...data.conversation.messages]
-			: [];
-	});
-
-	// eslint-disable-next-line svelte/prefer-writable-derived -- same pattern as messages: written by the real-time event handler
-	let lendingStatus: Conversation['lendingStatus'] = $state(
-		// eslint-disable-next-line svelte/no-unused-svelte-ignore
-		// svelte-ignore state_referenced_locally
-		data.conversation.lendingStatus
-	);
-	$effect(() => {
-		lendingStatus = data.conversation.lendingStatus;
-	});
-
-	// eslint-disable-next-line svelte/prefer-writable-derived -- same pattern: written by the real-time event handler
-	let counterfactual: Conversation['counterfactual'] = $state(
-		// eslint-disable-next-line svelte/no-unused-svelte-ignore
-		// svelte-ignore state_referenced_locally
-		data.conversation.counterfactual
-	);
-	$effect(() => {
-		counterfactual = data.conversation.counterfactual;
-	});
+	const lendingStatus = realtimeSynced(() => data.conversation.lendingStatus);
+	const counterfactual = realtimeSynced(() => data.conversation.counterfactual);
 
 	let loggedInUserIsItemOwner = $derived(
 		data.currentUser.id === data.conversation.itemOwner.id
@@ -69,7 +45,7 @@
 	// UI state variables
 	let deleteConversationModal = $state(false);
 	let showCounterfactualModal = $derived(
-		counterfactual === 'pending' && !loggedInUserIsItemOwner
+		counterfactual.value === 'pending' && !loggedInUserIsItemOwner
 	);
 	let isSubmitting: boolean = $state(false);
 	let chatWindow: HTMLDivElement;
@@ -84,7 +60,7 @@
 
 	// Scroll chat window to bottom when messages change
 	$effect(() => {
-		if (messages && messages.length > 0 && chatWindow) {
+		if (messages.value && messages.value.length > 0 && chatWindow) {
 			setTimeout(() => scrollToBottom(true), 0);
 		}
 	});
@@ -124,55 +100,27 @@
 		};
 	});
 
-	// Handle incoming real-time message events
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	async function handleConversationEvent(event: RecordSubscription<any>) {
-		if (!pb) return;
-		if (event.action === 'update') {
-			// Update lending status if it changed
-			if (event.record.lendingStatus !== undefined) {
-				lendingStatus = event.record.lendingStatus || undefined;
-			}
-			if (event.record.counterfactual !== undefined) {
-				counterfactual = event.record.counterfactual || undefined;
-			}
-
-			// Extract the last message id from the updated conversation record
-			const lastMessageId =
-				event.record.messages?.[event.record.messages.length - 1];
-
-			// Skip fetch if there's no new message or we already have it
-			if (!lastMessageId || messages.some((m) => m.id === lastMessageId)) return;
-
-			// get last messages contents from pocketbase
-			let latestMessage: Message;
-			try {
-				latestMessage = await pb.collection('messages').getOne(lastMessageId);
-				// Deduplicate: server reload via use:enhance may have already added this message
-				if (!messages.some((m) => m.id === latestMessage.id)) {
-					messages = [...messages, latestMessage];
-				}
-			} catch (error) {
-				console.error('Failed to fetch last message record:', error);
-			}
-		}
-	}
-
-	// Set up real-time subscription.
+	// Set up real-time subscription. The merge/refetch/dedupe logic lives in the
+	// co-located conversationRealtime helper (issue #469).
 	// Uses the $derived conversationId so the subscription re-targets when navigating
 	// between conversations, but does NOT re-subscribe on invalidateAll() (same id).
 	$effect(() => {
 		if (!pb) return;
-		return subscribeRealtime({
-			collection: 'conversations',
-			topic: conversationId,
-			handler: handleConversationEvent,
+		return subscribeConversation(
+			pb,
+			conversationId,
+			{
+				getMessages: () => messages.value,
+				setMessages: (next) => (messages.value = next),
+				setLendingStatus: (s) => (lendingStatus.value = s),
+				setCounterfactual: (c) => (counterfactual.value = c),
+			},
 			// Messages sent while the stream was down (e.g. the phone was asleep)
 			// aren't replayed by realtime — refetch the conversation on reconnect
 			// so the missing messages appear. Fixes the "doesn't update for one
 			// party" symptom in #435.
-			onReconnect: () => invalidateAll(),
-		});
+			() => invalidateAll()
+		);
 	});
 
 	// Presence heartbeat: periodically update the lastSeenAt timestamp so the backend
@@ -207,7 +155,7 @@
 />
 
 <LendingStatusBar
-	{lendingStatus}
+	lendingStatus={lendingStatus.value}
 	isOwner={loggedInUserIsItemOwner}
 	itemOwnerUsername={displayName(data.conversation.itemOwner)}
 />
@@ -217,7 +165,7 @@
 	bind:this={chatWindow}
 	class="flex flex-col flex-1 overflow-auto px-4 py-4 gap-0.5 bg-papier dark:bg-tinte-900"
 >
-	{#if lendingStatus === 'pending' && messages.length === 0 && !loggedInUserIsItemOwner}
+	{#if lendingStatus.value === 'pending' && messages.value.length === 0 && !loggedInUserIsItemOwner}
 		<p
 			class="text-xl p-4 text-center max-w-100 mx-auto my-auto text-tinte-400 dark:text-tinte-500 italic"
 		>
@@ -227,7 +175,7 @@
 			)}
 		</p>
 	{/if}
-	{#each messages as message (message.id)}
+	{#each messages.value as message (message.id)}
 		<MessageElement {message} isFromCurrentUser={data.currentUser?.id} />
 	{/each}
 </div>

--- a/src/routes/conversations/[conversationId]/conversationRealtime.test.ts
+++ b/src/routes/conversations/[conversationId]/conversationRealtime.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { RecordSubscription } from 'pocketbase';
+import type { Conversation, Message } from '$lib/types/models';
+
+// Capture the options passed to subscribeRealtime so tests can fire synthetic
+// events at the registered handler. The real client-pb pulls in $env/static/public
+// and opens an EventSource — neither is wanted here, so the whole module is mocked.
+const { subscribeRealtime, unsubscribe } = vi.hoisted(() => ({
+	subscribeRealtime: vi.fn(),
+	unsubscribe: vi.fn(),
+}));
+
+vi.mock('$lib/client-pb', () => ({ subscribeRealtime }));
+
+import { subscribeConversation } from './conversationRealtime';
+
+type Handler = (event: RecordSubscription<Conversation>) => void | Promise<void>;
+
+/** Reads the handler that the helper registered with subscribeRealtime. */
+function registeredHandler(): Handler {
+	expect(subscribeRealtime).toHaveBeenCalledTimes(1);
+	return subscribeRealtime.mock.calls[0][0].handler as Handler;
+}
+
+/** Minimal realtime `update` event carrying a raw conversation record. */
+function updateEvent(record: Record<string, unknown>): RecordSubscription<Conversation> {
+	return { action: 'update', record } as unknown as RecordSubscription<Conversation>;
+}
+
+function msg(id: string): Message {
+	return { id, messageContent: `content-${id}` } as Message;
+}
+
+/** Backing state + accessors, mirroring how the page wires realtimeSynced boxes. */
+function makeState(initialMessages: Message[] = []) {
+	let messages = initialMessages;
+	const setLendingStatus = vi.fn<(s: Conversation['lendingStatus']) => void>();
+	const setCounterfactual = vi.fn<(c: Conversation['counterfactual']) => void>();
+	const setMessages = vi.fn((next: Message[]) => {
+		messages = next;
+	});
+	return {
+		accessors: {
+			getMessages: () => messages,
+			setMessages,
+			setLendingStatus,
+			setCounterfactual,
+		},
+		get messages() {
+			return messages;
+		},
+		setMessages,
+		setLendingStatus,
+		setCounterfactual,
+	};
+}
+
+/** A fake PocketBase whose `messages` collection getOne is scriptable. */
+function makePb(getOne: ReturnType<typeof vi.fn>) {
+	return {
+		collection: vi.fn((name: string) => {
+			if (name === 'messages') return { getOne };
+			return {};
+		}),
+	} as never;
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	subscribeRealtime.mockReturnValue(unsubscribe);
+});
+
+describe('subscribeConversation', () => {
+	it('wires the subscription to the conversation record and returns the unsubscribe fn', () => {
+		const state = makeState();
+		const onReconnect = vi.fn();
+		const cleanup = subscribeConversation(makePb(vi.fn()), 'conv1', state.accessors, onReconnect);
+
+		expect(subscribeRealtime).toHaveBeenCalledTimes(1);
+		const opts = subscribeRealtime.mock.calls[0][0];
+		expect(opts.collection).toBe('conversations');
+		expect(opts.topic).toBe('conv1');
+		expect(opts.onReconnect).toBe(onReconnect);
+		expect(cleanup).toBe(unsubscribe);
+	});
+
+	it('fetches and appends the message when the last id is new (case 1)', async () => {
+		const state = makeState([msg('m1')]);
+		const getOne = vi.fn().mockResolvedValue(msg('m2'));
+		subscribeConversation(makePb(getOne), 'conv1', state.accessors);
+
+		await registeredHandler()(updateEvent({ messages: ['m1', 'm2'] }));
+
+		expect(getOne).toHaveBeenCalledWith('m2');
+		expect(state.setMessages).toHaveBeenCalledTimes(1);
+		expect(state.messages).toEqual([msg('m1'), msg('m2')]);
+	});
+
+	it('skips the fetch when the last message id is already present (case 2)', async () => {
+		const state = makeState([msg('m1')]);
+		const getOne = vi.fn();
+		subscribeConversation(makePb(getOne), 'conv1', state.accessors);
+
+		await registeredHandler()(updateEvent({ messages: ['m1'] }));
+
+		expect(getOne).not.toHaveBeenCalled();
+		expect(state.setMessages).not.toHaveBeenCalled();
+	});
+
+	it('does not double-append when the message arrived during the fetch (case 3)', async () => {
+		const state = makeState([msg('m1')]);
+		// Simulate a use:enhance reload adding m2 while getOne is in flight.
+		const getOne = vi.fn().mockImplementation(async () => {
+			state.setMessages([msg('m1'), msg('m2')]);
+			return msg('m2');
+		});
+		subscribeConversation(makePb(getOne), 'conv1', state.accessors);
+
+		await registeredHandler()(updateEvent({ messages: ['m1', 'm2'] }));
+
+		expect(getOne).toHaveBeenCalledWith('m2');
+		// setMessages ran once (from the reload simulation), not again from the handler.
+		expect(state.setMessages).toHaveBeenCalledTimes(1);
+		expect(state.messages.filter((m) => m.id === 'm2')).toHaveLength(1);
+	});
+
+	it('does nothing for a missing or empty messages field (case 4)', async () => {
+		const getOne = vi.fn();
+
+		const stateMissing = makeState([msg('m1')]);
+		subscribeConversation(makePb(getOne), 'conv1', stateMissing.accessors);
+		await registeredHandler()(updateEvent({}));
+		expect(getOne).not.toHaveBeenCalled();
+		expect(stateMissing.setMessages).not.toHaveBeenCalled();
+
+		vi.clearAllMocks();
+		subscribeRealtime.mockReturnValue(unsubscribe);
+
+		const stateEmpty = makeState([msg('m1')]);
+		subscribeConversation(makePb(getOne), 'conv1', stateEmpty.accessors);
+		await registeredHandler()(updateEvent({ messages: [] }));
+		expect(getOne).not.toHaveBeenCalled();
+		expect(stateEmpty.setMessages).not.toHaveBeenCalled();
+	});
+
+	it('sets lendingStatus/counterfactual only when present, mapping "" to undefined (case 5)', async () => {
+		// Present, non-empty → set through.
+		const s1 = makeState();
+		subscribeConversation(makePb(vi.fn()), 'conv1', s1.accessors);
+		await registeredHandler()(updateEvent({ lendingStatus: 'accepted', counterfactual: 'would_buy' }));
+		expect(s1.setLendingStatus).toHaveBeenCalledWith('accepted');
+		expect(s1.setCounterfactual).toHaveBeenCalledWith('would_buy');
+
+		vi.clearAllMocks();
+		subscribeRealtime.mockReturnValue(unsubscribe);
+
+		// Present but empty string → undefined.
+		const s2 = makeState();
+		subscribeConversation(makePb(vi.fn()), 'conv1', s2.accessors);
+		await registeredHandler()(updateEvent({ lendingStatus: '', counterfactual: '' }));
+		expect(s2.setLendingStatus).toHaveBeenCalledWith(undefined);
+		expect(s2.setCounterfactual).toHaveBeenCalledWith(undefined);
+
+		vi.clearAllMocks();
+		subscribeRealtime.mockReturnValue(unsubscribe);
+
+		// Field absent → not touched.
+		const s3 = makeState();
+		subscribeConversation(makePb(vi.fn()), 'conv1', s3.accessors);
+		await registeredHandler()(updateEvent({ messages: [] }));
+		expect(s3.setLendingStatus).not.toHaveBeenCalled();
+		expect(s3.setCounterfactual).not.toHaveBeenCalled();
+	});
+
+	it('logs and leaves state unchanged when the fetch rejects (case 6)', async () => {
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const state = makeState([msg('m1')]);
+		const getOne = vi.fn().mockRejectedValue(new Error('boom'));
+		subscribeConversation(makePb(getOne), 'conv1', state.accessors);
+
+		// Must not throw / reject (no unhandled rejection).
+		await expect(registeredHandler()(updateEvent({ messages: ['m1', 'm2'] }))).resolves.toBeUndefined();
+
+		expect(getOne).toHaveBeenCalledWith('m2');
+		expect(state.setMessages).not.toHaveBeenCalled();
+		expect(state.messages).toEqual([msg('m1')]);
+		expect(consoleError).toHaveBeenCalled();
+		consoleError.mockRestore();
+	});
+
+	it('ignores non-update events (case 7)', async () => {
+		const state = makeState([msg('m1')]);
+		const getOne = vi.fn();
+		subscribeConversation(makePb(getOne), 'conv1', state.accessors);
+
+		const handler = registeredHandler();
+		for (const action of ['create', 'delete'] as const) {
+			await handler({ action, record: { messages: ['m1', 'm2'], lendingStatus: 'accepted' } } as unknown as RecordSubscription<Conversation>);
+		}
+
+		expect(getOne).not.toHaveBeenCalled();
+		expect(state.setMessages).not.toHaveBeenCalled();
+		expect(state.setLendingStatus).not.toHaveBeenCalled();
+		expect(state.setCounterfactual).not.toHaveBeenCalled();
+	});
+});

--- a/src/routes/conversations/[conversationId]/conversationRealtime.ts
+++ b/src/routes/conversations/[conversationId]/conversationRealtime.ts
@@ -1,0 +1,75 @@
+import type PocketBase from 'pocketbase';
+import { subscribeRealtime } from '$lib/client-pb';
+import type { Conversation, Message } from '$lib/types/models';
+
+/**
+ * Keep a single open conversation in sync with realtime `conversations` events.
+ *
+ * Encapsulates the wire-format handling that would otherwise live in the
+ * conversation page: an `update` event carries only the changed conversation
+ * record (lending status, counterfactual, and the message-id list), so the newly
+ * appended message has to be refetched before it can be rendered.
+ *
+ * State is read/written through the `accessors` closures so the caller keeps
+ * ownership of the reactive state — this helper never touches Svelte runes.
+ * Built on {@link subscribeRealtime}, so it inherits retry-on-connect-failure and
+ * recovery after a network drop / mobile background-freeze (issue #435).
+ *
+ * @param pb             Shared client PocketBase instance (from `getClientPB()`).
+ * @param conversationId Record id of the conversation to subscribe to.
+ * @param accessors      Read/write hooks for the caller's reactive state.
+ * @param onReconnect    Optional callback run after the stream reconnects —
+ *   messages sent while the stream was down are not replayed, so the caller
+ *   should refetch (e.g. `invalidateAll()`). Fixes the "doesn't update for one
+ *   party" symptom in #435.
+ * @returns An unsubscribe function suitable for `$effect`/`onMount` cleanup.
+ */
+export function subscribeConversation(
+	pb: PocketBase,
+	conversationId: string,
+	accessors: {
+		getMessages: () => Message[];
+		setMessages: (next: Message[]) => void;
+		setLendingStatus: (s: Conversation['lendingStatus']) => void;
+		setCounterfactual: (c: Conversation['counterfactual']) => void;
+	},
+	onReconnect?: () => void
+): () => void {
+	const { getMessages, setMessages, setLendingStatus, setCounterfactual } = accessors;
+
+	return subscribeRealtime<Conversation>({
+		collection: 'conversations',
+		topic: conversationId,
+		handler: async (event) => {
+			if (event.action !== 'update') return;
+
+			// Update lending status / counterfactual if they changed (empty string → undefined).
+			if (event.record.lendingStatus !== undefined) {
+				setLendingStatus(event.record.lendingStatus || undefined);
+			}
+			if (event.record.counterfactual !== undefined) {
+				setCounterfactual(event.record.counterfactual || undefined);
+			}
+
+			// Extract the last message id from the updated conversation record.
+			const messageIds = event.record.messages as unknown as string[] | undefined;
+			const lastMessageId = messageIds?.[messageIds.length - 1];
+
+			// Skip fetch if there's no new message or we already have it.
+			if (!lastMessageId || getMessages().some((m) => m.id === lastMessageId)) return;
+
+			// Get the last message's contents from PocketBase.
+			try {
+				const latestMessage = await pb.collection('messages').getOne<Message>(lastMessageId);
+				// Deduplicate: a server reload via use:enhance may have already added this
+				// message while the fetch was in flight.
+				if (!getMessages().some((m) => m.id === latestMessage.id)) {
+					setMessages([...getMessages(), latestMessage]);
+				}
+			} catch (error) {
+				console.error('Failed to fetch last message record:', error);
+			}
+		},
+		onReconnect,
+	});
+}


### PR DESCRIPTION
## What & why

The conversation page (`src/routes/conversations/[conversationId]/+page.svelte`) carried **7 ESLint suppressions** around its realtime state:

- 3× `svelte/prefer-writable-derived` — `messages`, `lendingStatus`, `counterfactual` were each `$state` + a manual sync-`$effect`, because the realtime handler also writes them (a comment warned that a plain `$derived` had once caused an OOM loop).
- 3× `svelte/no-unused-svelte-ignore` — attached to the `state_referenced_locally` ignores of those inits.
- 1× `@typescript-eslint/no-explicit-any` — `handleConversationEvent(event: RecordSubscription<any>)`.

The pattern was copy-pasted 3×, fragile against Svelte updates, and the merge logic (message backfill + dedupe) was untestable inside the component.

This is a **behaviour-preserving refactor** that removes all 7 suppressions.

## What changed

- **new** `src/lib/stores/realtimeSynced.svelte.ts` — a small reactive box for "server-load data + local realtime writes", built on an assignable `$derived` (canonical since Svelte 5.25; project is on ^5.55.7). It re-syncs on `invalidateAll` / `use:enhance` reload and is directly writable by the realtime handler, replacing the `$state` + sync-`$effect` pattern.
- **new** `src/routes/conversations/[conversationId]/conversationRealtime.ts` — rune-free, co-located subscription/merge helper `subscribeConversation()` modelled on the existing `conversationListRealtime.ts`. Holds the full former `handleConversationEvent` logic and is typed on `RecordSubscription<Conversation>` (drops the `any`).
- **new** `conversationRealtime.test.ts` — 8 Vitest cases: fetch+append on new last-message id, dedupe before fetch, dedupe after the `await` (use:enhance race), empty/absent `messages`, `lendingStatus`/`counterfactual` mapping incl. `'' → undefined`, `getOne` rejection → `console.error` (no unhandled rejection), non-`update` actions ignored, plus a wiring assertion.
- **changed** `+page.svelte` — rebuilt onto both helpers; the three `$state`+`$effect` blocks become three `realtimeSynced(() => data.…)` boxes, the handler + subscription `$effect` become one slim `$effect` calling `subscribeConversation`. Scroll logic, presence heartbeat, `pb` setup, modals and markup are untouched. `onReconnect: () => invalidateAll()` (fix #435) is passed through unchanged; the subscription re-targets on conversation switch but does **not** re-subscribe on `invalidateAll` (same id).
- **changed** `docs/architecture.md` — documents both helpers under "Real-time Architecture".

No schema/backend change, no new env vars, no new strings (`texts.ts` untouched).

## Behaviour equivalence

The realtime logic is preserved 1:1: only `action === 'update'`; `lendingStatus`/`counterfactual` set only when present in the event record, keeping the `'' → undefined` mapping; last-message-id extraction with skip when missing/already present; **second** dedupe check after the `getOne` await; fetch error → `console.error`, no throw.

## Test notes

- `npm run lint` — clean.
- `npx vitest run` — **551/551 green** (incl. the 8 new cases).
- `npm run check` / `npm run build` — fail only on the **6 pre-existing `$env/static/private` sync-var errors** (`SYNC_SECRET`, `PB_SUPERUSER_EMAIL`, `PB_SUPERUSER_PASSWORD`) unrelated to this diff; no errors/new warnings in the changed files (1589 modules transform successfully).
- Project reviewer (`sveltekit-pb-reviewer`): 0 findings.
- Manual browser smoke (two users): live receive + auto-scroll, no duplicate on own `use:enhance` send, live `lendingStatus` update, header notification badge unchanged. **OOM regression check:** flat heap across 80 realtime events (16.89 → 16.97 MB), DOM mutations strictly linear (3/message), exactly one `getOne` per event, no `effect_update_depth_exceeded`, no idle loop.

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)