### PR TITLE
docs: document the inactivity-deletion warning (users.deletionWarnedAt)

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -33,6 +33,7 @@ erDiagram
         bool legalLocked "decline lock — set/cleared only by backend hooks"
         date lastLoginAt "stamped on auth (throttled 24h) — drives inactive-account retention; hidden field, superuser-only"
         date retentionNotifiedAt "last open-loan skip-notice (retention job); hidden field, superuser-only"
+        date deletionWarnedAt "last inactivity-deletion warning email (once per inactivity cycle); hidden field, superuser-only"
         date created
         date updated
     }
@@ -376,7 +377,7 @@ Self-service account deletion (GDPR Art. 17) is **two-phase, anonymize-in-place*
 
 **Phase 2 — purge** (partially implemented, issue #461): purging `deleted_accounts` rows and the
 anonymized `users` rows after their dispute-resolution window is still open. **Automated retention
-is implemented** as four nightly cron jobs in the backend (`pb_hooks/retention.pb.js` +
+is implemented** as five nightly cron jobs in the backend (`pb_hooks/retention.pb.js` +
 `pb_hooks/jobs/retention.js`), enforcing the privacy policy (DSE v2.8):
 
 - **Inactive accounts** (6 months without login, keyed on `users.lastLoginAt`, stamped on auth and
@@ -388,6 +389,11 @@ is implemented** as four nightly cron jobs in the backend (`pb_hooks/retention.p
   `messages`, and notifications whose `relatedId` points at it are deleted — regardless of
   `lendingStatus` (product decision in #461).
 - **Notifications** older than 90 days and **feedback** older than 6 months are deleted.
+- **Inactivity warning**: `RETENTION_INACTIVE_WARN_DAYS` (default 30) days before an account
+  reaches the deletion threshold, the user is emailed the concrete deletion date and that logging
+  in prevents it — at most once per inactivity cycle (stamped in `users.deletionWarnedAt`; a login
+  re-arms the warning because the stamp then predates `lastLoginAt`). Accounts with open loans are
+  warned too. The warning runs independently of the deletion job and never delays it.
 
 Windows are configurable per deployment via `RETENTION_*` env vars (0 disables a job); jobs are
 idempotent and log counts only, never personal data.

--- a/src/lib/types/models.ts
+++ b/src/lib/types/models.ts
@@ -172,6 +172,15 @@ export interface User extends PocketBaseEntity {
 	lastLoginAt?: string;
 
 	/**
+	 * ISO datetime the "your account will be deleted on <date>" inactivity warning
+	 * email was last sent (backend retention job; once per inactivity cycle — a stamp
+	 * older than `lastLoginAt` is stale). `hidden: true` on the collection — only
+	 * readable via the superuser context, so it never reaches a client (kept here to
+	 * document the schema).
+	 */
+	deletionWarnedAt?: string;
+
+	/**
 	 * Cache of the latest platform ToS version this user has accepted (Issue #399).
 	 * Authoritative record lives in `user_legal_acceptances`; this mirror lets the
 	 * consent gate decide from the already-loaded auth record without a DB query.


### PR DESCRIPTION
## What & why

Docs/type sync for the backend inactivity-deletion **warning email** (share-open-sharing-infrastructure/allerleih-backend#39): a fifth nightly retention job now emails accounts `RETENTION_INACTIVE_WARN_DAYS` (default 30, `0` = off) before the 6-month inactivity deletion threshold, stating the concrete deletion date and that logging in prevents it. It sends at most once per inactivity cycle via the new hidden `users.deletionWarnedAt` stamp (a login re-arms it), runs independently of the deletion job, and also warns open-loan accounts.

Per issue triage the warning is **email-only**, so there are no frontend behavior changes — this PR only keeps the schema documentation in sync:

- `docs/data-model.md`: `deletionWarnedAt` in the users ERD + the warning job in the retention section (now five jobs)
- `src/lib/types/models.ts`: documented `deletionWarnedAt?` on `User` (hidden/superuser-only, never reaches a client — mirrors the existing `lastLoginAt` note)

## Test notes

- `npm run lint` ✔, `npm run check` ✔ (0 errors, 10 pre-existing warnings), `npx vitest run` ✔ 615/615, `npm run build` ✔
- Docs-only change; nothing to verify manually beyond reading the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)