### PR TITLE
refactor(items): deduplicate item form logic and drop any-casts (#470)

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -83,6 +83,37 @@ export const actions = {
 
 Here, we see the counter-part to the "addtrustee"-submit action of the form. You can get the form data via the request object, and in this case have to update the list of users that the logged-in user trusts. We have found that this works smoothest by creating an updateData object which - in this case - appends the id of the newly-to-be-trusted user to the existing ones and then calls the underlying database accordingly. After this, there is actually nothing you have to take care of - SvelteKit and the enhance-function take care of updating the UI in reaction to any underlying DB changes.
 
+### Shared server form helpers
+
+When the *same* entity is created/edited from more than one form, don't duplicate the
+FormData-to-payload logic in each action — extract it into a `$lib/server/*` module and keep the
+actions thin. Field **extraction**, **validation** and **sanitization** belong in the helper; the
+action only orchestrates (validate → sanitize → `pb.create/update` → `fail`/`redirect`). This way a
+new field is wired **once**, both flows stay consistent, and the payload is typed instead of a
+`Record<string, any>`.
+
+The canonical example is **`$lib/server/itemForm.ts`**, shared by the single add/edit action
+(`user/items/+page.server.ts`) and the bulk add action (`user/items/bulk-add/+page.server.ts`):
+
+- `extractItemForm(data)` / `extractBulkItemDraft(data, i)` — read each form's own wire format
+  (the wire formats stay flow-specific; only the logic between "FormData in" and "payload out" is
+  shared).
+- `validateItemFields(input, { requireImage })` — one validator for both flows. Its error-flag
+  keys (`nameIsMissing` … `tooManyImages`) are **API**: `ItemModal.svelte` and the route tests key
+  off them, so don't rename them.
+- `sanitizeCategories` and `sanitizeGroups` / `filterAttachableGroups` — the **security-relevant**
+  bits. `sanitizeGroups` filters submitted group ids against `getAttachableGroups` (owned + member)
+  so a tampered form can't share an item into arbitrary groups; never weaken this. In a per-row
+  loop (bulk), load the attachable set **once** per request and reuse `filterAttachableGroups`,
+  rather than re-querying per row.
+- `ItemWritePayload` — the typed create/update payload; `image` is only set when new files were
+  uploaded (on update, omitting it keeps the existing images).
+
+Characterize before you extract: the single-flow route test is the no-behavior-change anchor (it
+must stay green *unchanged*), and the bulk flow got a characterization test written **before** the
+refactor. Any deliberate behavior change (here: the MIME whitelist now also applies to bulk rows)
+is called out in a test comment.
+
 ### Data (Re-)Loading
 
 The load function passes the data to the UI component:

--- a/src/lib/server/itemForm.test.ts
+++ b/src/lib/server/itemForm.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { getAttachableGroupsMock } = vi.hoisted(() => ({ getAttachableGroupsMock: vi.fn() }));
+vi.mock('$lib/server/groups', () => ({ getAttachableGroups: getAttachableGroupsMock }));
+
+import {
+	sanitizeCategories,
+	sanitizeGroups,
+	filterAttachableGroups,
+	validateItemFields,
+	extractItemForm,
+	extractBulkItemDraft,
+	MAX_ITEM_IMAGES,
+} from './itemForm';
+
+function imageFile(name = 'a.jpg', type = 'image/jpeg', body: BlobPart[] = ['x']) {
+	return new File(body, name, { type });
+}
+
+describe('sanitizeCategories', () => {
+	it('keeps known categories, drops unknown ones', () => {
+		expect(sanitizeCategories(['Bücher', 'nonsense', 'Küche'])).toEqual(['Bücher', 'Küche']);
+	});
+	it('returns [] for empty input', () => {
+		expect(sanitizeCategories([])).toEqual([]);
+	});
+});
+
+describe('filterAttachableGroups', () => {
+	it('keeps only ids in the allowed set', () => {
+		expect(filterAttachableGroups(['g1', 'g2', 'g3'], new Set(['g1', 'g3']))).toEqual(['g1', 'g3']);
+	});
+});
+
+describe('sanitizeGroups', () => {
+	const pb = {} as unknown as Parameters<typeof sanitizeGroups>[0];
+	beforeEach(() => vi.clearAllMocks());
+
+	it('returns [] without a PB call on empty input', async () => {
+		expect(await sanitizeGroups(pb, 'u1', [])).toEqual([]);
+		expect(getAttachableGroupsMock).not.toHaveBeenCalled();
+	});
+
+	it('keeps only attachable groups', async () => {
+		getAttachableGroupsMock.mockResolvedValue([{ id: 'g1' }, { id: 'g2' }]);
+		expect(await sanitizeGroups(pb, 'u1', ['g1', 'g-foreign', 'g2'])).toEqual(['g1', 'g2']);
+		expect(getAttachableGroupsMock).toHaveBeenCalledWith(pb, 'u1');
+	});
+});
+
+describe('validateItemFields', () => {
+	const ok = { name: 'Ding', description: 'Beschreibung', images: [imageFile()] };
+
+	it('is valid when all fields are present and image types are accepted', () => {
+		expect(validateItemFields(ok, { requireImage: true }).isValid).toBe(true);
+	});
+
+	it('flags a missing name', () => {
+		const r = validateItemFields({ ...ok, name: '' }, { requireImage: true });
+		expect(r.isValid).toBe(false);
+		expect(r.errors.nameIsMissing).toBe(true);
+	});
+
+	it('flags a missing description', () => {
+		const r = validateItemFields({ ...ok, description: null }, { requireImage: true });
+		expect(r.errors.descriptionIsMissing).toBe(true);
+	});
+
+	it('flags a missing image only when requireImage is true', () => {
+		expect(validateItemFields({ ...ok, images: [] }, { requireImage: true }).errors.imageIsMissing).toBe(true);
+		expect(validateItemFields({ ...ok, images: [] }, { requireImage: false }).errors.imageIsMissing).toBe(false);
+	});
+
+	it('flags an invalid image type', () => {
+		const r = validateItemFields(
+			{ ...ok, images: [imageFile('bad.pdf', 'application/pdf')] },
+			{ requireImage: true }
+		);
+		expect(r.errors.imageInvalidType).toBe(true);
+	});
+
+	it('accepts SVG', () => {
+		const r = validateItemFields(
+			{ ...ok, images: [imageFile('logo.svg', 'image/svg+xml', ['<svg></svg>'])] },
+			{ requireImage: true }
+		);
+		expect(r.isValid).toBe(true);
+	});
+
+	it(`accepts exactly ${MAX_ITEM_IMAGES} images and rejects one more`, () => {
+		const five = Array.from({ length: MAX_ITEM_IMAGES }, (_, i) => imageFile(`${i}.jpg`));
+		expect(validateItemFields({ ...ok, images: five }, { requireImage: true }).errors.tooManyImages).toBe(false);
+		expect(
+			validateItemFields({ ...ok, images: [...five, imageFile('x.jpg')] }, { requireImage: true }).errors
+				.tooManyImages
+		).toBe(true);
+	});
+});
+
+describe('extractItemForm', () => {
+	it('collects multi-file images, filters 0-byte files, and maps trusteesOnly', () => {
+		const fd = new FormData();
+		fd.set('itemName', 'Ding');
+		fd.set('itemDescription', 'Beschreibung');
+		fd.set('itemPlace', 'Berlin');
+		const a = imageFile('a.jpg');
+		const b = imageFile('b.png', 'image/png');
+		fd.append('itemImage', a);
+		fd.append('itemImage', b);
+		fd.append('itemImage', new File([], 'empty.jpg', { type: 'image/jpeg' }));
+		fd.append('categories', 'Bücher');
+		fd.append('groups', 'g1');
+		fd.set('trusteesOnly', 'on');
+
+		const out = extractItemForm(fd);
+
+		expect(out.name).toBe('Ding');
+		expect(out.description).toBe('Beschreibung');
+		expect(out.place).toBe('Berlin');
+		expect(out.images).toEqual([a, b]);
+		expect(out.rawCategories).toEqual(['Bücher']);
+		expect(out.rawGroups).toEqual(['g1']);
+		expect(out.trusteesOnly).toBe(true);
+	});
+
+	it('returns nulls/empties for absent fields and trusteesOnly false', () => {
+		const out = extractItemForm(new FormData());
+		expect(out.name).toBeNull();
+		expect(out.description).toBeNull();
+		expect(out.place).toBeNull();
+		expect(out.images).toEqual([]);
+		expect(out.rawCategories).toEqual([]);
+		expect(out.rawGroups).toEqual([]);
+		expect(out.trusteesOnly).toBe(false);
+	});
+});
+
+describe('extractBulkItemDraft', () => {
+	it('reads indexed fields and JSON-decodes categories/groups', () => {
+		const fd = new FormData();
+		const img = imageFile('0.jpg');
+		fd.set('name_0', 'Bohrer');
+		fd.set('description_0', 'Beschreibung');
+		fd.set('image_0', img);
+		fd.set('categories_0', JSON.stringify(['Bücher']));
+		fd.set('groups_0', JSON.stringify(['g1']));
+		fd.set('trusteesOnly_0', 'on');
+
+		const out = extractBulkItemDraft(fd, 0);
+
+		expect(out.name).toBe('Bohrer');
+		expect(out.description).toBe('Beschreibung');
+		expect(out.image).toBe(img);
+		expect(out.rawCategories).toEqual(['Bücher']);
+		expect(out.rawGroups).toEqual(['g1']);
+		expect(out.trusteesOnly).toBe(true);
+	});
+
+	it('falls back to [] on garbage JSON and null on a missing/0-byte file', () => {
+		const fd = new FormData();
+		fd.set('name_1', 'Ding');
+		fd.set('description_1', 'd');
+		fd.set('image_1', new File([], 'empty.jpg', { type: 'image/jpeg' }));
+		fd.set('categories_1', '{not json');
+		fd.set('groups_1', 'nope');
+
+		const out = extractBulkItemDraft(fd, 1);
+
+		expect(out.image).toBeNull();
+		expect(out.rawCategories).toEqual([]);
+		expect(out.rawGroups).toEqual([]);
+	});
+
+	it('returns null name/description when the indexed fields are absent', () => {
+		const out = extractBulkItemDraft(new FormData(), 3);
+		expect(out.name).toBeNull();
+		expect(out.description).toBeNull();
+		expect(out.image).toBeNull();
+	});
+});

--- a/src/lib/server/itemForm.ts
+++ b/src/lib/server/itemForm.ts
@@ -1,0 +1,181 @@
+import type PocketBase from 'pocketbase';
+import { ITEM_CATEGORIES, type ItemCategory } from '$lib/texts';
+import type { Item } from '$lib/types/models';
+import { getAttachableGroups } from '$lib/server/groups';
+
+/**
+ * Shared server-side helpers for the two item-creation flows (single add/edit in
+ * `user/items/+page.server.ts` and bulk add in `user/items/bulk-add/+page.server.ts`).
+ * Extraction, validation and sanitization live here so a new item field only has to
+ * be wired once. The wire formats of the two forms stay unchanged; only the logic
+ * between "FormData in" and "PocketBase payload out" is shared.
+ */
+
+/**
+ * Max images per item — mirrors the items.image maxSelect in the backend migration.
+ * PocketBase rejects more, so guard here too (defends against a direct/tampered POST).
+ * Change there ⇒ change here.
+ */
+export const MAX_ITEM_IMAGES = 5;
+
+/** Accepted image MIME types for uploaded item photos. */
+export const VALID_IMAGE_TYPES = [
+	'image/jpeg',
+	'image/jpg',
+	'image/png',
+	'image/gif',
+	'image/webp',
+	'image/svg+xml',
+] as const;
+
+/**
+ * Typed write payload for items create/update — replaces the former
+ * `Record<string, any>`. `image` is only set when new files were uploaded; on
+ * update, omitting it keeps the existing images. `owner` is create-only, `place`
+ * is single-flow-only (bulk has no place field).
+ */
+export interface ItemWritePayload {
+	name: FormDataEntryValue | null;
+	description: FormDataEntryValue | null;
+	place?: FormDataEntryValue | null;
+	trusteesOnly: boolean;
+	groups: string[];
+	status: Item['status'];
+	categories: ItemCategory[];
+	image?: File | File[];
+	owner?: string;
+}
+
+/** Drop unknown categories — single source of truth for both flows. */
+export function sanitizeCategories(raw: string[]): ItemCategory[] {
+	return raw.filter((c): c is ItemCategory => ITEM_CATEGORIES.includes(c as ItemCategory));
+}
+
+/**
+ * Keep only the submitted group ids the user may actually attach against a
+ * pre-loaded allowed-id set. Split out so the bulk flow can load the attachable
+ * set once per request (not once per row) and still share the filter.
+ */
+export function filterAttachableGroups(submitted: string[], allowedIds: Set<string>): string[] {
+	return submitted.filter((id) => allowedIds.has(id));
+}
+
+/**
+ * Keep only the submitted group ids the user is actually allowed to attach
+ * (groups they own or are a member of), so a tampered form can't share an item
+ * with arbitrary groups. Early-returns without a DB call on empty input.
+ */
+export async function sanitizeGroups(
+	pb: PocketBase,
+	userId: string,
+	submitted: string[]
+): Promise<string[]> {
+	if (submitted.length === 0) return [];
+	const allowed = new Set((await getAttachableGroups(pb, userId)).map((g) => g.id));
+	return filterAttachableGroups(submitted, allowed);
+}
+
+/**
+ * Validation error flags. **The key names are API**: `ItemModal.svelte` and the
+ * item route tests key off them — do not rename.
+ */
+export interface ItemValidationErrors {
+	nameIsMissing: boolean;
+	descriptionIsMissing: boolean;
+	imageIsMissing: boolean;
+	imageInvalidType: boolean;
+	tooManyImages: boolean;
+}
+
+/**
+ * Validate the shared item fields. `requireImage` is true on create (an image is
+ * mandatory) and false on update (a submit without new files keeps the existing
+ * images). The MIME whitelist and image-count guards apply to whatever files are
+ * present regardless.
+ */
+export function validateItemFields(
+	input: {
+		name: FormDataEntryValue | null;
+		description: FormDataEntryValue | null;
+		images: File[];
+	},
+	opts: { requireImage: boolean }
+): { isValid: boolean; errors: ItemValidationErrors } {
+	const errors: ItemValidationErrors = {
+		nameIsMissing: !input.name,
+		descriptionIsMissing: !input.description,
+		imageIsMissing: opts.requireImage ? input.images.length === 0 : false,
+		imageInvalidType: input.images.some(
+			(img) => !VALID_IMAGE_TYPES.includes(img.type as (typeof VALID_IMAGE_TYPES)[number])
+		),
+		tooManyImages: input.images.length > MAX_ITEM_IMAGES,
+	};
+
+	return { isValid: Object.values(errors).every((e) => !e), errors };
+}
+
+/**
+ * Extract the single add/edit form (field names `itemName`, `itemDescription`,
+ * `itemPlace`, `itemImage` [multi-file], `categories`/`groups` [repeated],
+ * `trusteesOnly`). Empty (0-byte) files — i.e. an untouched file input — are
+ * filtered out so they count as "no new image".
+ */
+export function extractItemForm(data: FormData): {
+	name: FormDataEntryValue | null;
+	description: FormDataEntryValue | null;
+	place: FormDataEntryValue | null;
+	images: File[];
+	rawCategories: string[];
+	rawGroups: string[];
+	trusteesOnly: boolean;
+} {
+	return {
+		name: data.get('itemName'),
+		description: data.get('itemDescription'),
+		place: data.get('itemPlace'),
+		images: data.getAll('itemImage').filter((f): f is File => f instanceof File && f.size > 0),
+		rawCategories: data.getAll('categories').map(String),
+		rawGroups: data.getAll('groups').map(String),
+		trusteesOnly: data.get('trusteesOnly') === 'on',
+	};
+}
+
+/** JSON-decode a bulk field to a string array, falling back to [] on garbage. */
+function parseJsonStringArray(raw: FormDataEntryValue | null): string[] {
+	try {
+		const parsed = JSON.parse(typeof raw === 'string' ? raw : '[]');
+		return Array.isArray(parsed) ? parsed.map(String) : [];
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * Extract one bulk-add row (index `i`) from the wire format ReviewStep emits:
+ * `name_${i}`, `description_${i}`, `image_${i}` (exactly one file),
+ * `categories_${i}`/`groups_${i}` (JSON-encoded arrays), `trusteesOnly_${i}`.
+ * A missing/non-File/0-byte `image_${i}` yields `null`.
+ */
+export function extractBulkItemDraft(
+	data: FormData,
+	i: number
+): {
+	name: string | null;
+	description: string | null;
+	image: File | null;
+	rawCategories: string[];
+	rawGroups: string[];
+	trusteesOnly: boolean;
+} {
+	const name = data.get(`name_${i}`);
+	const description = data.get(`description_${i}`);
+	const image = data.get(`image_${i}`);
+	return {
+		name: typeof name === 'string' ? name : null,
+		description: typeof description === 'string' ? description : null,
+		image: image instanceof File && image.size > 0 ? image : null,
+		rawCategories: parseJsonStringArray(data.get(`categories_${i}`)),
+		rawGroups: parseJsonStringArray(data.get(`groups_${i}`)),
+		trusteesOnly: data.get(`trusteesOnly_${i}`) === 'on',
+	};
+}

--- a/src/routes/user/items/+page.server.ts
+++ b/src/routes/user/items/+page.server.ts
@@ -1,28 +1,17 @@
 import { fail } from '@sveltejs/kit';
 import type { ClientResponseError } from 'pocketbase';
 import { PUBLIC_PB_URL } from '../../../hooks.server';
-import { ITEM_CATEGORIES, texts, type ItemCategory } from '$lib/texts';
+import { texts } from '$lib/texts';
 import type { Item } from '$lib/types/models';
 import { getAttachableGroups } from '$lib/server/groups';
 import { deleteItem, deleteMultipleItems, setItemStatus } from '$lib/server/items';
-
-/** Max images per item — mirrors the items.image maxSelect in the backend migration. */
-const MAX_IMAGES = 5;
-
-/**
- * Keep only the submitted group ids the user is actually allowed to attach
- * (groups they own or are a member of), so a tampered form can't share an item
- * with arbitrary groups.
- */
-async function sanitizeGroups(
-	pb: App.Locals['pb'],
-	userId: string,
-	submitted: string[]
-): Promise<string[]> {
-	if (submitted.length === 0) return [];
-	const allowed = new Set((await getAttachableGroups(pb, userId)).map((g) => g.id));
-	return submitted.filter((id) => allowed.has(id));
-}
+import {
+	extractItemForm,
+	sanitizeCategories,
+	sanitizeGroups,
+	validateItemFields,
+	type ItemWritePayload,
+} from '$lib/server/itemForm';
 
 export async function load({ locals, url }) {
 	const page = Math.max(1, parseInt(url.searchParams.get('page') ?? '1'));
@@ -59,74 +48,38 @@ export async function load({ locals, url }) {
 	};
 }
 
-function validateItemData(data: FormData, isImageRequired: boolean = true) {
-	const name = data.get('itemName');
-	const description = data.get('itemDescription');
-	// `image` is a multi-file field: an item can carry several photos.
-	const images = data
-		.getAll('itemImage')
-		.filter((f): f is File => f instanceof File && f.size > 0);
-
-	// Check that every uploaded file is a valid image type.
-	const validImageTypes = [
-		'image/jpeg',
-		'image/jpg',
-		'image/png',
-		'image/gif',
-		'image/webp',
-		'image/svg+xml',
-	];
-	const hasInvalidImage = images.some((img) => !validImageTypes.includes(img.type));
-
-	const errors = {
-		nameIsMissing: !name,
-		descriptionIsMissing: !description,
-		imageIsMissing: isImageRequired ? images.length === 0 : false,
-		imageInvalidType: hasInvalidImage,
-		// Keep in sync with the items.image maxSelect in the backend migration; PocketBase
-		// rejects more, so guard here too (defends against a direct/tampered POST).
-		tooManyImages: images.length > MAX_IMAGES,
-	};
-
-	return { isValid: Object.values(errors).every((e) => !e), errors, images };
-}
-
 export const actions = {
 	create: async ({ locals, request }) => {
 		const formData = await request.formData();
-		const validationResult = validateItemData(formData, true);
+		const { name, description, place, images, rawCategories, rawGroups, trusteesOnly } =
+			extractItemForm(formData);
+		const validation = validateItemFields({ name, description, images }, { requireImage: true });
 
-		if (!validationResult.isValid) {
+		if (!validation.isValid) {
 			return fail(400, {
 				fail: true,
-				missingFields: validationResult.errors,
+				missingFields: validation.errors,
 				message: texts.pages.items.validationFailed,
 			});
 		}
 
-		const createCategories = (formData.getAll('categories') as string[]).filter((c) =>
-			ITEM_CATEGORIES.includes(c as ItemCategory)
-		);
-		const trusteesOnly = formData.get('trusteesOnly') === 'on';
 		// Trustees and groups are independent audiences — save groups regardless.
-		const createGroups = await sanitizeGroups(
-			locals.pb,
-			locals.user.id,
-			formData.getAll('groups') as string[]
-		);
+		const createGroups = await sanitizeGroups(locals.pb, locals.user.id, rawGroups);
+
+		const payload: ItemWritePayload = {
+			name,
+			description,
+			place,
+			image: images,
+			owner: locals.user.id,
+			trusteesOnly,
+			groups: createGroups,
+			status: 'available',
+			categories: sanitizeCategories(rawCategories),
+		};
 
 		try {
-			await locals.pb.collection('items').create({
-				name: formData.get('itemName'),
-				description: formData.get('itemDescription'),
-				place: formData.get('itemPlace'),
-				image: validationResult.images,
-				owner: locals.user.id,
-				trusteesOnly,
-				groups: createGroups,
-				status: 'available',
-				categories: createCategories,
-			});
+			await locals.pb.collection('items').create(payload);
 		} catch (error) {
 			// Surface the failure instead of swallowing it — otherwise the modal treats a
 			// rejected create (e.g. too many images / size limit) as success and closes.
@@ -137,48 +90,41 @@ export const actions = {
 
 	update: async ({ locals, request }) => {
 		const formData = await request.formData();
-		const validationResult = validateItemData(formData, false);
+		const { name, description, place, images, rawCategories, rawGroups, trusteesOnly } =
+			extractItemForm(formData);
+		const validation = validateItemFields({ name, description, images }, { requireImage: false });
 
-		if (!validationResult.isValid) {
+		if (!validation.isValid) {
 			return fail(400, {
 				fail: true,
-				missingFields: validationResult.errors,
+				missingFields: validation.errors,
 				message: texts.pages.items.validationFailed,
 			});
 		}
 
-		const updateCategories = (formData.getAll('categories') as string[]).filter((c) =>
-			ITEM_CATEGORIES.includes(c as ItemCategory)
-		);
-		const trusteesOnly = formData.get('trusteesOnly') === 'on';
 		// Trustees and groups are independent audiences — save groups regardless.
-		const updateGroups = await sanitizeGroups(
-			locals.pb,
-			locals.user.id,
-			formData.getAll('groups') as string[]
-		);
+		const updateGroups = await sanitizeGroups(locals.pb, locals.user.id, rawGroups);
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const updateData: Record<string, any> = {
-			name: formData.get('itemName'),
-			description: formData.get('itemDescription'),
-			place: formData.get('itemPlace'),
+		const payload: ItemWritePayload = {
+			name,
+			description,
+			place,
 			trusteesOnly,
 			groups: updateGroups,
 			status: formData.get('isAvailable') === 'on' ? 'available' : 'unavailable',
-			categories: updateCategories,
+			categories: sanitizeCategories(rawCategories),
 		};
 
 		// Only touch the image field when new files were uploaded; a submit without
 		// new files keeps the existing images. New files replace the whole set.
-		if (validationResult.images.length > 0) {
-			updateData.image = validationResult.images;
+		if (images.length > 0) {
+			payload.image = images;
 		}
 
 		const itemId = formData?.get('itemId')?.toString();
 		if (itemId) {
 			try {
-				await locals.pb.collection('items').update(itemId, updateData);
+				await locals.pb.collection('items').update(itemId, payload);
 			} catch (err) {
 				// Surface the failure instead of swallowing it (see create above).
 				console.error(err instanceof Error ? err.message : err);
@@ -199,9 +145,8 @@ export const actions = {
 						conversationIds: result.conversationIds,
 					});
 				}
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			} catch (err: Error | any) {
-				console.error(err ? err.message : err);
+			} catch (err: unknown) {
+				console.error(err instanceof Error ? err.message : err);
 			}
 		}
 	},
@@ -218,9 +163,8 @@ export const actions = {
 		for (const itemId of itemIds) {
 			try {
 				await setItemStatus(locals.pb, itemId, locals.user.id, newStatus);
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			} catch (err: Error | any) {
-				console.error(err?.message ?? err);
+			} catch (err: unknown) {
+				console.error(err instanceof Error ? err.message : err);
 			}
 		}
 	},

--- a/src/routes/user/items/bulk-add/+page.server.ts
+++ b/src/routes/user/items/bulk-add/+page.server.ts
@@ -1,6 +1,13 @@
 import { fail, redirect } from '@sveltejs/kit';
-import { ITEM_CATEGORIES, texts, type ItemCategory } from '$lib/texts';
+import { texts } from '$lib/texts';
 import { getAttachableGroups } from '$lib/server/groups';
+import {
+	extractBulkItemDraft,
+	filterAttachableGroups,
+	sanitizeCategories,
+	validateItemFields,
+	type ItemWritePayload,
+} from '$lib/server/itemForm';
 
 export async function load({ locals }) {
 	const attachableGroups = await getAttachableGroups(locals.pb, locals.user.id);
@@ -14,7 +21,8 @@ export const actions = {
 		if (!itemCount || itemCount < 1) return fail(400, { message: 'Keine Gegenstände.' });
 
 		// Only group ids the user may actually attach (owned or member), so a
-		// tampered form can't share an item with arbitrary groups.
+		// tampered form can't share an item with arbitrary groups. Loaded once per
+		// request (not per row).
 		const allowedGroupIds = new Set(
 			(await getAttachableGroups(locals.pb, locals.user.id)).map((g) => g.id)
 		);
@@ -22,45 +30,32 @@ export const actions = {
 		let successCount = 0;
 
 		for (let i = 0; i < itemCount; i++) {
-			const name = formData.get(`name_${i}`) as string;
-			const description = formData.get(`description_${i}`) as string;
-			const image = formData.get(`image_${i}`);
-			const categoriesRaw = formData.get(`categories_${i}`) as string;
-			const groupsRaw = formData.get(`groups_${i}`) as string;
+			const draft = extractBulkItemDraft(formData, i);
+			const images = draft.image ? [draft.image] : [];
 
-			let categories: string[] = [];
-			try {
-				categories = (JSON.parse(categoriesRaw ?? '[]') as string[]).filter((c) =>
-					ITEM_CATEGORIES.includes(c as ItemCategory)
-				);
-			} catch {
-				categories = [];
+			// Skip incomplete rows (missing name/description/file) and rows whose file
+			// is not an accepted image type — the shared validator applies the MIME
+			// whitelist to bulk too, so an invalid image type is just another invalid row.
+			if (!validateItemFields({ name: draft.name, description: draft.description, images }, { requireImage: true }).isValid) {
+				continue;
 			}
 
-			let groups: string[] = [];
-			try {
-				groups = (JSON.parse(groupsRaw ?? '[]') as string[]).filter((id) => allowedGroupIds.has(id));
-			} catch {
-				groups = [];
-			}
+			const payload: ItemWritePayload = {
+				name: draft.name,
+				description: draft.description,
+				image: draft.image ?? undefined,
+				owner: locals.user.id,
+				categories: sanitizeCategories(draft.rawCategories),
+				groups: filterAttachableGroups(draft.rawGroups, allowedGroupIds),
+				status: 'available',
+				trusteesOnly: draft.trusteesOnly,
+			};
 
-			if (!name || !description || !(image instanceof File) || image.size === 0) continue;
-
 			try {
-				await locals.pb.collection('items').create({
-					name,
-					description,
-					image,
-					owner: locals.user.id,
-					categories,
-					groups,
-					status: 'available',
-					trusteesOnly: formData.get(`trusteesOnly_${i}`) === 'on',
-				});
+				await locals.pb.collection('items').create(payload);
 				successCount++;
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			} catch (err: Error | any) {
-				console.error('bulkCreate item error:', err?.message ?? err);
+			} catch (err: unknown) {
+				console.error('bulkCreate item error:', err instanceof Error ? err.message : err);
 			}
 		}
 

--- a/src/routes/user/items/bulk-add/page.server.test.ts
+++ b/src/routes/user/items/bulk-add/page.server.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Characterization tests for the bulk-add action (#470). They pin down today's
+// behavior BEFORE the itemForm.ts extraction so the refactor is provably
+// behavior-preserving. The single documented exception is the invalid-image-type
+// row (see the test flagged "INTENTIONAL BEHAVIOR CHANGE"): the shared validator
+// activates the MIME whitelist for bulk too, so such a row is now skipped.
+
+const { getAttachableGroupsMock } = vi.hoisted(() => ({
+	getAttachableGroupsMock: vi.fn(),
+}));
+vi.mock('$lib/server/groups', () => ({ getAttachableGroups: getAttachableGroupsMock }));
+
+import { actions } from './+page.server';
+import { texts } from '$lib/texts';
+
+type BulkEvent = Parameters<typeof actions.bulkCreate>[0];
+
+function imageFile(name = 'a.jpg', type = 'image/jpeg') {
+	return new File(['x'], name, { type });
+}
+
+function buildPb() {
+	const createMock = vi.fn().mockResolvedValue({});
+	const pbClient = { collection: vi.fn(() => ({ create: createMock })) };
+	return { pbClient, createMock };
+}
+
+/** Appends one bulk row (index i) to a FormData in the wire format ReviewStep emits. */
+function appendRow(
+	fd: FormData,
+	i: number,
+	row: {
+		name?: string;
+		description?: string;
+		image?: File | null;
+		categories?: string; // raw JSON string as sent over the wire
+		groups?: string; // raw JSON string as sent over the wire
+		trusteesOnly?: 'on' | 'off';
+	}
+) {
+	if (row.name !== undefined) fd.set(`name_${i}`, row.name);
+	if (row.description !== undefined) fd.set(`description_${i}`, row.description);
+	if (row.image !== undefined && row.image !== null) fd.set(`image_${i}`, row.image);
+	if (row.categories !== undefined) fd.set(`categories_${i}`, row.categories);
+	if (row.groups !== undefined) fd.set(`groups_${i}`, row.groups);
+	fd.set(`trusteesOnly_${i}`, row.trusteesOnly ?? 'off');
+}
+
+function runBulk(pbClient: unknown, fd: FormData) {
+	return actions.bulkCreate({
+		locals: { pb: pbClient, user: { id: 'u1' } },
+		request: { formData: vi.fn().mockResolvedValue(fd) },
+	} as unknown as BulkEvent);
+}
+
+/** redirect() throws; capture the thrown Redirect for assertions. */
+async function runBulkCatchRedirect(pbClient: unknown, fd: FormData) {
+	try {
+		return { result: await runBulk(pbClient, fd), thrown: undefined as unknown };
+	} catch (thrown) {
+		return { result: undefined, thrown };
+	}
+}
+
+describe('bulk-add: bulkCreate action', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		getAttachableGroupsMock.mockResolvedValue([]);
+	});
+
+	it('creates one item per valid row with the correct payload (happy path)', async () => {
+		getAttachableGroupsMock.mockResolvedValue([{ id: 'g1' }, { id: 'g2' }]);
+		const { pbClient, createMock } = buildPb();
+		const fd = new FormData();
+		fd.set('count', '2');
+		appendRow(fd, 0, {
+			name: 'Bohrer',
+			description: 'Beschreibung 0',
+			image: imageFile('0.jpg'),
+			categories: JSON.stringify(['Werkzeug und Garten']),
+			groups: JSON.stringify(['g1']),
+			trusteesOnly: 'on',
+		});
+		appendRow(fd, 1, {
+			name: 'Leiter',
+			description: 'Beschreibung 1',
+			image: imageFile('1.png', 'image/png'),
+			categories: JSON.stringify(['Bücher']),
+			groups: JSON.stringify(['g2']),
+			trusteesOnly: 'off',
+		});
+
+		const { thrown } = await runBulkCatchRedirect(pbClient, fd);
+
+		// success ⇒ redirect(303) is thrown
+		expect((thrown as { status?: number }).status).toBe(303);
+		expect(createMock).toHaveBeenCalledTimes(2);
+		expect(createMock.mock.calls[0][0]).toMatchObject({
+			name: 'Bohrer',
+			description: 'Beschreibung 0',
+			owner: 'u1',
+			status: 'available',
+			trusteesOnly: true,
+			categories: ['Werkzeug und Garten'],
+			groups: ['g1'],
+		});
+		expect(createMock.mock.calls[1][0]).toMatchObject({
+			trusteesOnly: false,
+			categories: ['Bücher'],
+			groups: ['g2'],
+		});
+	});
+
+	it('drops group ids the user may not attach (tampering guard)', async () => {
+		getAttachableGroupsMock.mockResolvedValue([{ id: 'g1' }]);
+		const { pbClient, createMock } = buildPb();
+		const fd = new FormData();
+		fd.set('count', '1');
+		appendRow(fd, 0, {
+			name: 'Ding',
+			description: 'Beschreibung',
+			image: imageFile(),
+			groups: JSON.stringify(['g1', 'g-foreign']),
+		});
+
+		await runBulkCatchRedirect(pbClient, fd);
+
+		expect(createMock.mock.calls[0][0].groups).toEqual(['g1']);
+	});
+
+	it('drops unknown categories', async () => {
+		const { pbClient, createMock } = buildPb();
+		const fd = new FormData();
+		fd.set('count', '1');
+		appendRow(fd, 0, {
+			name: 'Ding',
+			description: 'Beschreibung',
+			image: imageFile(),
+			categories: JSON.stringify(['Werkzeug und Garten', 'nonsense-cat']),
+		});
+
+		await runBulkCatchRedirect(pbClient, fd);
+
+		expect(createMock.mock.calls[0][0].categories).toEqual(['Werkzeug und Garten']);
+	});
+
+	it('falls back to [] when categories/groups JSON is garbage, still creating the row', async () => {
+		const { pbClient, createMock } = buildPb();
+		const fd = new FormData();
+		fd.set('count', '1');
+		appendRow(fd, 0, {
+			name: 'Ding',
+			description: 'Beschreibung',
+			image: imageFile(),
+			categories: '{not json',
+			groups: 'also not json',
+		});
+
+		await runBulkCatchRedirect(pbClient, fd);
+
+		expect(createMock).toHaveBeenCalledTimes(1);
+		expect(createMock.mock.calls[0][0].categories).toEqual([]);
+		expect(createMock.mock.calls[0][0].groups).toEqual([]);
+	});
+
+	it('skips rows missing name, description, or file (and 0-byte files) but keeps valid rows', async () => {
+		const { pbClient, createMock } = buildPb();
+		const fd = new FormData();
+		fd.set('count', '5');
+		// 0: missing name
+		appendRow(fd, 0, { description: 'd', image: imageFile() });
+		// 1: missing description
+		appendRow(fd, 1, { name: 'n', image: imageFile() });
+		// 2: missing file
+		appendRow(fd, 2, { name: 'n', description: 'd' });
+		// 3: 0-byte file
+		appendRow(fd, 3, { name: 'n', description: 'd', image: new File([], 'empty.jpg', { type: 'image/jpeg' }) });
+		// 4: valid
+		appendRow(fd, 4, { name: 'Gut', description: 'd', image: imageFile() });
+
+		await runBulkCatchRedirect(pbClient, fd);
+
+		expect(createMock).toHaveBeenCalledTimes(1);
+		expect(createMock.mock.calls[0][0].name).toBe('Gut');
+	});
+
+	it('isolates a per-row create failure: logs it, keeps going, still redirects on ≥1 success', async () => {
+		const { pbClient, createMock } = buildPb();
+		createMock.mockRejectedValueOnce(new Error('boom'));
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const fd = new FormData();
+		fd.set('count', '2');
+		appendRow(fd, 0, { name: 'Fehlt', description: 'd', image: imageFile() });
+		appendRow(fd, 1, { name: 'Klappt', description: 'd', image: imageFile() });
+
+		const { thrown } = await runBulkCatchRedirect(pbClient, fd);
+
+		expect(createMock).toHaveBeenCalledTimes(2);
+		expect(errSpy).toHaveBeenCalled();
+		expect((thrown as { status?: number }).status).toBe(303);
+		errSpy.mockRestore();
+	});
+
+	it('fails with 500 when every row fails to create', async () => {
+		const { pbClient, createMock } = buildPb();
+		createMock.mockRejectedValue(new Error('boom'));
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		const fd = new FormData();
+		fd.set('count', '1');
+		appendRow(fd, 0, { name: 'Ding', description: 'd', image: imageFile() });
+
+		const { result, thrown } = await runBulkCatchRedirect(pbClient, fd);
+
+		expect(thrown).toBeUndefined();
+		expect(result?.status).toBe(500);
+		expect((result?.data as { message?: string }).message).toBe(texts.bulkUpload.uploadFailed);
+	});
+
+	it('redirects to /user/items on success', async () => {
+		const { pbClient } = buildPb();
+		const fd = new FormData();
+		fd.set('count', '1');
+		appendRow(fd, 0, { name: 'Ding', description: 'd', image: imageFile() });
+
+		const { thrown } = await runBulkCatchRedirect(pbClient, fd);
+
+		expect((thrown as { status?: number; location?: string }).status).toBe(303);
+		expect((thrown as { location?: string }).location).toBe('/user/items');
+	});
+
+	it('fails with 400 when count is missing, zero, or negative', async () => {
+		const { pbClient, createMock } = buildPb();
+		for (const count of [undefined, '0', '-3']) {
+			const fd = new FormData();
+			if (count !== undefined) fd.set('count', count);
+			const result = await runBulk(pbClient, fd);
+			expect(result?.status).toBe(400);
+		}
+		expect(createMock).not.toHaveBeenCalled();
+	});
+
+	// INTENTIONAL BEHAVIOR CHANGE (#470, decided by the maintainer): the shared
+	// validateItemFields applies the MIME whitelist to bulk rows too. A row whose
+	// file is not an accepted image type is now treated as an invalid row and
+	// skipped — exactly like a missing file — with no new error UI.
+	// Pre-refactor this row WAS created (bulk had no MIME check). This is the one
+	// documented deviation from strict "no behavior change".
+	it('skips a row with an invalid image type (MIME whitelist now active in bulk)', async () => {
+		const { pbClient, createMock } = buildPb();
+		const fd = new FormData();
+		fd.set('count', '2');
+		appendRow(fd, 0, { name: 'PDF', description: 'd', image: imageFile('bad.pdf', 'application/pdf') });
+		appendRow(fd, 1, { name: 'Gut', description: 'd', image: imageFile('ok.jpg') });
+
+		await runBulkCatchRedirect(pbClient, fd);
+
+		expect(createMock).toHaveBeenCalledTimes(1);
+		expect(createMock.mock.calls[0][0].name).toBe('Gut');
+	});
+});


### PR DESCRIPTION
## What & why

Item create/edit logic was duplicated across the single-item flow
(`src/routes/user/items/+page.server.ts`) and the bulk-add flow
(`src/routes/user/items/bulk-add/+page.server.ts`): field extraction,
visibility toggles (`trusteesOnly`, `groups`), category filtering and
validation were maintained in parallel, so every new item field had to be
wired up in two places. The same routes also carried four
`no-explicit-any` suppressions right where form data meets the DB.

This PR extracts the shared logic into a new **`$lib/server/itemForm.ts`**
module that both flows consume:

- `extractItemForm` / `extractBulkItemDraft` — per-flow field extraction
  (wire formats unchanged: `itemName`/`itemImage`/… for single,
  indexed + JSON-encoded `name_${i}`/`categories_${i}`/… for bulk).
- `validateItemFields` — moved from `validateItemData`; **error object shape
  is unchanged** (`nameIsMissing` / `descriptionIsMissing` / `imageIsMissing`
  / `imageInvalidType` / `tooManyImages`) because `ItemModal.svelte` and the
  existing tests depend on it.
- `sanitizeCategories` — single source of truth, replacing three inline
  `ITEM_CATEGORIES` filters (create, update, bulk).
- `sanitizeGroups` / `filterAttachableGroups` — the tamper guard that filters
  submitted group IDs against `getAttachableGroups` (owned + member); loaded
  once per request in the bulk flow, not per row.
- `ItemWritePayload` — typed write payload replacing `Record<string, any>`.

### Removed all 4 `no-explicit-any` suppressions in the item routes
- `+page.server.ts` update: `Record<string, any>` → typed `ItemWritePayload`
- `+page.server.ts` delete: `catch (err: Error | any)` → `catch (err: unknown)` + narrowing
- `+page.server.ts` bulkSetStatus: same `catch (err: unknown)` conversion
- `bulk-add/+page.server.ts` bulkCreate: same `catch (err: unknown)` conversion

### Deliberate behavior change (bulk MIME validation)
The bulk-add flow previously ran **no image MIME-type validation** (a gap vs.
the single flow). It now runs the shared `validateItemFields` including the
MIME whitelist, so a bulk row with an invalid image type is **silently
skipped** like any other invalid row — no new error UI, just a consistent
definition of "invalid row". This is the one intentional deviation from
strict no-behavior-change and is covered by a dedicated, comment-flagged test.
In practice it only triggers on a hand-crafted POST, since `ReviewStep`
transcodes images to JPEG client-side before submit (defense in depth).

Out of scope (per the issue): client-side dedup of `ItemModal.svelte` /
`ReviewStep.svelte`, and `expand?: Record<string, any>` in `models.ts`.

Closes #470

## Test notes
- `npm run lint` — clean.
- `npx vitest run` — **570/570 passing** (50 files), including the unchanged
  single-flow anchor test `page.server.test.ts` (no-behavior-change proof),
  17 new `itemForm.test.ts` cases and 10 new bulk-add characterization cases.
- Browser smoke (single create with 2 images, edit without/with new image,
  bulk-add with group assignment, missing-name validation) — all pass.
- `npm run check` / `npm run build` fail **locally** on 6 pre-existing
  `$env/static/private` sync-var errors (`SYNC_SECRET`, `PB_SUPERUSER_EMAIL`,
  `PB_SUPERUSER_PASSWORD`) in the integration files — **not** from this diff;
  they resolve in CI where those env vars are set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
