### PR TITLE
Keep ItemModal category/group selection across in-session edits (#546)

### DIFF
--- a/e2e/tests/item-upload.spec.ts
+++ b/e2e/tests/item-upload.spec.ts
@@ -88,3 +88,55 @@ test.describe('item modal', () => {
 		await expect(page.getByRole('region', { name: 'Foto-Upload-Bereich' })).toBeVisible();
 	});
 });
+
+// Regression for #546: in one SPA session (no reload), a category chosen on an item must
+// survive repeated edit-save cycles. Before the fix the edit modal's category checkbox went
+// stale after the first in-session edit, and the next save persisted categories=[].
+test.describe('item category staleness (#546)', () => {
+	const category = (dialog: Locator) => dialog.getByRole('checkbox', { name: 'Bücher' });
+
+	test('keeps a category checked across repeated edits without a page reload', async ({
+		page,
+	}) => {
+		await page.goto('/user/items');
+
+		// 1. Create an item with a name, description, image AND one category (Bücher).
+		const name = `E2E Kategorie ${Date.now()}`;
+		const addDialog = await openAddModal(page);
+		await addDialog.getByRole('textbox', { name: 'Name:' }).fill(name);
+		await addDialog
+			.getByRole('textbox', { name: 'Beschreibung:' })
+			.fill('Erste Beschreibung');
+		await addDialog.locator('input#itemImage').setInputFiles({
+			name: 'item.png',
+			mimeType: 'image/png',
+			buffer: PNG_1x1,
+		});
+		await category(addDialog).check();
+		await addDialog.getByRole('button', { name: 'Hinzufügen' }).click();
+		await expect(addDialog).toBeHidden();
+
+		// The new row's edit button, targeted via the item's unique name.
+		const row = page.locator('div.border-b', { has: page.getByRole('link', { name }) });
+		const editBtn = row.getByRole('button', { name: 'Bearbeiten' });
+
+		// 2. Open the edit modal — the category reflects the persisted state (checked).
+		let dialog = await openModalVia(page, editBtn);
+		await expect(category(dialog)).toBeChecked();
+
+		// 3. Change ONLY the description, then save.
+		await dialog.getByRole('textbox', { name: 'Beschreibung:' }).fill('Zweite Beschreibung');
+		await dialog.getByRole('button', { name: 'Speichern' }).click();
+		await expect(dialog).toBeHidden();
+
+		// 4. Reopen — the category must STILL be checked (the core #546 assertion), then save.
+		dialog = await openModalVia(page, editBtn);
+		await expect(category(dialog)).toBeChecked();
+		await dialog.getByRole('button', { name: 'Speichern' }).click();
+		await expect(dialog).toBeHidden();
+
+		// 5. Reopen once more — still checked (guards the "saved empty once, stays empty" state).
+		dialog = await openModalVia(page, editBtn);
+		await expect(category(dialog)).toBeChecked();
+	});
+});

--- a/src/routes/user/items/ItemModal.svelte
+++ b/src/routes/user/items/ItemModal.svelte
@@ -46,7 +46,7 @@
 		form
 	}: Props = $props();
 
-	let isAvailable = $derived(editingItem?.status === 'available' ? true : false);
+	let isAvailable = $state(true);
 
 	let selectedCategories = $state<string[]>([]);
 	let selectedGroups = $state<string[]>([]);
@@ -85,6 +85,7 @@
 			selectedCategories = [...(editingItem?.categories ?? [])];
 			selectedGroups = [...(editingItem?.groups ?? [])];
 			trusteesOn = editingItem?.trusteesOnly ?? true;
+			isAvailable = editingItem?.status === 'available';
 			isDirty = false;
 			imageError = null;
 			// Seed the existing-image gallery so editing an item with several photos shows
@@ -93,12 +94,6 @@
 				pbUrl && editingItem?.image?.length ? itemOwnFileUrls(pbUrl, editingItem) : [];
 		}
 	});
-
-	function toggleGroup(id: string, checked: boolean) {
-		selectedGroups = checked
-			? [...selectedGroups, id]
-			: selectedGroups.filter((g) => g !== id);
-	}
 
 	// Trustees and groups are independent audiences; an item is public only when
 	// neither is set.
@@ -109,19 +104,6 @@
 	let anyPublicGroupSelected = $derived(
 		groups.some((g) => g.isPublic && selectedGroups.includes(g.id))
 	);
-
-	function handleCategoryChange(e: Event) {
-		const cb = e.target as HTMLInputElement;
-		if (cb.checked) {
-			if (selectedCategories.length >= 3) {
-				cb.checked = false;
-				return;
-			}
-			selectedCategories = [...selectedCategories, cb.value];
-		} else {
-			selectedCategories = selectedCategories.filter((c) => c !== cb.value);
-		}
-	}
 
 	// Keep in sync with the `items.image` file field's maxSelect in the backend
 	// migration (1783500000_items_image_multi.js). Exceeding it makes PocketBase reject
@@ -342,9 +324,8 @@
 							<Checkbox
 								name="categories"
 								value={cat}
-								checked={selectedCategories.includes(cat)}
+								bind:group={selectedCategories}
 								disabled={selectedCategories.length >= 3 && !selectedCategories.includes(cat)}
-								onchange={handleCategoryChange}
 							/>
 							{cat}
 						</Label>
@@ -398,8 +379,7 @@
 								<Checkbox
 									name="groups"
 									value={g.id}
-									checked={selectedGroups.includes(g.id)}
-									onchange={(e) => toggleGroup(g.id, (e.target as HTMLInputElement).checked)}
+									bind:group={selectedGroups}
 								/>
 								{g.name}
 								{#if g.isPublic}


### PR DESCRIPTION
## What & why

In a single SPA session (no page reload), repeatedly editing an item through the edit modal
(`ItemModal.svelte`) silently dropped its **categories**: on reopen the previously-set category
checkboxes rendered unchecked, and the next save persisted `categories=[]`.

**Root cause.** The category/group checkboxes passed a one-way `checked` prop into Flowbite's
`Checkbox`, whose `checked` is `$bindable` and which runs internal `group`↔`checked` sync
effects. With no `group` bound, `group` defaults to `[]` but `Array.isArray(group)` is still
true, so on every (re)mount Flowbite's effect hard-sets `checked = group.includes(value)` →
`false`. Because the modal's per-open seeding writes a *value-equal* array, the prop expression
doesn't change, so it never re-asserts against Flowbite's `false` write — the checkbox stays
unchecked. Since submission reads the native DOM checkboxes, the next save writes `categories=[]`
("lost once, stays empty"). The DOM is remounted on each open (Flowbite `Dialog` is under
`{#if open}`), which is why a fresh page load worked but in-session re-edits didn't.

## Fix (client-only — no server/schema/text changes)

- **Categories & groups** → bind the checkboxes with `bind:group={selectedCategories}` /
  `bind:group={selectedGroups}`, making the `$state` array the single source of truth (Flowbite's
  internal effect becomes the correct derivation path instead of fighting the prop). The manual
  `handleCategoryChange` / `toggleGroup` handlers are removed; the existing `disabled` predicate
  still enforces the 3-category cap in both directions.
- **Two co-fixed neighbouring spots:**
  - *Group checkboxes* had the identical anti-pattern (same latent bug class) — migrated too.
  - *`isAvailable`* was a writable `$derived`; a toggled-then-discarded value stuck across opens.
    It is now `$state`, seeded per open in the visibility `$effect`, so every per-open state is
    initialised in one place.

## Test notes

Preflight: `npm run lint` ✅, `npx vitest run` ✅ (636 passed). `npm run check` / `npm run build`
fail **only** on the 6 pre-existing `$env/static/private` missing-export errors (`SYNC_SECRET`,
`PB_SUPERUSER_EMAIL`, `PB_SUPERUSER_PASSWORD`) from the local `.env` — unrelated to this diff;
CI has those vars.

- **E2E regression** added to the existing `e2e/tests/item-upload.spec.ts` (PR #533 already
  merged, so no new spec file) as an `item category staleness (#546)` describe block: create an
  item with a category → edit (checked) → change only the description → save → reopen (still
  checked) → save → reopen (still checked). `npm run test:e2e -- item-upload` → 13/13 green.
- **Manual/browser smoke** green: save now sends `categories=Bücher,Spiele,Küche` (non-empty),
  3-cap enforces + releases correctly, groups survive the same cycles, no console errors.

## Coordination

Plan #489 (replace `confirm()` dialogs) also touches `ItemModal.svelte` (the modal `oncancel`,
a different region than this checkbox/handler diff) — whoever merges second rebases.

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)
