### PR TITLE
fix(auth): normalize email to lowercase at all user boundaries (#557)

### DIFF
--- a/e2e/tests/email-case-insensitive.spec.ts
+++ b/e2e/tests/email-case-insensitive.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect, type Page } from '@playwright/test';
+import { SEED_PASSWORD } from '../fixtures/users';
+
+/**
+ * Case-insensitive email — regression guard for #557.
+ *
+ * PocketBase matched `users.email` case-sensitively and did not normalize on save,
+ * so an account registered with a mixed-case address (`Julika7@…`) became
+ * unreachable by the lowercase login/reset the user later typed. The frontend now
+ * normalizes (trim + lowercase) at every email boundary. These tests register with
+ * a deliberately mixed-case address and prove the lowercase variant reaches the
+ * same account.
+ *
+ * Runs logged-out in the `public` project. Each test registers its own fresh,
+ * unique account, so it never touches the seeded fixtures and is parallel-safe.
+ * No SMTP dependency: the reset guard only asserts the action redirects cleanly
+ * (the silent 204 / anti-enumeration behaviour is intentional and unasserted).
+ */
+
+type FreshUser = {
+	/** As typed at registration — deliberately mixed-case (the #557 repro). */
+	emailMixed: string;
+	/** What the user types later, on a different device: the lowercase variant. */
+	emailLower: string;
+	username: string;
+	password: string;
+};
+
+/**
+ * Register a brand-new account through the real form with a mixed-case email.
+ * Leaves the page authenticated (redirected off the register form). Reuses the
+ * same role/label selectors as auth.spec.ts; the newsletter opt-in is unchecked
+ * so registration makes no external (Keila) call.
+ */
+async function registerFreshUser(page: Page): Promise<FreshUser> {
+	const unique = `${Date.now()}${Math.floor(Math.random() * 1_000_000)}`;
+	const emailMixed = `Julika7.${unique}@Example.COM`;
+	const user: FreshUser = {
+		emailMixed,
+		emailLower: emailMixed.toLowerCase(),
+		username: `e2e557u${unique}`,
+		password: SEED_PASSWORD,
+	};
+
+	await page.goto('/auth/register');
+	// Register has two textboxes whose accessible names both contain "E-Mail" (the
+	// username field's hint text mentions logging in with the E-Mail address), so the
+	// role-name match is ambiguous here. Target the input by its stable `name`
+	// attribute instead. (Login/reset each have a single email field, so those stay
+	// on the role selector shared with auth.spec.ts.)
+	await page.locator('input[name="email"]').fill(user.emailMixed);
+	await page.getByRole('textbox', { name: 'Nutzername' }).fill(user.username);
+	await page.getByRole('textbox', { name: 'Passwort' }).fill(user.password);
+	await page.getByRole('checkbox', { name: /stimme beiden zu/ }).check();
+	await page.getByRole('checkbox', { name: /Newsletter erhalten/ }).uncheck();
+	await page.getByRole('button', { name: 'Registrieren' }).click();
+
+	// The register action redirects to /onboarding only on success (a failed create
+	// returns a fail() and stays on /auth/register), so this URL is the precise
+	// "registered + session started" signal. Note: the layout hides the NavBar on
+	// /onboarding, which is why logout() below first navigates to a nav-bearing route.
+	await expect(page).toHaveURL(/\/onboarding/);
+
+	return user;
+}
+
+/**
+ * Drop the session by clearing the browser context's cookies — the deterministic,
+ * idiomatic way to reach a fresh unauthenticated session. This sidesteps the nav's
+ * logout UI entirely (Flowbite dropdown hydration is unrelated to #557 and flaky in
+ * this harness). The auth token is a normal `pb_auth` HTTP cookie in this same context,
+ * so `context.clearCookies()` (no filter → all cookies) removes it.
+ *
+ * #557 is about a fresh session logging in with the lowercase variant — not about the
+ * logout UI — so a cookie-cleared session is the semantically correct precondition.
+ */
+async function logout(page: Page): Promise<void> {
+	await page.context().clearCookies();
+	// Confirm the session is gone: /auth/login renders its form only when
+	// unauthenticated (it redirects to '/' otherwise).
+	await page.goto('/auth/login');
+	await expect(page.getByRole('textbox', { name: 'E-Mail' })).toBeVisible();
+}
+
+test.describe('email case-insensitivity (#557)', () => {
+	// The nav collapses to a hamburger below Tailwind's xl (1280px); pin a comfortably
+	// wide viewport so the profile dropdown trigger is always directly clickable.
+	test.use({ viewport: { width: 1440, height: 900 } });
+
+	test('login with the lowercase variant of a mixed-case registration succeeds', async ({
+		page,
+	}) => {
+		const user = await registerFreshUser(page);
+		await logout(page);
+
+		// The core #557 repro: typed lowercase, account stored via a mixed-case form.
+		await page.getByRole('textbox', { name: 'E-Mail' }).fill(user.emailLower);
+		await page.getByRole('textbox', { name: 'Passwort' }).fill(user.password);
+		await page.getByRole('button', { name: 'Anmelden' }).click();
+
+		// Login redirected off the form...
+		await expect(page).not.toHaveURL(/\/auth\/login/);
+		// ...and the session is authenticated: on a nav-bearing route the profile
+		// dropdown trigger (this run's username) renders only when logged in, while the
+		// logged-out "Login" link is absent. Explicit goto('/') keeps this independent
+		// of the login landing route. This is the #557 core assertion: the LOWERCASE
+		// variant of the mixed-case registration authenticates.
+		await page.goto('/');
+		await expect(page.locator('button', { hasText: user.username })).toBeVisible();
+		await expect(page.getByRole('link', { name: 'Login' })).toHaveCount(0);
+	});
+
+	test('password reset with the lowercase variant redirects cleanly', async ({ page }) => {
+		const user = await registerFreshUser(page);
+		await logout(page);
+
+		await page.goto('/auth/reset');
+		await page.getByRole('textbox', { name: 'E-Mail' }).fill(user.emailLower);
+		await page.getByRole('button', { name: 'Setze mein Passwort zurück!' }).click();
+
+		// The reset action found the account and redirected to login (no 500 error
+		// alert). We do NOT assert mail delivery — the silent 204 is intentional.
+		await expect(page).toHaveURL(/\/auth\/login/);
+	});
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
 			testMatch: [
 				'tests/smoke.spec.ts',
 				'tests/auth.spec.ts',
+				'tests/email-case-insensitive.spec.ts',
 				'tests/misc.spec.ts',
 				'tests/search-focus.spec.ts',
 				'tests/search-focus.mobile.spec.ts',

--- a/src/lib/server/email.test.ts
+++ b/src/lib/server/email.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeEmail } from './email';
+
+describe('normalizeEmail', () => {
+	it('lowercases a mixed-case address (the #557 root cause)', () => {
+		expect(normalizeEmail('Julika7@ich-will-net.de')).toBe('julika7@ich-will-net.de');
+	});
+
+	it('trims surrounding whitespace', () => {
+		expect(normalizeEmail('  julika7@x.de  ')).toBe('julika7@x.de');
+	});
+
+	it('trims and lowercases together', () => {
+		expect(normalizeEmail(' Julika7@X.de\n')).toBe('julika7@x.de');
+	});
+
+	it('leaves an already-normalized address unchanged', () => {
+		expect(normalizeEmail('julika7@x.de')).toBe('julika7@x.de');
+	});
+
+	it('handles an empty string', () => {
+		expect(normalizeEmail('')).toBe('');
+	});
+});

--- a/src/lib/server/email.ts
+++ b/src/lib/server/email.ts
@@ -1,0 +1,18 @@
+/**
+ * Normalize a user-typed email before it goes to PocketBase (or any email lookup).
+ *
+ * PocketBase matches `users.email` case-sensitively and does NOT normalize on
+ * save (issue #557): a mixed-case registration such as `Julika7@…` becomes an
+ * account that a later lowercase login or password-reset lookup can never reach.
+ * Trimming + lowercasing at every user-email boundary keeps the stored form and
+ * every subsequent lookup in the same case. Use this at every place where a
+ * user-typed email reaches PocketBase (register, login, reset, email change).
+ */
+export function normalizeEmail(email: string): string {
+	// Assumption: ASCII local-parts. For IDN/Unicode local-parts with
+	// locale-sensitive casing, V8 (this frontend) and PocketBase's goja runtime
+	// (backend hook `pb_hooks/utils/email.js`) could in theory diverge on
+	// `toLowerCase()`. The two sides MUST apply the same normalization for the
+	// lookup to match — keep this in sync with the backend helper.
+	return email.trim().toLowerCase();
+}

--- a/src/lib/server/registration.test.ts
+++ b/src/lib/server/registration.test.ts
@@ -99,6 +99,15 @@ describe('validateRegistrationForm', () => {
 		expect(result.inviteCode).toBe('abc123');
 	});
 
+	it('normalizes a mixed-case/whitespace email to lowercase (#557)', () => {
+		const result = validateRegistrationForm(
+			makeFormData({ ...validFormFields, email: '  Julika7@Example.com ' })
+		);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.email).toBe('julika7@example.com');
+	});
+
 	it('trims whitespace from username', () => {
 		const result = validateRegistrationForm(
 			makeFormData({ ...validFormFields, username: '  alice  ' })

--- a/src/lib/server/registration.ts
+++ b/src/lib/server/registration.ts
@@ -5,6 +5,7 @@ import type { User } from '$lib/types/models';
 import { createNotification, sendPushToUser } from '$lib/server/notifications';
 import { addTrust } from '$lib/server/trust';
 import { normalizeUsername, validateUsername } from '$lib/utils/username';
+import { normalizeEmail } from '$lib/server/email';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -59,7 +60,9 @@ export function validateRegistrationForm(data: FormData): ValidationResult {
 
 	return {
 		ok: true,
-		email: email.toString(),
+		// Normalize here so the created record, the immediate authWithPassword,
+		// verification mail, and newsletter signup all inherit the same form (#557).
+		email: normalizeEmail(email.toString()),
 		password: password.toString(),
 		username,
 		subscribeToNewsletter: data.get('subscribeToNewsletter') === 'on',

--- a/src/routes/auth/login/+page.server.ts
+++ b/src/routes/auth/login/+page.server.ts
@@ -1,6 +1,7 @@
 import { error, fail, redirect } from '@sveltejs/kit';
 import type { ClientResponseError } from 'pocketbase';
 import { texts } from '$lib/texts';
+import { normalizeEmail } from '$lib/server/email';
 
 export async function load({ locals, url }) {
 	if (locals.user) {
@@ -28,7 +29,7 @@ export const actions = {
 		try {
 			await locals.pb
 				.collection('users')
-				.authWithPassword(email.toString(), password.toString()); // TODO: Is this encrypted / does it need to be?
+				.authWithPassword(normalizeEmail(email.toString()), password.toString()); // TODO: Is this encrypted / does it need to be?
 		} catch (err) {
 			// if error is "failed to authenticate", display error message
 			console.error('Failed to login', err);

--- a/src/routes/auth/login/+page.svelte
+++ b/src/routes/auth/login/+page.svelte
@@ -43,6 +43,9 @@
 						placeholder={texts.auth.emailPlaceholder}
 						class="focus:border-primary-700 focus:ring-primary-700"
 						autocomplete="email"
+						autocapitalize="none"
+						autocorrect="off"
+						spellcheck="false"
 						required
 					/>
 					<p class="text-sm text-tinte-500 dark:text-tinte-400">{texts.auth.loginWithEmailHint}</p>

--- a/src/routes/auth/login/page.server.test.ts
+++ b/src/routes/auth/login/page.server.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { isRedirect } from '@sveltejs/kit';
+import { actions } from './+page.server';
+
+type ActionEvent = Parameters<typeof actions.login>[0];
+
+describe('Login page action', () => {
+	let authWithPassword: ReturnType<typeof vi.fn>;
+	let mockLocals: { pb: { collection: ReturnType<typeof vi.fn> } };
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		authWithPassword = vi.fn().mockResolvedValue({});
+		mockLocals = {
+			pb: { collection: vi.fn(() => ({ authWithPassword })) },
+		};
+	});
+
+	function buildRequest(fields: Record<string, string>) {
+		const data = new FormData();
+		for (const [key, value] of Object.entries(fields)) data.append(key, value);
+		return { formData: vi.fn().mockResolvedValue(data) };
+	}
+
+	function callLogin(request: ReturnType<typeof buildRequest>) {
+		return actions.login({ locals: mockLocals, request } as unknown as ActionEvent);
+	}
+
+	it('normalizes a mixed-case/whitespace email before authenticating (#557)', async () => {
+		const request = buildRequest({ email: '  Julika7@Example.com ', password: 'password123' });
+
+		try {
+			await callLogin(request);
+			expect.unreachable('expected redirect to be thrown');
+		} catch (error) {
+			if (!isRedirect(error)) throw error;
+			expect(error.status).toBe(303);
+		}
+
+		expect(authWithPassword).toHaveBeenCalledWith('julika7@example.com', 'password123');
+	});
+
+	it('fails with 400 when email is missing', async () => {
+		const result = await callLogin(buildRequest({ password: 'password123' }));
+		expect(result?.status).toBe(400);
+		expect(authWithPassword).not.toHaveBeenCalled();
+	});
+});

--- a/src/routes/auth/register/+page.svelte
+++ b/src/routes/auth/register/+page.svelte
@@ -91,6 +91,9 @@
 						placeholder={texts.auth.emailPlaceholder}
 						class="focus:border-primary-700 focus:ring-primary-700"
 						autocomplete="email"
+						autocapitalize="none"
+						autocorrect="off"
+						spellcheck="false"
 						required
 					/>
 				</Label>

--- a/src/routes/auth/reset/+page.server.ts
+++ b/src/routes/auth/reset/+page.server.ts
@@ -1,6 +1,7 @@
 import { fail, redirect } from '@sveltejs/kit';
 import type { ClientResponseError } from 'pocketbase';
 import { texts } from '$lib/texts';
+import { normalizeEmail } from '$lib/server/email';
 
 export async function load({ locals }) {
 	if (locals.user) {
@@ -22,7 +23,7 @@ export const actions = {
 		try {
 			await locals.pb
 				.collection('users')
-				.requestPasswordReset(email.toString());
+				.requestPasswordReset(normalizeEmail(email.toString()));
 		} catch (error) {
 			const errorObj = error as ClientResponseError;
 			return fail(500, {

--- a/src/routes/auth/reset/+page.svelte
+++ b/src/routes/auth/reset/+page.svelte
@@ -3,11 +3,12 @@
 	import { Section, Register } from 'flowbite-svelte-blocks';
 	import { Label, Input } from 'flowbite-svelte';
 	import Button from '$lib/components/ui/Button.svelte';
-	export let form: ActionData;
 	import { resolve } from '$app/paths';
 	import { texts } from '$lib/texts';
 	import CustomAlert from '$lib/components/CustomAlert.svelte';
 	import SeoHead from '$lib/components/SeoHead.svelte';
+
+	let { form }: { form: ActionData } = $props();
 </script>
 
 <SeoHead
@@ -36,6 +37,9 @@
 						name="email"
 						placeholder={texts.forms.email}
 						class="focus:border-primary-700 focus:ring-primary-700"
+						autocapitalize="none"
+						autocorrect="off"
+						spellcheck="false"
 						required
 					/>
 				</Label>

--- a/src/routes/auth/reset/page.server.test.ts
+++ b/src/routes/auth/reset/page.server.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { isRedirect } from '@sveltejs/kit';
+import { actions } from './+page.server';
+
+type ActionEvent = Parameters<typeof actions.reset>[0];
+
+describe('Password reset page action', () => {
+	let requestPasswordReset: ReturnType<typeof vi.fn>;
+	let mockLocals: { pb: { collection: ReturnType<typeof vi.fn> } };
+	let mockCookies: { set: ReturnType<typeof vi.fn> };
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		requestPasswordReset = vi.fn().mockResolvedValue(undefined);
+		mockLocals = {
+			pb: { collection: vi.fn(() => ({ requestPasswordReset })) },
+		};
+		mockCookies = { set: vi.fn() };
+	});
+
+	function buildRequest(fields: Record<string, string>) {
+		const data = new FormData();
+		for (const [key, value] of Object.entries(fields)) data.append(key, value);
+		return { formData: vi.fn().mockResolvedValue(data) };
+	}
+
+	function callReset(request: ReturnType<typeof buildRequest>) {
+		return actions.reset({
+			locals: mockLocals,
+			request,
+			cookies: mockCookies,
+		} as unknown as ActionEvent);
+	}
+
+	it('normalizes a mixed-case/whitespace email before the reset lookup (#557)', async () => {
+		const request = buildRequest({ email: '  Julika7@Example.com ' });
+
+		try {
+			await callReset(request);
+			expect.unreachable('expected redirect to be thrown');
+		} catch (error) {
+			if (!isRedirect(error)) throw error;
+			expect(error.status).toBe(303);
+			expect(error.location).toBe('/auth/login');
+		}
+
+		expect(requestPasswordReset).toHaveBeenCalledWith('julika7@example.com');
+	});
+
+	it('fails with 400 when email is missing', async () => {
+		const result = await callReset(buildRequest({}));
+		expect(result?.status).toBe(400);
+		expect(requestPasswordReset).not.toHaveBeenCalled();
+	});
+});

--- a/src/routes/misc/newsletter/+page.server.ts
+++ b/src/routes/misc/newsletter/+page.server.ts
@@ -1,5 +1,6 @@
 import { redirect } from '@sveltejs/kit';
 import type { Actions } from './$types';
+import { normalizeEmail } from '$lib/server/email';
 
 export const actions: Actions = {
 	subscribe: async ({ request }) => {
@@ -9,7 +10,7 @@ export const actions: Actions = {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
 			body: new URLSearchParams({
-				'contact[email]': (data.get('contact[email]') as string) ?? '',
+				'contact[email]': normalizeEmail((data.get('contact[email]') as string) ?? ''),
 				'contact[first_name]': (data.get('contact[first_name]') as string) ?? '',
 				'h[url]': '',
 			}),

--- a/src/routes/misc/newsletter/+page.svelte
+++ b/src/routes/misc/newsletter/+page.svelte
@@ -41,6 +41,9 @@
 					type="email"
 					placeholder="deine@mail.de"
 					class="focus:border-primary-700 focus:ring-primary-700"
+					autocapitalize="none"
+					autocorrect="off"
+					spellcheck="false"
 					required
 				/>
 			</div>

--- a/src/routes/misc/newsletter/page.server.test.ts
+++ b/src/routes/misc/newsletter/page.server.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { isRedirect } from '@sveltejs/kit';
+import { actions } from './+page.server';
+
+type ActionEvent = Parameters<NonNullable<typeof actions.subscribe>>[0];
+
+describe('Newsletter subscribe action', () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchMock = vi.fn().mockResolvedValue({ ok: true });
+		vi.stubGlobal('fetch', fetchMock);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	function buildRequest(fields: Record<string, string>) {
+		const data = new FormData();
+		for (const [key, value] of Object.entries(fields)) data.append(key, value);
+		return { formData: vi.fn().mockResolvedValue(data) };
+	}
+
+	function callSubscribe(request: ReturnType<typeof buildRequest>) {
+		return actions.subscribe!({ request } as unknown as ActionEvent);
+	}
+
+	it('normalizes a mixed-case/whitespace email before sending it to Keila (#557)', async () => {
+		const request = buildRequest({
+			'contact[email]': '  Julika7@Example.com ',
+			'contact[first_name]': 'Julika',
+		});
+
+		try {
+			await callSubscribe(request);
+			expect.unreachable('expected redirect to be thrown');
+		} catch (error) {
+			if (!isRedirect(error)) throw error;
+			expect(error.status).toBe(303);
+		}
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const body = fetchMock.mock.calls[0][1].body as URLSearchParams;
+		expect(body.get('contact[email]')).toBe('julika7@example.com');
+	});
+});

--- a/src/routes/user/profile/updatemail/+page.server.ts
+++ b/src/routes/user/profile/updatemail/+page.server.ts
@@ -1,5 +1,6 @@
 import { fail } from '@sveltejs/kit';
 import type { ClientResponseError } from 'pocketbase';
+import { normalizeEmail } from '$lib/server/email';
 
 export const actions = {
 	updatemail: async ({ locals, request }) => {
@@ -10,12 +11,16 @@ export const actions = {
 			return fail(400, { emailRequired: email === null });
 		}
 
+		// Normalize before it reaches PocketBase so the stored email stays lowercase
+		// and a later login/reset lookup matches (#557).
+		const normalizedEmail = normalizeEmail(email.toString());
+
 		try {
-			await locals.pb.collection('users').requestEmailChange(email.toString());
+			await locals.pb.collection('users').requestEmailChange(normalizedEmail);
 
 			return {
 				success: true,
-				message: `Eine Bestätigungs-E-Mail wurde an deine neue Adresse ${email} gesendet. Bitte überprüfe deinen Posteingang.`,
+				message: `Eine Bestätigungs-E-Mail wurde an deine neue Adresse ${normalizedEmail} gesendet. Bitte überprüfe deinen Posteingang.`,
 			};
 		} catch (error) {
 			console.error(error);

--- a/src/routes/user/profile/updatemail/+page.svelte
+++ b/src/routes/user/profile/updatemail/+page.svelte
@@ -34,6 +34,9 @@
 						bind:value={newEmail}
 						placeholder={texts.forms.email}
 						class="focus:border-primary-700 focus:ring-primary-700"
+						autocapitalize="none"
+						autocorrect="off"
+						spellcheck="false"
 						required
 					/>
 				</Label>

--- a/src/routes/user/profile/updatemail/page.server.test.ts
+++ b/src/routes/user/profile/updatemail/page.server.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { actions } from './+page.server';
+
+type ActionEvent = Parameters<typeof actions.updatemail>[0];
+
+describe('Update-email page action', () => {
+	let requestEmailChange: ReturnType<typeof vi.fn>;
+	let mockLocals: { pb: { collection: ReturnType<typeof vi.fn> } };
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		requestEmailChange = vi.fn().mockResolvedValue(undefined);
+		mockLocals = {
+			pb: { collection: vi.fn(() => ({ requestEmailChange })) },
+		};
+	});
+
+	function buildRequest(fields: Record<string, string>) {
+		const data = new FormData();
+		for (const [key, value] of Object.entries(fields)) data.append(key, value);
+		return { formData: vi.fn().mockResolvedValue(data) };
+	}
+
+	function callUpdate(request: ReturnType<typeof buildRequest>) {
+		return actions.updatemail({ locals: mockLocals, request } as unknown as ActionEvent);
+	}
+
+	it('normalizes a mixed-case/whitespace email before requesting the change (#557)', async () => {
+		const result = await callUpdate(buildRequest({ newEmail: '  Julika7@Example.com ' }));
+
+		expect(requestEmailChange).toHaveBeenCalledWith('julika7@example.com');
+		expect(result).toMatchObject({ success: true });
+		// The confirmation message reflects the normalized address.
+		expect((result as { message: string }).message).toContain('julika7@example.com');
+		expect((result as { message: string }).message).not.toContain('Julika7');
+	});
+
+	it('fails with 400 when newEmail is missing', async () => {
+		const result = await callUpdate(buildRequest({}));
+		expect((result as { status?: number })?.status).toBe(400);
+		expect(requestEmailChange).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Problem

A user reported that password reset produced no email (#557). Root cause (proven in prod
logs + record + local repro): **PocketBase matches emails case-sensitively and does not
normalize on save.** The user registered with a mixed-case address (e.g. `Julika7@…`, likely
from mobile auto-capitalization) but typed it lower-case on login/reset. The result:

- Login fails on every device (case mismatch).
- Password reset hits PocketBase's anti-enumeration path and **silently no-ops** (HTTP 204,
  no mail) — so it looks like "the mail never arrives".

The frontend previously normalized email **nowhere**, so any mixed-case registration creates a
permanently unreachable account.

## Change

Normalize (trim + lowercase) the entered email **before it reaches PocketBase** at every user
boundary, via a single shared `normalizeEmail()` helper (`$lib/server/email.ts`):

- Registration (`validateRegistrationForm` — inherited by create/verify/newsletter payloads)
- Login (`authWithPassword`)
- Password reset request (`requestPasswordReset`)
- Email change (`requestEmailChange`)
- Newsletter signup (Keila)

Plus UX hardening (`autocapitalize="none" autocorrect="off" spellcheck="false"`) on the email
inputs, since `type="email"` alone does not stop auto-capitalization on all mobile keyboards.

The reset flow keeps its **intentional anti-enumeration behaviour** (silent success flash) —
this PR only makes the typed address actually match a stored account.

## Not changed (intentional)

- The reset silent-204 / success flash (anti-enumeration by design).
- Reset email template / SMTP config (both correct — SMTP was never the cause).

## Companion backend PR

A separate backend mini-PR (`allerleih-backend`) adds defense-in-depth: a `users`
create/update hook that normalizes on every write path, plus a backfill migration
(collision-aware) that heals existing mixed-case rows:
share-open-sharing-infrastructure/allerleih-backend#43

## Test notes

- `npm run lint` — clean.
- `npx vitest run` — **649/649 green** (helper unit tests + per-boundary normalization tests).
- New e2e spec `e2e/tests/email-case-insensitive.spec.ts` — **green, stable over repeated runs**:
  registers with a mixed-case email, then logs in / requests reset with the lower-case variant
  and asserts it succeeds (the exact #557 repro).
- `npm run check` / `npm run build` fail locally only on the pre-existing `$env/static/private`
  gap (`SYNC_SECRET`, `PB_SUPERUSER_*`) — unrelated to this diff; CI provides those vars.

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)
