### PR TITLE
Serve item images as PocketBase thumbnails and fix card loading jank

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -18,7 +18,7 @@ erDiagram
         string city
         bool verified
         bool isInstitution
-        string profileImage
+        string profileImage "thumb whitelist 100x100 (avatar chips)"
         string bio
         string contactMethod "issue #438 — ''|email|link: item CTA becomes a mailto:/external link instead of the in-app flow"
         string contactEmail "dedicated contact address (contactMethod=email) — raw value never in a *_public view"
@@ -103,7 +103,7 @@ erDiagram
     ITEM{
         string id PK
         string name
-        string image "filename(s) in PocketBase Files (multi-select, cover first)"
+        string image "filename(s) in PocketBase Files (multi-select, cover first; thumb whitelist 0x300)"
         string externalImgUrl "for imported items"
         string description
         string place
@@ -470,7 +470,7 @@ conversation access never leaks an item into search/profile/sitemap.
 
 | Field | Source | Notes |
 |---|---|---|
-| id, name, image, externalImgUrl, externalUrl, description, trusteesOnly, status, categories, updated | items | Direct columns (in `items_public` masked to `NULL` for any restricted item — trustees-only **or** group-shared). `image` is a **multi-select** file field → an array of filenames (cover first); serve each via `api/files/items_searchable/{id}/{filename}` |
+| id, name, image, externalImgUrl, externalUrl, description, trusteesOnly, status, categories, updated | items | Direct columns (in `items_public` masked to `NULL` for any restricted item — trustees-only **or** group-shared). `image` is a **multi-select** file field → an array of filenames (cover first); serve each via `api/files/items_searchable/{id}/{filename}`. Thumb whitelist `0x300` (backend `1784402877_image_thumbs.js`) — cards append `?thumb=0x300` for a downscaled variant; `users.profileImage` likewise whitelists `100x100` for avatar chips |
 | userId, username, isInstitution, bio, verified, profileImage, userCreated | users | Joined from owner (no trust data is exposed — trust lives in the separate `trusts` collection) |
 | ownerHasLocation | SQL expression on `user_geolocations` | 1 if the owner has a non-(0,0) location, else 0 |
 | ownerContactMethod, ownerContactEmail, ownerContactUrl | SQL expression on `users` | `items_public` only — the owner's off-platform contact (#438), NULL unless `contactPublic` **and** the item is unmasked; raw contact fields never selected |

--- a/src/lib/utils/utils.test.ts
+++ b/src/lib/utils/utils.test.ts
@@ -63,6 +63,27 @@ describe('itemImageUrl', () => {
 		});
 		expect(url).toBe('https://catalogue.example/cover.jpg');
 	});
+
+	it('appends the thumb param to PocketBase file URLs when requested', () => {
+		const url = itemImageUrl(PB_URL, { id: 'item123', image: 'photo_abc.jpg' }, '0x300');
+		expect(url).toBe(
+			'https://pb.example.com/api/files/items_searchable/item123/photo_abc.jpg?thumb=0x300'
+		);
+	});
+
+	it('omits the thumb param when not requested', () => {
+		const url = itemImageUrl(PB_URL, { id: 'item123', image: 'photo_abc.jpg' });
+		expect(url).not.toContain('thumb');
+	});
+
+	it('never appends the thumb param to the externalImgUrl fallback', () => {
+		const url = itemImageUrl(
+			PB_URL,
+			{ id: 'item123', image: null, externalImgUrl: 'https://catalogue.example/cover.jpg' },
+			'0x300'
+		);
+		expect(url).toBe('https://catalogue.example/cover.jpg');
+	});
 });
 
 describe('itemImageUrls', () => {

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -38,14 +38,21 @@ export function displayName(
  * to everyone and trustees-only items only to authorized viewers. Use this for any item
  * loaded from a public view; base-`items` records (their own `collectionId` already resolves)
  * don't need it.
+ *
+ * `thumb` requests a downscaled variant (e.g. '0x300') from PocketBase. The size must be
+ * whitelisted in the `items.image` field's `thumbs` option (backend migration
+ * `1784402877_image_thumbs.js`), otherwise PocketBase silently serves the original. It is
+ * never appended to the `externalImgUrl` fallback — external hosts don't understand it.
  */
 export function itemImageUrl(
 	pbUrl: string,
-	item: { id: string; image?: string | string[] | null; externalImgUrl?: string | null }
+	item: { id: string; image?: string | string[] | null; externalImgUrl?: string | null },
+	thumb?: string
 ): string | null {
 	const first = Array.isArray(item.image) ? item.image[0] : item.image;
 	if (first) {
-		return `${pbUrl}api/files/items_searchable/${item.id}/${first}`;
+		const url = `${pbUrl}api/files/items_searchable/${item.id}/${first}`;
+		return thumb ? `${url}?thumb=${thumb}` : url;
 	}
 	return item.externalImgUrl || null;
 }

--- a/src/routes/search/ItemCard.svelte
+++ b/src/routes/search/ItemCard.svelte
@@ -20,6 +20,8 @@
 		/** Travel time in minutes. undefined = not yet fetched, null = owner has no location */
 		travelMinutes?: number | null;
 		transportMode?: TransportMode;
+		/** Load the cover image eagerly (for above-the-fold cards). */
+		eager?: boolean;
 	}
 	let {
 		item,
@@ -28,11 +30,24 @@
 		profileView = false,
 		travelMinutes,
 		transportMode = 'bicycle',
+		eager = false,
 	}: Props = $props();
 
 	const isInstitution = $derived(!!item.isInstitution);
 	const hasRealImage = $derived(!!imgUrl);
 	const categoryPlaceholder = $derived(getCategoryPlaceholder(item.categories));
+
+	// The cover image is never hidden — the browser paints it the moment it decodes,
+	// independent of hydration. The category placeholder sits BEHIND it (so a pending
+	// image shows the placeholder, not an empty box) and is removed on load purely as
+	// cleanup, so it can't shine through photos with transparency.
+	let imgEl = $state<HTMLImageElement | null>(null);
+	let imgLoaded = $state(false);
+	$effect(() => {
+		// Covers images that completed before hydration attached the onload listener
+		// (e.g. served from the browser cache).
+		if (imgEl?.complete && imgEl.naturalWidth > 0) imgLoaded = true;
+	});
 </script>
 
 <Card
@@ -44,7 +59,25 @@
 	<!-- Image area always in slot so we can overlay the availability badge -->
 	<div class="relative w-24 max-w-36 shrink-0 self-stretch rounded-s-lg overflow-hidden">
 		{#if hasRealImage}
-			<img src={imgUrl} alt={item.name} loading="lazy" decoding="async" class="w-full h-full max-h-36 object-cover" />
+			{#if !imgLoaded}
+				<div class="absolute inset-0 bg-gray-100 flex items-center justify-center">
+					{#if categoryPlaceholder}
+						<img src={categoryPlaceholder} alt="" class="w-full h-full object-contain p-3 opacity-30" />
+					{/if}
+				</div>
+			{/if}
+			<!-- `relative` stacks the image above the absolutely-positioned placeholder;
+			     `text-transparent` hides the alt-text flash while loading (screen readers
+			     are unaffected — only the glyphs are invisible). -->
+			<img
+				bind:this={imgEl}
+				src={imgUrl}
+				alt={item.name}
+				loading={eager ? 'eager' : 'lazy'}
+				decoding="async"
+				onload={() => (imgLoaded = true)}
+				class="relative w-full h-full max-h-36 object-cover text-transparent"
+			/>
 		{:else}
 			<div class="w-full h-full bg-gray-100 flex items-center justify-center">
 				{#if categoryPlaceholder}

--- a/src/routes/search/ItemCard.svelte
+++ b/src/routes/search/ItemCard.svelte
@@ -44,7 +44,7 @@
 	<!-- Image area always in slot so we can overlay the availability badge -->
 	<div class="relative w-24 max-w-36 shrink-0 self-stretch rounded-s-lg overflow-hidden">
 		{#if hasRealImage}
-			<img src={imgUrl} alt={item.name} class="w-full h-full max-h-36 object-cover" />
+			<img src={imgUrl} alt={item.name} loading="lazy" decoding="async" class="w-full h-full max-h-36 object-cover" />
 		{:else}
 			<div class="w-full h-full bg-gray-100 flex items-center justify-center">
 				{#if categoryPlaceholder}
@@ -96,7 +96,7 @@
 					class="relative inline-flex items-center rounded-full border hover:cursor-pointer pl-1 pr-2 py-0.5 bg-white/90 text-tinte-700 border-tinte-300 hover:bg-tinte-50/90"
 				>
 					{#if ownerImgUrl}
-						<img src={ownerImgUrl} alt="" class="h-6 w-6 rounded-full object-cover" />
+						<img src={ownerImgUrl} alt="" loading="lazy" decoding="async" class="h-6 w-6 rounded-full object-cover" />
 					{:else if isInstitution}
 						<HomeOutline class="h-6 w-6 inline" />
 					{:else}

--- a/src/routes/search/ResultsList.svelte
+++ b/src/routes/search/ResultsList.svelte
@@ -23,9 +23,9 @@
 	{#each filteredItemList as item (item.id)}
 		<ItemCard
 			{item}
-			imgUrl={itemImageUrl(PB_IMG_URL, item) ?? ''}
+			imgUrl={itemImageUrl(PB_IMG_URL, item, '0x300') ?? ''}
 			ownerImgUrl={item.profileImage
-				? `${PB_IMG_URL}api/files/users/${item.userId}/${item.profileImage}`
+				? `${PB_IMG_URL}api/files/users/${item.userId}/${item.profileImage}?thumb=100x100`
 				: undefined}
 			travelMinutes={travelTimes[item.userId]}
 			{transportMode}

--- a/src/routes/search/ResultsList.svelte
+++ b/src/routes/search/ResultsList.svelte
@@ -20,9 +20,10 @@
 </script>
 
 <Gallery class="gap-2 mt-4 grid-cols-1 sm:grid-cols-2">
-	{#each filteredItemList as item (item.id)}
+	{#each filteredItemList as item, i (item.id)}
 		<ItemCard
 			{item}
+			eager={i < 4}
 			imgUrl={itemImageUrl(PB_IMG_URL, item, '0x300') ?? ''}
 			ownerImgUrl={item.profileImage
 				? `${PB_IMG_URL}api/files/users/${item.userId}/${item.profileImage}?thumb=100x100`

--- a/src/routes/users/[id]/ItemsSection.svelte
+++ b/src/routes/users/[id]/ItemsSection.svelte
@@ -128,7 +128,7 @@
 			{#each displayedItems as item (item.id)}
 				<ItemCard
 					item={item as unknown as ItemPublic}
-					imgUrl={itemImageUrl(pbImgUrl, item) ?? ''}
+					imgUrl={itemImageUrl(pbImgUrl, item, '0x300') ?? ''}
 					ownerImgUrl={profileImageUrl ?? undefined}
 					profileView={true}
 				/>


### PR DESCRIPTION
Closes #456

## What & why

Item images on `/search` (and profile item grids) loaded slowly and appeared one-by-one in random order, sometimes with the item title (alt text) flashing in the empty image box. Two changes:

1. **Thumbnails instead of full-size originals.** `itemImageUrl()` now takes an optional `thumb` param; search/profile cards request `?thumb=0x300` for covers (aspect-preserving 300px height — the card's `object-cover` CSS does the single crop) and `?thumb=100x100` for the round owner avatars. This cuts a card image from up to 5 MB to ~17 KB. **Requires the companion backend migration** (share-open-sharing-infrastructure/allerleih-backend PR: `images-load-oddly` branch) — PocketBase only serves a thumb when the size is whitelisted in the file field's `thumbs` option and *silently returns the original otherwise*, so deploy the backend first (frontend-first causes no breakage, just no speedup). The `externalImgUrl` fallback never gets the param (external hosts don't understand it). The item detail gallery intentionally keeps full-quality originals.

2. **Loading-state treatment in `ItemCard`.** While a cover is in flight, the gray/category placeholder shows *behind* it instead of an empty box; the alt-text flash is suppressed with `text-transparent` (glyphs invisible, screen readers unaffected). The `<img>` itself is never opacity-gated on JS state, so each image paints the moment the browser decodes it — independent of hydration (an earlier fade-in approach made all images appear at once only after hydration). The first 4 cards load eagerly, the rest `loading="lazy"` + `decoding="async"`. `onload` (with an `img.complete` check for cache-instant images) removes the backdrop as cleanup so it can't shine through transparent photos.

## Investigation findings (why this started "recently")

This was **not a regression in image handling — thumbnails never existed**; cards always downloaded the full uploaded originals and CSS-scaled them into a ~96×144 px box. It became visible recently because of cache churn, not code that broke:

- PocketBase serves files with `Cache-Control: max-age=2592000` (30 days). For months, images painted instantly from browser disk cache.
- The public-collection restructure (#434) changed **every image URL** (`api/files/<items-collection-id>/…` → `api/files/items_searchable/…`), cold-starting every user's image cache at once. Suddenly images genuinely loaded over the network — as multi-MB originals — making the load process visible: alt-text flash (Firefox renders alt text while an image loads), random completion order (normal parallel-network behavior), and a slow waterfall (up to 5 files/item competing for ~6 connections per host).
- Note for testing: F5 in Firefox revalidates *every* image (one round-trip each, PB answers 304) even with a warm cache, so reloads always show the loading process; Chrome's F5 serves subresources from cache. "It used to be instant" describes normal navigation with a warm cache.
- Serving files through the `items_searchable` view costs ~20–30 ms per request locally (PocketBase executes the view query per file request) vs ~6–9 ms via the base collection — measurable but not the bottleneck at thumb sizes, and **the view route is load-bearing for security**: it's what enforces trust-visibility on the files themselves (serving from base `items` would let anyone with a filename fetch a trustees-only item's photo). Don't "optimize" this away.
- Thumbs are generated lazily on first request and then cached server-side, so the first post-deploy load of each image pays a one-time resize.

## Test notes

- Preflight: `npm run lint`, `npm run check` (0 errors), `npx vitest run` (618 passed), `npm run build` — all green.
- New unit tests for `itemImageUrl` thumb handling (appended for PB files, omitted by default, never on `externalImgUrl`).
- Manually verified in local dev against a seeded PocketBase: `/search` cover requests carry `?thumb=0x300` and return ~17 KB responses served through the `items_searchable` view (confirms the view's cloned field picks up the whitelist after the backend migration); placeholders show during load, cards fill top-first, external-image items unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)