### PR TITLE
Render line breaks and safe clickable links in item descriptions

### DIFF
--- a/e2e/tests/item-upload.spec.ts
+++ b/e2e/tests/item-upload.spec.ts
@@ -140,3 +140,46 @@ test.describe('item category staleness (#546)', () => {
 		await expect(category(dialog)).toBeChecked();
 	});
 });
+
+// Regression for #395 + #455: the item description keeps its line breaks (rendered via a
+// `whitespace-pre-line` wrapper) and http(s) URLs are turned into safe, clickable links
+// (target=_blank + noopener/noreferrer/nofollow) on the public detail page.
+test.describe('item description line breaks & links (#395 #455)', () => {
+	test('renders newlines as pre-line and linkifies a URL on the detail page', async ({ page }) => {
+		await page.goto('/user/items');
+		const dialog = await openAddModal(page);
+
+		const name = `E2E Beschreibung ${Date.now()}`;
+		const url = 'https://example.com/anleitung';
+		await dialog.getByRole('textbox', { name: 'Name:' }).fill(name);
+		await dialog
+			.getByRole('textbox', { name: 'Beschreibung:' })
+			.fill(`Zeile eins\nZeile zwei\nMehr unter ${url}`);
+		await dialog.locator('input#itemImage').setInputFiles({
+			name: 'item.png',
+			mimeType: 'image/png',
+			buffer: PNG_1x1,
+		});
+		await dialog.getByRole('button', { name: 'Hinzufügen' }).click();
+
+		// Modal closes; open the new item's detail page from its list row.
+		await expect(dialog).toBeHidden();
+		const row = page.getByRole('link', { name });
+		await expect(row).toBeVisible();
+		await row.click();
+		await expect(page).toHaveURL(/\/items\/[^/]+$/);
+
+		// The URL became a clickable link with the exact href and safe target/rel.
+		const link = page.getByRole('link', { name: url });
+		await expect(link).toBeVisible();
+		await expect(link).toHaveAttribute('href', url);
+		await expect(link).toHaveAttribute('target', '_blank');
+		await expect(link).toHaveAttribute('rel', /noopener/);
+		await expect(link).toHaveAttribute('rel', /noreferrer/);
+		await expect(link).toHaveAttribute('rel', /nofollow/);
+
+		// The wrapping <p> preserves the entered line breaks (CSS, not stored markup).
+		const description = page.locator('p', { has: link });
+		await expect(description).toHaveCSS('white-space', 'pre-line');
+	});
+});

--- a/src/lib/components/LinkifiedText.svelte
+++ b/src/lib/components/LinkifiedText.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { linkifySegments } from '$lib/utils/linkify';
+
+	// Plain-text description rendered with clickable http(s) links. Storage stays plain text;
+	// this only linkifies at render time. No {@html}: text segments are escaped, and link hrefs
+	// are attribute-bound (also escaped by Svelte) — see $lib/utils/linkify. Line breaks come
+	// from a `whitespace-pre-line` wrapper on the parent, not from this component.
+	let { text }: { text: string } = $props();
+
+	const segments = $derived(linkifySegments(text));
+</script>
+
+{#each segments as seg (seg)}{#if seg.type === 'link'}<a
+			href={seg.url}
+			target="_blank"
+			rel="external noopener noreferrer nofollow ugc"
+			class="break-all text-accent underline hover:opacity-80">{seg.url}</a
+		>{:else}{seg.text}{/if}{/each}

--- a/src/lib/server/itemForm.test.ts
+++ b/src/lib/server/itemForm.test.ts
@@ -11,6 +11,7 @@ import {
 	extractItemForm,
 	extractBulkItemDraft,
 	MAX_ITEM_IMAGES,
+	MAX_DESCRIPTION_LENGTH,
 } from './itemForm';
 
 function imageFile(name = 'a.jpg', type = 'image/jpeg', body: BlobPart[] = ['x']) {
@@ -64,6 +65,22 @@ describe('validateItemFields', () => {
 	it('flags a missing description', () => {
 		const r = validateItemFields({ ...ok, description: null }, { requireImage: true });
 		expect(r.errors.descriptionIsMissing).toBe(true);
+	});
+
+	it(`accepts exactly ${MAX_DESCRIPTION_LENGTH} characters and rejects one more`, () => {
+		const atLimit = validateItemFields(
+			{ ...ok, description: 'x'.repeat(MAX_DESCRIPTION_LENGTH) },
+			{ requireImage: true }
+		);
+		expect(atLimit.errors.descriptionTooLong).toBe(false);
+		expect(atLimit.isValid).toBe(true);
+
+		const overLimit = validateItemFields(
+			{ ...ok, description: 'x'.repeat(MAX_DESCRIPTION_LENGTH + 1) },
+			{ requireImage: true }
+		);
+		expect(overLimit.errors.descriptionTooLong).toBe(true);
+		expect(overLimit.isValid).toBe(false);
 	});
 
 	it('flags a missing image only when requireImage is true', () => {

--- a/src/lib/server/itemForm.ts
+++ b/src/lib/server/itemForm.ts
@@ -18,6 +18,14 @@ import { getAttachableGroups } from '$lib/server/groups';
  */
 export const MAX_ITEM_IMAGES = 5;
 
+/**
+ * Max description length. Mirrors the import pipelines' cap
+ * (`integrations/leihbackend/mapping.ts` `MAX_DESCRIPTION_LENGTH` and
+ * `integrations/winbiap/csv.ts`) so manually entered and imported descriptions share one
+ * limit. Enforced server-side here; the item textareas also carry it as `maxlength` for UX.
+ */
+export const MAX_DESCRIPTION_LENGTH = 4000;
+
 /** Accepted image MIME types for uploaded item photos. */
 export const VALID_IMAGE_TYPES = [
 	'image/jpeg',
@@ -82,6 +90,7 @@ export async function sanitizeGroups(
 export interface ItemValidationErrors {
 	nameIsMissing: boolean;
 	descriptionIsMissing: boolean;
+	descriptionTooLong: boolean;
 	imageIsMissing: boolean;
 	imageInvalidType: boolean;
 	tooManyImages: boolean;
@@ -104,6 +113,8 @@ export function validateItemFields(
 	const errors: ItemValidationErrors = {
 		nameIsMissing: !input.name,
 		descriptionIsMissing: !input.description,
+		descriptionTooLong:
+			typeof input.description === 'string' && input.description.length > MAX_DESCRIPTION_LENGTH,
 		imageIsMissing: opts.requireImage ? input.images.length === 0 : false,
 		imageInvalidType: input.images.some(
 			(img) => !VALID_IMAGE_TYPES.includes(img.type as (typeof VALID_IMAGE_TYPES)[number])

--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -750,6 +750,7 @@ export const texts = {
 			saveFailed: 'Der Gegenstand konnte nicht gespeichert werden. Bitte versuche es erneut.',
 			validationFailed:
 				'Es fehlen erforderliche Felder oder es wurden ungültige Bilddateien hochgeladen.',
+			descriptionTooLong: 'Die Beschreibung darf höchstens 4.000 Zeichen lang sein.',
 			search: 'Suchen...',
 			filterAll: 'Alle',
 			filterAvailable: 'Verfügbar',

--- a/src/lib/utils/linkify.test.ts
+++ b/src/lib/utils/linkify.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { linkifySegments, type DescriptionSegment } from './linkify';
+
+const link = (url: string): DescriptionSegment => ({ type: 'link', url });
+const text = (t: string): DescriptionSegment => ({ type: 'text', text: t });
+
+describe('linkifySegments', () => {
+	it('returns a single text segment when there is no link', () => {
+		expect(linkifySegments('Nur ganz normaler Text ohne Link.')).toEqual([
+			text('Nur ganz normaler Text ohne Link.'),
+		]);
+	});
+
+	it('returns a single link segment for a bare URL', () => {
+		expect(linkifySegments('https://example.com/anleitung')).toEqual([
+			link('https://example.com/anleitung'),
+		]);
+	});
+
+	it('handles a link at the very start', () => {
+		expect(linkifySegments('https://example.com ist die Quelle')).toEqual([
+			link('https://example.com'),
+			text(' ist die Quelle'),
+		]);
+	});
+
+	it('handles a link at the very end', () => {
+		expect(linkifySegments('Mehr dazu unter https://example.com/x')).toEqual([
+			text('Mehr dazu unter '),
+			link('https://example.com/x'),
+		]);
+	});
+
+	it('handles multiple links with text in between', () => {
+		expect(
+			linkifySegments('Erst https://a.de dann https://b.de/pfad fertig')
+		).toEqual([
+			text('Erst '),
+			link('https://a.de'),
+			text(' dann '),
+			link('https://b.de/pfad'),
+			text(' fertig'),
+		]);
+	});
+
+	it('strips a trailing period off the URL and keeps it as text', () => {
+		expect(linkifySegments('Siehe https://x.de/a.')).toEqual([
+			text('Siehe '),
+			link('https://x.de/a'),
+			text('.'),
+		]);
+	});
+
+	it('strips a run of trailing punctuation', () => {
+		expect(linkifySegments('Wirklich? https://x.de/a?!')).toEqual([
+			text('Wirklich? '),
+			link('https://x.de/a'),
+			text('?!'),
+		]);
+	});
+
+	it('treats a closing paren wrapping the URL as text', () => {
+		expect(
+			linkifySegments('(siehe https://de.wikipedia.org/wiki/Bohrmaschine)')
+		).toEqual([
+			text('(siehe '),
+			link('https://de.wikipedia.org/wiki/Bohrmaschine'),
+			text(')'),
+		]);
+	});
+
+	it('keeps a closing paren that balances an opening paren inside the URL', () => {
+		expect(
+			linkifySegments('https://de.wikipedia.org/wiki/Bohrmaschine_(Werkzeug)')
+		).toEqual([link('https://de.wikipedia.org/wiki/Bohrmaschine_(Werkzeug)')]);
+	});
+
+	it('keeps the balanced paren but strips a following period', () => {
+		expect(
+			linkifySegments('https://en.wikipedia.org/wiki/Drill_(tool).')
+		).toEqual([link('https://en.wikipedia.org/wiki/Drill_(tool)'), text('.')]);
+	});
+
+	it('matches an uppercase scheme without normalizing the URL', () => {
+		expect(linkifySegments('HTTPS://EXAMPLE.COM/A')).toEqual([
+			link('HTTPS://EXAMPLE.COM/A'),
+		]);
+	});
+
+	it('does not linkify javascript: URLs', () => {
+		expect(linkifySegments('javascript:alert(1)')).toEqual([
+			text('javascript:alert(1)'),
+		]);
+	});
+
+	it('does not linkify data: URLs', () => {
+		expect(linkifySegments('data:text/html,<script>x</script>')).toEqual([
+			text('data:text/html,<script>x</script>'),
+		]);
+	});
+
+	it('does not linkify scheme-less www. addresses', () => {
+		expect(linkifySegments('Besuche www.example.de bitte')).toEqual([
+			text('Besuche www.example.de bitte'),
+		]);
+	});
+
+	it('does not linkify ftp:// URLs', () => {
+		expect(linkifySegments('ftp://files.example.de/x')).toEqual([
+			text('ftp://files.example.de/x'),
+		]);
+	});
+
+	it('preserves umlauts and special characters in surrounding text', () => {
+		expect(linkifySegments('Schöne Grüße – hier: https://x.de/ä')).toEqual([
+			text('Schöne Grüße – hier: '),
+			link('https://x.de/ä'),
+		]);
+	});
+
+	it('preserves newlines in text segments around a link', () => {
+		expect(
+			linkifySegments(
+				'Zeile eins\nZeile zwei\nMehr unter https://example.com/x'
+			)
+		).toEqual([
+			text('Zeile eins\nZeile zwei\nMehr unter '),
+			link('https://example.com/x'),
+		]);
+	});
+
+	it('keeps a pure multiline text as one text segment', () => {
+		expect(linkifySegments('Zeile eins\nZeile zwei')).toEqual([
+			text('Zeile eins\nZeile zwei'),
+		]);
+	});
+});

--- a/src/lib/utils/linkify.ts
+++ b/src/lib/utils/linkify.ts
@@ -1,0 +1,78 @@
+/**
+ * Split a plain-text item description into text and link segments for safe rendering.
+ *
+ * Only `http(s)://…` URLs become links: the match is scheme-safe by construction, so
+ * `javascript:` / `data:` payloads and scheme-less `www.…` are deliberately left as text and
+ * can never become an `href`. Nothing here produces HTML — the consuming component renders
+ * text segments as escaped text and link segments as attribute-bound `<a>` elements, so there
+ * is no `{@html}` / XSS surface. Storage stays plain text; this only affects rendering.
+ */
+
+export type DescriptionSegment =
+	| { type: 'text'; text: string }
+	| { type: 'link'; url: string };
+
+/** Prose punctuation that commonly trails a URL and should not be part of the link. */
+const TRAILING_PUNCTUATION = new Set([
+	'.',
+	',',
+	';',
+	':',
+	'!',
+	'?',
+	'"',
+	"'",
+	'»',
+	')',
+]);
+
+/**
+ * Turn plain text into an ordered list of text/link segments. `http(s)://` URLs (scheme match
+ * is case-insensitive) become link segments; everything else — including newlines, which the
+ * caller preserves via `whitespace-pre-line` — stays in text segments.
+ *
+ * Trailing prose punctuation (`.,;:!?"'»)`) is trimmed off the URL and folded back into the
+ * following text, except a closing `)` that balances an opening `(` inside the URL itself
+ * (e.g. `…/Drill_(tool)` Wikipedia paths), which stays part of the link.
+ */
+export function linkifySegments(text: string): DescriptionSegment[] {
+	const segments: DescriptionSegment[] = [];
+	const re = /https?:\/\/\S+/gi;
+	let lastIndex = 0;
+	let match: RegExpExecArray | null;
+
+	while ((match = re.exec(text)) !== null) {
+		let url = match[0];
+
+		// Trim trailing prose punctuation off the URL. A closing ")" is kept only when the URL
+		// itself contains a matching "(", otherwise it is treated as sentence punctuation.
+		while (url.length > 0) {
+			const last = url[url.length - 1];
+			if (!TRAILING_PUNCTUATION.has(last)) break;
+			if (last === ')') {
+				const opens = (url.match(/\(/g) ?? []).length;
+				const closes = (url.match(/\)/g) ?? []).length;
+				if (closes <= opens) break;
+			}
+			url = url.slice(0, -1);
+		}
+
+		const start = match.index;
+		if (start > lastIndex) {
+			segments.push({ type: 'text', text: text.slice(lastIndex, start) });
+		}
+		segments.push({ type: 'link', url });
+
+		// Continue scanning right after the (possibly trimmed) URL. The trimmed trailing
+		// punctuation is left in the stream and re-emitted as text — it can never start a new
+		// `https?://` match, so this cannot loop.
+		lastIndex = start + url.length;
+		re.lastIndex = lastIndex;
+	}
+
+	if (lastIndex < text.length) {
+		segments.push({ type: 'text', text: text.slice(lastIndex) });
+	}
+
+	return segments;
+}

--- a/src/routes/items/[id]/+page.svelte
+++ b/src/routes/items/[id]/+page.svelte
@@ -13,6 +13,7 @@
 	import OwnerCard from './OwnerCard.svelte';
 	import ShareButton from '$lib/components/ShareButton.svelte';
 	import CustomAlert from '$lib/components/CustomAlert.svelte';
+	import LinkifiedText from '$lib/components/LinkifiedText.svelte';
 	import SeoHead from '$lib/components/SeoHead.svelte';
 
 	const { data, form } = $props();
@@ -52,7 +53,7 @@
 	const seoTitle = $derived(texts.seo.itemDetail(item.name, item.username ?? ''));
 	const seoDesc = $derived(
 		item.description
-			? item.description.slice(0, 155)
+			? item.description.replace(/\s+/g, ' ').trim().slice(0, 155)
 			: texts.seo.itemDetailDescription(
 					item.name,
 					item.username ?? ''
@@ -112,8 +113,8 @@
 
 	<!-- Description -->
 	{#if item.description}
-		<p class="leading-relaxed text-tinte-700 dark:text-tinte-300">
-			{item.description}
+		<p class="whitespace-pre-line leading-relaxed text-tinte-700 dark:text-tinte-300">
+			<LinkifiedText text={item.description} />
 		</p>
 	{/if}
 

--- a/src/routes/user/items/ItemModal.svelte
+++ b/src/routes/user/items/ItemModal.svelte
@@ -213,8 +213,15 @@
 					// Show the failure inline right above the submit button (#522). Sourced
 					// from this form's own result — not the shared page-level `form` prop,
 					// which is fanned out to every row's modal and written by unrelated
-					// inline/bulk actions — so it stays tied to *this* submit.
-					submitError = (result.data as { message?: string } | undefined)?.message ?? null;
+					// inline/bulk actions — so it stays tied to *this* submit. A too-long
+					// description gets its own message instead of the generic one (the client
+					// maxlength normally prevents it; this covers a tampered/pasted submit).
+					const data = result.data as
+						| { message?: string; missingFields?: { descriptionTooLong?: boolean } }
+						| undefined;
+					submitError = data?.missingFields?.descriptionTooLong
+						? texts.pages.items.descriptionTooLong
+						: (data?.message ?? null);
 				}
 				await update();
 			};
@@ -313,6 +320,7 @@
 					placeholder={texts.forms.itemDescription}
 					value={editingItem?.description ? editingItem.description : ''}
 					autocomplete="off"
+					maxlength={4000}
 					required
 				/>
 			</Label>

--- a/src/routes/user/items/bulk-add/ReviewStep.svelte
+++ b/src/routes/user/items/bulk-add/ReviewStep.svelte
@@ -169,6 +169,7 @@
 							<textarea
 								use:autoresize={draft.description}
 								rows={1}
+								maxlength={4000}
 								placeholder={texts.forms.itemDescription}
 								bind:value={draft.description}
 								class="block w-full resize-none overflow-hidden rounded-lg border border-tinte-300 bg-papier p-2.5 text-sm text-tinte-900 focus:border-primary-500 focus:ring-primary-500 dark:border-tinte-600 dark:bg-tinte-700 dark:text-white dark:placeholder-tinte-400 dark:focus:border-primary-500 dark:focus:ring-primary-500"


### PR DESCRIPTION
## What & why

Item descriptions are stored as plain text but were rendered on a single line with inert URLs. This makes rendering smarter without changing storage, the schema, or the backend.

- **#455 — line breaks:** the item detail page now renders the description with `whitespace-pre-line`, so entered newlines are preserved (same idiom already used for group descriptions).
- **#395 — clickable links:** a new pure `linkify` util splits the plain text into text/link segments and a `LinkifiedText` component renders them. **Security by construction:** only `https?://` URLs become links, there is **no `{@html}`** anywhere — text is rendered as escaped text nodes and the `href` is an attribute binding, so `javascript:`/`data:` schemes can never become a link. Links get `target="_blank"` + `rel="external noopener noreferrer nofollow ugc"`. Trailing punctuation is trimmed off the URL; a balanced closing `)` stays part of the URL (Wikipedia-style paths).
- **Length cap:** server-side `MAX_DESCRIPTION_LENGTH = 4000` in `validateItemFields` (new `descriptionTooLong` error key, existing keys untouched), mirrored as `maxlength={4000}` on the single-item and bulk-add textareas, with a German error message in `texts.ts`. This also aligns the UI with the existing import-pipeline caps.

Storage stays plain text, so search (matches raw text) and the archive-prefix logic (`description.startsWith(...)`) are unaffected. Card/row previews stay plain, clamped/truncated text (no links).

## Test notes

Preflight: `npm run lint` ✅, `npx vitest run` ✅ (681 tests). `npm run check` and `npm run build` fail **only** on the 6 pre-existing `$env/static/private` errors (missing local `SYNC_SECRET`/`PB_SUPERUSER_*` env vars in `pocketbase.ts`, `syncEndpoint.ts`, `user/import`); none touch this diff and they pass on CI where the vars are set.

New/extended tests:
- `src/lib/utils/linkify.test.ts` — no-link, link positions, multiple links, trailing punctuation, balanced-paren case, `HTTPS://` casing, negative cases (`javascript:`, `data:`, `www.` without scheme, `ftp://`), umlauts, `\n` preservation.
- `src/lib/server/itemForm.test.ts` — 4000 ok / 4001 → `descriptionTooLong`.
- `e2e/tests/item-upload.spec.ts` — new block: creates an item with newlines + a URL, asserts the rendered link's `href`/`target`/`rel` and `white-space: pre-line` on the detail page.

Manually verified in the browser (multi-line + URL rendering, trailing-punctuation trimming, long-URL wrapping on mobile, plain card preview, no console/network errors).

Closes #395, closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)