### PR TITLE
Add group filter to search page (#484)

### DIFF
--- a/docs/search-discovery.md
+++ b/docs/search-discovery.md
@@ -23,13 +23,14 @@ SearchParameters  ──buildItemFilter()──►  PocketBase filter string
 | Concern | File | Notes |
 |---|---|---|
 | Parse & validate URL params | [`searchFilter.ts`](../src/routes/search/searchFilter.ts) `parseSearchParameters` | Returns a fully-typed `SearchParameters`; clamps `page`/`perPage`, drops unknown categories. |
-| Build the PB filter | [`searchFilter.ts`](../src/routes/search/searchFilter.ts) `buildItemFilter` / `buildSearchFilter` | Combines name, owner-exclusion, categories, availability, owner-type with `&&`. |
+| Build the PB filter | [`searchFilter.ts`](../src/routes/search/searchFilter.ts) `buildItemFilter` / `buildSearchFilter` | Combines name, owner-exclusion, categories, availability, owner-type and group with `&&`. |
 | Server load | [`+page.server.ts`](../src/routes/search/+page.server.ts) | Reads the `items_searchable` view, sorts, paginates, logs non-empty queries. |
 | Page shell + client filters | [`+page.svelte`](../src/routes/search/+page.svelte) | Wires search bar, filters, results, pagination. |
 | Results grid | [`ResultsList.svelte`](../src/routes/search/ResultsList.svelte) → [`ItemCard.svelte`](../src/routes/search/ItemCard.svelte) | Takes an `ItemPublic[]` and renders cards. |
 | Pagination UI | [`Pagination.svelte`](../src/routes/search/Pagination.svelte) | Page buttons + per-page selector; a GET form so no `goto()` is needed. |
 | URL building | [`searchUrl.ts`](../src/routes/search/searchUrl.ts) `buildSearchUrl` | Single source of truth for constructing `/search?...` links. |
 | Travel-time filter | [`TravelTimeFilter.svelte`](../src/routes/search/TravelTimeFilter.svelte) | Client-side; filters/sorts the **current page** by bucketed minutes (see below). |
+| Group filter | [`GroupFilter.svelte`](../src/routes/search/GroupFilter.svelte) | Single-select dropdown of the user's groups; navigates via `buildSearchUrl`. Rendered only when the user has groups (guests never see it). |
 
 ## Which view it reads
 
@@ -55,7 +56,28 @@ All discovery state lives in the URL (deep-linkable, server-rendered). Defaults 
 | `op` | `or` (default) / `and` — how multiple categories combine |
 | `onlyAvailable` | `true` (default); `false` includes unavailable items |
 | `ownerType` | `all` (default) / `institution` / `private` |
+| `group` | a single group id — restrict results to items shared with that group. Only groups the requester owns or is a member of are accepted (see the security note below); anything else is silently dropped |
 | `page` (1), `perPage` (20, max 50) | pagination |
+
+### Group filter (`group`) — security
+
+`buildItemFilter` appends a `groups ~ "<id>"` clause when a group is selected. The `~` operator
+is the any-of membership match PocketBase uses for the view's `groups` column — the same operator
+the group-detail page (`user/groups/[id]/+page.server.ts`) uses against the same `items_searchable`
+view. The clause is built by string concatenation (the whole filter string is, by design) with
+the id quote-escaped as defense-in-depth; the parser already restricts `group` to a 15-char id.
+
+The **authorization is server-side, not UI-side** (`+page.server.ts` load): the `group` param is
+only allowed to filter when the user is in `getAttachableGroups(pb, user.id)` (groups they own or
+belong to). A non-member, guest, or garbage id is dropped to `null` — a shared link with a foreign
+group id then just shows the unfiltered search, no error (mirroring how unknown `cats` are
+ignored). This matters because URLs are shareable/editable: without the check, filtering by a
+foreign group id would disclose which of the items a user can see are *also* in that group.
+
+The `items.groups` column stays out of the `fields` allowlist regardless — it is only traversed by
+the view's row rule and must never be serialized to a client (it would leak an item's *other*
+group memberships). The selected group id is also **not** written to the `searches` analytics log:
+it is a private social-graph datum, and the `hasQuery` logging condition is unchanged.
 
 ## Conventions / gotchas
 

--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -674,6 +674,8 @@ export const texts = {
 			ownerTypeAll: 'Alle',
 			ownerTypeInstitution: 'Institutionen',
 			ownerTypePrivate: 'Personen',
+			groupFilterLabel: 'Gruppe',
+			groupFilterAll: 'Alle Gruppen',
 		},
 		logout: {
 			message: 'Ausloggen...',

--- a/src/routes/search/+page.server.ts
+++ b/src/routes/search/+page.server.ts
@@ -3,16 +3,32 @@ import type { ItemPublic } from '$lib/types/models';
 import { parseSearchParameters, buildItemFilter, type SearchParameters } from './searchFilter';
 import type { ListResult } from 'pocketbase';
 import { upsertUserPreferences } from '$lib/server/userPreferences';
+import { getAttachableGroups } from '$lib/server/groups';
 
 export async function load({ locals, url }) {
 	// 1. Parse search parameters from URL
 	const searchParameters = parseSearchParameters(url) as SearchParameters;
 	const hasQuery = !!searchParameters.query || searchParameters.selectedCategories.length > 0;
 
-	// 2. Build PocketBase filter
+	// 2. Load the user's own groups (the dropdown needs them anyway) and enforce the group
+	//    filter's authorization here — this, not the UI, is the security boundary. A shared URL
+	//    carrying a foreign group id must not let the requester probe which of the items they can
+	//    see are also in that group; so the group is only allowed to filter when the user is a
+	//    member of it. Non-members / guests / garbage ids are silently dropped to `null`
+	//    (mirroring how unknown `cats` values are ignored) — a shared link then just shows the
+	//    unfiltered search, no error. Guests never call getAttachableGroups.
+	const attachableGroups = locals.user ? await getAttachableGroups(locals.pb, locals.user.id) : [];
+	if (
+		searchParameters.selectedGroup &&
+		!attachableGroups.some((g) => g.id === searchParameters.selectedGroup)
+	) {
+		searchParameters.selectedGroup = null;
+	}
+
+	// 3. Build PocketBase filter (group clause only present for a membership-validated id above)
 	const filter = buildItemFilter(searchParameters, locals.user?.id);
 
-	// 3. Fetch paginated items, newest listings first (by creation date, so edits don't
+	// 4. Fetch paginated items, newest listings first (by creation date, so edits don't
 	//    resurface old items). Empty-query browsing shows the same newest-first catalogue.
 	let result: ListResult<ItemPublic> = { page: 1, perPage: searchParameters.perPage, totalItems: 0, totalPages: 0, items: [] };
 	try {
@@ -31,7 +47,9 @@ export async function load({ locals, url }) {
 		console.error('Error fetching items:', error);
 	}
 
-	// 4. Log search queries (fire-and-forget) — skip blank default browsing
+	// 5. Log search queries (fire-and-forget) — skip blank default browsing. The selected group
+	//    is deliberately NOT logged: it's a private social-graph datum and the log only serves
+	//    search-term statistics. The `hasQuery` condition is intentionally left untouched.
 	if (hasQuery) {
 		void locals.pb.collection('searches').create({
 			query: searchParameters.query,
@@ -47,6 +65,9 @@ export async function load({ locals, url }) {
 		op: searchParameters.op,
 		onlyAvailable: searchParameters.onlyAvailable,
 		ownerType: searchParameters.ownerType,
+		selectedGroup: searchParameters.selectedGroup,
+		// Only id + name reach the client — never the `groups` column of items.
+		attachableGroups: attachableGroups.map(({ id, name }) => ({ id, name })),
 		currentUser: locals.user ?? null,
 		page: result.page,
 		perPage: result.perPage,

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -101,17 +101,7 @@
 		group={data.selectedGroup}
 	/>
 
-	{#if data.attachableGroups.length > 0}
-		<GroupFilter
-			groups={data.attachableGroups}
-			selectedGroup={data.selectedGroup}
-			q={data.q}
-			cats={data.selectedCategories}
-			op={data.op}
-			onlyAvailable={data.onlyAvailable}
-			ownerType={data.ownerType}
-		/>
-	{/if}
+
 
 	<hr class="border-tinte-300 max-w-100! my-2 mx-auto"/>
 
@@ -135,7 +125,17 @@
 			href={searchUrl({ ownerType: ownerTypeNext[data.ownerType as keyof typeof ownerTypeNext] })}
 			class="flex items-center rounded-full border px-3 py-1 text-sm font-medium transition-colors border-tinte-300 bg-papier text-tinte-700 hover:border-primary hover:text-primary dark:border-tinte-600 dark:bg-tinte-800 dark:text-tinte-300 dark:hover:border-primary dark:hover:text-primary"
 		><ArrowsRepeatOutline class="mr-1 h-4 w-4 shrink-0" />{texts.pages.search.ownerTypePrefix}: {ownerTypeLabel[data.ownerType as keyof typeof ownerTypeLabel]}</a>
-
+		{#if data.attachableGroups.length > 0}
+			<GroupFilter
+				groups={data.attachableGroups}
+				selectedGroup={data.selectedGroup}
+				q={data.q}
+				cats={data.selectedCategories}
+				op={data.op}
+				onlyAvailable={data.onlyAvailable}
+				ownerType={data.ownerType}
+			/>
+		{/if}
 	</div>
 
 	<hr class="border-tinte-300 max-w-100! my-2 mx-auto"/>

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -5,6 +5,7 @@
 	import ResultsList from './ResultsList.svelte';
 	import Pagination from './Pagination.svelte';
 	import CategoryFilter from './CategoryFilter.svelte';
+	import GroupFilter from './GroupFilter.svelte';
 	import TravelTimeFilter from './TravelTimeFilter.svelte';
 	import { texts } from '$lib/texts';
 	import { ArrowsRepeatOutline } from 'flowbite-svelte-icons';
@@ -32,6 +33,7 @@
 			op: data.op,
 			onlyAvailable: overrides.onlyAvailable ?? data.onlyAvailable,
 			ownerType: overrides.ownerType ?? data.ownerType,
+			group: data.selectedGroup ?? undefined,
 		});
 	}
 	const filteredItems = $derived.by(() => {
@@ -72,6 +74,7 @@
 			op={data.op}
 			onlyAvailable={data.onlyAvailable}
 			ownerType={data.ownerType}
+			group={data.selectedGroup}
 		/>
 	{/if}
 {/snippet}
@@ -95,7 +98,20 @@
 		perPage={data.perPage}
 		onlyAvailable={data.onlyAvailable}
 		ownerType={data.ownerType}
+		group={data.selectedGroup}
 	/>
+
+	{#if data.attachableGroups.length > 0}
+		<GroupFilter
+			groups={data.attachableGroups}
+			selectedGroup={data.selectedGroup}
+			q={data.q}
+			cats={data.selectedCategories}
+			op={data.op}
+			onlyAvailable={data.onlyAvailable}
+			ownerType={data.ownerType}
+		/>
+	{/if}
 
 	<hr class="border-tinte-300 max-w-100! my-2 mx-auto"/>
 
@@ -127,7 +143,7 @@
 	<TravelTimeFilter
 		{preferredMode}
 		isLoggedIn={!!data.currentUser}
-		hasQuery={data.q.length > 0 || data.selectedCategories.length > 0}
+		hasQuery={data.q.length > 0 || data.selectedCategories.length > 0 || !!data.selectedGroup}
 		items={data.items ?? []}
 		bind:transportMode
 		bind:travelTimes
@@ -135,7 +151,7 @@
 	/>
 
 	<div class="w-full items-center justify-center text-center mt-2">
-		{#if data.q || data.selectedCategories.length > 0}
+		{#if data.q || data.selectedCategories.length > 0 || data.selectedGroup}
 			<h5>{texts.ui.resultsFound(filterActive ? filteredItems.length : data.totalItems ?? 0)}</h5>
 		{:else}
 			<h5>{texts.pages.search.newestItemsHeading}</h5>

--- a/src/routes/search/CategoryFilter.svelte
+++ b/src/routes/search/CategoryFilter.svelte
@@ -12,13 +12,14 @@
 		perPage: number;
 		onlyAvailable: boolean;
 		ownerType: string;
+		group: string | null;
 	}
 
-	let { selectedCategories, op, q, perPage, onlyAvailable, ownerType }: Props = $props();
+	let { selectedCategories, op, q, perPage, onlyAvailable, ownerType, group }: Props = $props();
 
 	function buildUrl(newCats: string[], newOp: 'or' | 'and'): string {
 		// Always reset to page 1 when filter changes (omit page param).
-		return buildSearchUrl({ q, cats: newCats, op: newOp, onlyAvailable, ownerType, perPage: perPage !== 10 ? perPage : undefined });
+		return buildSearchUrl({ q, cats: newCats, op: newOp, onlyAvailable, ownerType, group: group ?? undefined, perPage: perPage !== 10 ? perPage : undefined });
 	}
 
 	function toggleCat(cat: string) {

--- a/src/routes/search/GroupFilter.svelte
+++ b/src/routes/search/GroupFilter.svelte
@@ -27,10 +27,7 @@
 </script>
 
 <!-- Only rendered when the user has groups (implies logged in); guests never see it. -->
-<div class="mt-3 flex flex-wrap items-center justify-center gap-2">
-	<label for="group-filter" class="text-sm text-tinte-600 dark:text-tinte-400">
-		{texts.pages.search.groupFilterLabel}
-	</label>
+<div class="flex flex-wrap items-center justify-center gap-2">
 	<!-- Styled as a pill matching the category chips / owner-type toggle: highlighted (primary)
 	     when a group is active, native arrow removed via appearance-none + custom chevron. -->
 	<div class="relative inline-flex">

--- a/src/routes/search/GroupFilter.svelte
+++ b/src/routes/search/GroupFilter.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { ChevronDownOutline } from 'flowbite-svelte-icons';
+	import { texts } from '$lib/texts';
+	import { buildSearchUrl } from './searchUrl';
+
+	interface Props {
+		groups: { id: string; name: string }[];
+		selectedGroup: string | null;
+		// All other active search params, threaded through so switching group preserves them.
+		q: string;
+		cats: string[];
+		op: 'or' | 'and';
+		onlyAvailable: boolean;
+		ownerType: string;
+	}
+
+	let { groups, selectedGroup, q, cats, op, onlyAvailable, ownerType }: Props = $props();
+
+	function onChange(event: Event) {
+		const value = (event.currentTarget as HTMLSelectElement).value;
+		// Reset to page 1 (page param omitted, matching CategoryFilter). An empty value clears
+		// the filter (group left undefined).
+		// eslint-disable-next-line svelte/no-navigation-without-resolve -- buildSearchUrl() already resolve()s the /search path; the rule can't see through the helper
+		goto(buildSearchUrl({ q, cats, op, onlyAvailable, ownerType, group: value || undefined }));
+	}
+</script>
+
+<!-- Only rendered when the user has groups (implies logged in); guests never see it. -->
+<div class="mt-3 flex flex-wrap items-center justify-center gap-2">
+	<label for="group-filter" class="text-sm text-tinte-600 dark:text-tinte-400">
+		{texts.pages.search.groupFilterLabel}
+	</label>
+	<!-- Styled as a pill matching the category chips / owner-type toggle: highlighted (primary)
+	     when a group is active, native arrow removed via appearance-none + custom chevron. -->
+	<div class="relative inline-flex">
+		<select
+			id="group-filter"
+			value={selectedGroup ?? ''}
+			onchange={onChange}
+			class="max-w-60 cursor-pointer appearance-none truncate rounded-full border py-1 pl-3 pr-8 text-sm font-medium transition-colors focus:ring-primary
+				{selectedGroup
+				? 'border-primary bg-primary text-white'
+				: 'border-tinte-300 bg-papier text-tinte-700 hover:border-primary hover:text-primary dark:border-tinte-600 dark:bg-tinte-800 dark:text-tinte-300 dark:hover:border-primary dark:hover:text-primary'}"
+		>
+			<option value="">{texts.pages.search.groupFilterAll}</option>
+			{#each groups as group (group.id)}
+				<option value={group.id}>{group.name}</option>
+			{/each}
+		</select>
+		<ChevronDownOutline
+			class="pointer-events-none absolute right-2.5 top-1/2 h-4 w-4 -translate-y-1/2 {selectedGroup
+				? 'text-white'
+				: 'text-tinte-500 dark:text-tinte-400'}"
+		/>
+	</div>
+</div>

--- a/src/routes/search/Pagination.svelte
+++ b/src/routes/search/Pagination.svelte
@@ -13,14 +13,15 @@
 		op: 'or' | 'and';
 		onlyAvailable: boolean;
 		ownerType: string;
+		group: string | null;
 	}
 
-	let { page, totalPages, perPage, q, selectedCategories, op, onlyAvailable, ownerType }: Props = $props();
+	let { page, totalPages, perPage, q, selectedCategories, op, onlyAvailable, ownerType, group }: Props = $props();
 
 	const perPageOptions = [10, 20, 50];
 
 	function pageUrl(n: number): string {
-		return buildSearchUrl({ q, page: n, perPage, cats: selectedCategories, op, onlyAvailable, ownerType });
+		return buildSearchUrl({ q, page: n, perPage, cats: selectedCategories, op, onlyAvailable, ownerType, group: group ?? undefined });
 	}
 
 	function getPages(): (number | '...')[] {
@@ -98,6 +99,9 @@
 			{/if}
 			{#if ownerType !== 'all'}
 				<input type="hidden" name="ownerType" value={ownerType} />
+			{/if}
+			{#if group}
+				<input type="hidden" name="group" value={group} />
 			{/if}
 			<span>{texts.pages.search.perPage}</span>
 			<select

--- a/src/routes/search/page.server.test.ts
+++ b/src/routes/search/page.server.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The load calls getAttachableGroups (the membership source of truth) to both feed the
+// dropdown and authorize the `group` param. Mock it so the leak-guard wiring is testable
+// without a real PocketBase.
+const { getAttachableGroupsMock } = vi.hoisted(() => ({ getAttachableGroupsMock: vi.fn() }));
+vi.mock('$lib/server/groups', () => ({ getAttachableGroups: getAttachableGroupsMock }));
+// +page.server re-exports PUBLIC_PB_URL from hooks.server, which reads it from $env at import.
+vi.mock('$env/static/public', () => ({ PUBLIC_PB_URL: 'http://localhost', PUBLIC_VAPID_PUBLIC_KEY: 'x' }));
+
+import { load } from './+page.server';
+
+// A well-formed 15-char PocketBase record id (survives parseSearchParameters' shape check).
+const MEMBER_GROUP = 'abcdefghij01234';
+const FOREIGN_GROUP = 'zyxwvutsrq98765';
+
+type LoadResult = Awaited<ReturnType<typeof load>>;
+
+function makeLocals(user: { id: string } | null) {
+	const getList = vi.fn().mockResolvedValue({ page: 1, perPage: 20, totalItems: 0, totalPages: 0, items: [] });
+	const create = vi.fn().mockResolvedValue({});
+	const collection = vi.fn((name: string) => {
+		if (name === 'items_searchable') return { getList };
+		if (name === 'searches') return { create };
+		return {};
+	});
+	return { locals: { pb: { collection }, user }, getList, create };
+}
+
+function run(locals: unknown, search = ''): Promise<LoadResult> {
+	const url = new URL(`http://x/search${search}`);
+	return load({ locals, url } as never);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('search load — group filter', () => {
+	it('applies a membership-validated group id to the getList filter and returns it', async () => {
+		getAttachableGroupsMock.mockResolvedValue([{ id: MEMBER_GROUP, name: 'Nachbarschaft', isPublic: false }]);
+		const { locals, getList } = makeLocals({ id: 'u1' });
+
+		const res = await run(locals, `?group=${MEMBER_GROUP}`);
+
+		const opts = getList.mock.calls[0][2];
+		expect(opts.filter).toContain(`groups ~ "${MEMBER_GROUP}"`);
+		expect(res.selectedGroup).toBe(MEMBER_GROUP);
+		// Only id + name reach the client — never the item's `groups` column.
+		expect(res.attachableGroups).toEqual([{ id: MEMBER_GROUP, name: 'Nachbarschaft' }]);
+	});
+
+	it('silently drops a foreign group id (leak guard): no group clause, selectedGroup null', async () => {
+		// The user is a member of a different group than the one in the URL.
+		getAttachableGroupsMock.mockResolvedValue([{ id: MEMBER_GROUP, name: 'Nachbarschaft', isPublic: false }]);
+		const { locals, getList } = makeLocals({ id: 'u1' });
+
+		const res = await run(locals, `?group=${FOREIGN_GROUP}`);
+
+		const opts = getList.mock.calls[0][2];
+		expect(opts.filter ?? '').not.toContain('groups');
+		expect(res.selectedGroup).toBeNull();
+	});
+
+	it('ignores the param for guests and never calls getAttachableGroups', async () => {
+		const { locals, getList } = makeLocals(null);
+
+		const res = await run(locals, `?group=${MEMBER_GROUP}`);
+
+		expect(getAttachableGroupsMock).not.toHaveBeenCalled();
+		expect(res.attachableGroups).toEqual([]);
+		expect(res.selectedGroup).toBeNull();
+		const opts = getList.mock.calls[0][2];
+		expect(opts.filter ?? '').not.toContain('groups');
+	});
+
+	it('never returns the items.groups column via the fields allowlist (leak regression)', async () => {
+		getAttachableGroupsMock.mockResolvedValue([{ id: MEMBER_GROUP, name: 'Nachbarschaft', isPublic: false }]);
+		const { locals, getList } = makeLocals({ id: 'u1' });
+
+		await run(locals, `?group=${MEMBER_GROUP}`);
+
+		const opts = getList.mock.calls[0][2];
+		expect(opts.fields).toBeTruthy();
+		expect(opts.fields).toContain('status');
+		expect(opts.fields).not.toContain('groups');
+	});
+
+	it('does not log to searches when only a group is selected (no q/cats)', async () => {
+		getAttachableGroupsMock.mockResolvedValue([{ id: MEMBER_GROUP, name: 'Nachbarschaft', isPublic: false }]);
+		const { locals, create } = makeLocals({ id: 'u1' });
+
+		await run(locals, `?group=${MEMBER_GROUP}`);
+
+		expect(create).not.toHaveBeenCalled();
+	});
+
+	it('logs the query but never the group id when q + group are combined', async () => {
+		getAttachableGroupsMock.mockResolvedValue([{ id: MEMBER_GROUP, name: 'Nachbarschaft', isPublic: false }]);
+		const { locals, create } = makeLocals({ id: 'u1' });
+
+		await run(locals, `?q=zelt&group=${MEMBER_GROUP}`);
+
+		expect(create).toHaveBeenCalledTimes(1);
+		const payload = create.mock.calls[0][0];
+		expect(payload).toEqual({ query: 'zelt', categories: '' });
+		// The private social-graph datum must not leak into the analytics log.
+		expect(JSON.stringify(payload)).not.toContain(MEMBER_GROUP);
+	});
+});

--- a/src/routes/search/searchFilter.test.ts
+++ b/src/routes/search/searchFilter.test.ts
@@ -37,6 +37,7 @@ describe('buildItemFilter', () => {
 		op: 'or',
 		onlyAvailable: true,
 		ownerType: 'all',
+		selectedGroup: null,
 	};
 
 	it('includes the username clause when a query is present', () => {
@@ -52,11 +53,69 @@ describe('buildItemFilter', () => {
 		const filter = buildItemFilter({ ...base, query: 'x' }, 'user123');
 		expect(filter).toContain('userId != "user123"');
 	});
+
+	it('adds no group clause when no group is selected', () => {
+		expect(buildItemFilter({ ...base, query: 'x' })).not.toContain('groups');
+	});
+
+	it('adds exactly one group clause with the "~" operator when a group is selected', () => {
+		const filter = buildItemFilter({ ...base, selectedGroup: 'abcdefghij01234' });
+		expect(filter).toContain('groups ~ "abcdefghij01234"');
+		// Only a single group clause is ever emitted (single-select).
+		expect(filter?.match(/groups ~ /g)).toHaveLength(1);
+	});
+
+	it('combines the group clause with query, categories, availability and ownerType', () => {
+		const filter = buildItemFilter(
+			{
+				...base,
+				query: 'zelt',
+				selectedCategories: ['Reisen und Outdoor'],
+				onlyAvailable: true,
+				ownerType: 'private',
+				selectedGroup: 'abcdefghij01234',
+			},
+			'user123'
+		);
+		expect(filter).toContain('name ~ "zelt"');
+		expect(filter).toContain('categories ~ ');
+		expect(filter).toContain("status != 'unavailable'");
+		expect(filter).toContain('isInstitution != true');
+		expect(filter).toContain('userId != "user123"');
+		expect(filter).toContain('groups ~ "abcdefghij01234"');
+		// All clauses are AND-combined.
+		expect(filter).toContain(' && ');
+	});
+
+	it('escapes double quotes in the group id (defense-in-depth)', () => {
+		// The parser already restricts the value to a 15-char id; the builder still escapes.
+		const filter = buildItemFilter({ ...base, selectedGroup: 'ab"cd' });
+		expect(filter).toContain('groups ~ "ab\\"cd"');
+	});
 });
 
 describe('parseSearchParameters', () => {
 	it('parses the query from the q parameter', () => {
 		const params = parseSearchParameters(new URL('https://x.test/search?q=hammer'));
 		expect(params.query).toBe('hammer');
+	});
+
+	it('accepts a well-formed 15-char group id', () => {
+		const params = parseSearchParameters(new URL('https://x.test/search?group=abcdefghij01234'));
+		expect(params.selectedGroup).toBe('abcdefghij01234');
+	});
+
+	it('defaults selectedGroup to null when the param is missing or empty', () => {
+		expect(parseSearchParameters(new URL('https://x.test/search')).selectedGroup).toBeNull();
+		expect(parseSearchParameters(new URL('https://x.test/search?group=')).selectedGroup).toBeNull();
+	});
+
+	it('drops malformed group ids to null (injection, wrong length, quotes, whitespace)', () => {
+		const cases = ['<script>', 'abcdefghij0123456789012345', 'ab"cdefghij0123', '   ', 'short'];
+		for (const bad of cases) {
+			const url = new URL('https://x.test/search');
+			url.searchParams.set('group', bad);
+			expect(parseSearchParameters(url).selectedGroup).toBeNull();
+		}
 	});
 });

--- a/src/routes/search/searchFilter.ts
+++ b/src/routes/search/searchFilter.ts
@@ -9,6 +9,14 @@ export type SearchParameters = {
 	op: 'or' | 'and';
 	onlyAvailable: boolean;
 	ownerType: 'all' | 'institution' | 'private';
+	/**
+	 * Raw, format-plausible group id parsed from the URL (or `null`). This is NOT yet a
+	 * proven-membership id: `parseSearchParameters` stays pure/sync and only shape-checks it.
+	 * The actual authorization — accept the group only if the user is a member — happens in the
+	 * `load` (see `+page.server.ts`), which nulls it out otherwise. Building the filter clause on
+	 * a validated value is therefore the caller's responsibility.
+	 */
+	selectedGroup: string | null;
 };
 
 /**
@@ -64,7 +72,14 @@ export function parseSearchParameters(url: URL): SearchParameters {
 	const ownerType: 'all' | 'institution' | 'private' =
 		ownerTypeParam === 'institution' || ownerTypeParam === 'private' ? ownerTypeParam : 'all';
 
-	return { query, page, perPage, selectedCategories, op, onlyAvailable, ownerType };
+	// Shape-check only: a PocketBase record id is 15 alphanumerics. Garbage is dropped to `null`
+	// here (keeps injection/nonsense out of the load); the real authorization is the membership
+	// check in the load. Not-a-member ids are also dropped there, mirroring how unknown `cats`
+	// values are silently ignored.
+	const groupParam = url.searchParams.get('group')?.trim() ?? '';
+	const selectedGroup = /^[a-z0-9]{15}$/i.test(groupParam) ? groupParam : null;
+
+	return { query, page, perPage, selectedCategories, op, onlyAvailable, ownerType, selectedGroup };
 }
 
 /**
@@ -100,8 +115,19 @@ export function buildItemFilter(params: SearchParameters, userId?: string): stri
 				? `${validateFilterField('isInstitution')} != true`
 				: null;
 
+	// `groups` is deliberately NOT part of `ItemPublic` — the column is never returned to
+	// clients (see the `fields` allowlist in +page.server.ts), so `validateFilterField` can't be
+	// used and we reference it as a string literal. Operator `~` matches the shipped group-detail
+	// page (src/routes/user/groups/[id]/+page.server.ts) filtering the same `items_searchable`
+	// view: PocketBase types the view's `groups` column as a relation, and `~` is the any-of
+	// membership match. `params.selectedGroup` is already membership-validated by the load; the
+	// quote-escape is defense-in-depth (the parser already restricts it to a 15-char id).
+	const groupFilter = params.selectedGroup
+		? `groups ~ "${params.selectedGroup.replace(/"/g, '\\"')}"`
+		: null;
+
 	return (
-		[nameFilter, ownerFilter, categoryFilter, availabilityFilter, institutionFilter]
+		[nameFilter, ownerFilter, categoryFilter, availabilityFilter, institutionFilter, groupFilter]
 			.filter(Boolean)
 			.join(' && ') || undefined
 	);

--- a/src/routes/search/searchUrl.ts
+++ b/src/routes/search/searchUrl.ts
@@ -6,6 +6,7 @@ export interface SearchUrlParams {
 	op?: 'or' | 'and';
 	onlyAvailable?: boolean;
 	ownerType?: string;
+	group?: string;
 	page?: number;
 	perPage?: number;
 }
@@ -19,5 +20,6 @@ export function buildSearchUrl(params: SearchUrlParams): string {
 	if (params.op === 'and') parts.push('op=and');
 	if (params.onlyAvailable === false) parts.push('onlyAvailable=false');
 	if (params.ownerType && params.ownerType !== 'all') parts.push(`ownerType=${params.ownerType}`);
+	if (params.group) parts.push(`group=${encodeURIComponent(params.group)}`);
 	return resolve('/search') + (parts.length ? '?' + parts.join('&') : '');
 }


### PR DESCRIPTION
## What & why

Implements #484 — items can be shared to groups and group members see them in search, but there was no explicit "show only items from group X" filter. This adds a single-select **group filter** to `/search`.

- New `group=<id>` URL param and a `GroupFilter.svelte` dropdown listing the user's own groups (`getAttachableGroups`), styled as a pill matching the category chips / owner-type toggle (custom chevron, highlighted when active).
- **Server-side membership sanitization (the security boundary):** `+page.server.ts` silently drops any `group` id the user is not a member of, so a shared or hand-edited URL cannot probe which of a user's visible items also belong to a *foreign* group. Guests trigger no `getAttachableGroups` call and get no dropdown.
- The `items_searchable` **`fields` allowlist is unchanged** — the `groups` column is never returned to clients (a member must not learn which *other* groups an item is shared to).
- Filter clause is `groups ~ "<id>"`, matching the existing group-detail-page precedent. The group id is format-checked (`/^[a-z0-9]{15}$/i`) and quotes are escaped (defense-in-depth), consistent with the documented manual-filter exception in `buildItemFilter`.
- `group` is threaded through the whole search pipeline (`searchFilter.ts`, `searchUrl.ts`, `+page.svelte`, `CategoryFilter`, `Pagination` incl. the per-page GET form) so it survives pagination and combines with query / categories / availability / owner-type.
- Search logging (`searches`) is unchanged — the group id is deliberately never logged (private social-graph datum).
- `SearchBar` is intentionally left untouched: a new text query resets all filters (including the group), same as today for `cats`/`ownerType`.

## Test notes

- `npm run lint` — pass.
- `npx vitest run` — **556 passed**. Extended `searchFilter.test.ts` (parse shape-check, filter clause, quote-escaping) and new `page.server.test.ts` (member / foreign-id-dropped / guest, allowlist-leak regression, no group id in the search log).
- `npm run check` / `npm run build` fail **only** on the 6 pre-existing `$env/static/private` sync-var errors (`SYNC_SECRET`, `PB_SUPERUSER_*` in the integration files) — unrelated to this diff, present on `main`; CI has those vars set.
- Browser-verified (Chrome DevTools MCP): dropdown only for members; `group=` in URL + filtering works; combines with category chip + "only available"; guests and logged-in non-members get an unfiltered result with no error/leak; no console errors, all app requests 2xx.

Docs: `docs/search-discovery.md` updated (param table + a dedicated security paragraph on the server-side membership validation and why `groups` never reaches the response).

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)
