### PR TITLE
docs(integrations): backend-local full sync + sync_config (share-mvp#487 phase 2)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -129,7 +129,7 @@ These prevent the most common bugs/security issues here — follow them without 
 | Groups: roles, public/self-join, visibility model | `docs/groups.md` |
 | Partner catalogue integrations (leihbackend, WINBIAP), `/api/sync` + `/api/refresh`, adding a new integration | `docs/integrations.md`; leihbackend API reference: `docs/leihbackend-integration-spec.md` |
 | Operating the sync/refresh endpoints (env vars, cron, failure modes) | `docs/operations/integration-sync.md` |
-| ⚠️ #487 Phase 1: the **scheduled** per-item refresh moved to the backend | see the double-truth note below; `Allerleih-Backend/pb_hooks/integrations/` |
+| ⚠️ #487 Phase 2: the **scheduled** full-sync AND per-item refresh moved to the backend (discovery via `sync_config`) | see the double-truth note below; `Allerleih-Backend/pb_hooks/integrations/` |
 | Account deletion & GDPR (Art. 17/15/20) | See "Account deletion" section below; backend: `allerleih-backend/pb_hooks/account.pb.js` |
 | Push notifications (VAPID helpers, subscription CRUD, service worker) | `docs/architecture.md` → "Real-time Architecture"; helpers in `$lib/server/notifications.ts`, `$lib/server/pushSubscriptions.ts` |
 | Business metrics (`/admin/metrics`, `/misc/stats`, the nightly `metrics_daily` snapshot) | `docs/operations/metrics.md`; helper in `$lib/server/metrics.ts` |
@@ -137,15 +137,22 @@ These prevent the most common bugs/security issues here — follow them without 
 | A backend-only issue (no frontend changes) | Still drive it through `/issue-to-pr` + `/create-pr` **here** — the plan gate and review dispatch (`sveltekit-pb-reviewer` covers `pb_hooks`/`pb_migrations`) live in this repo. The backend also has its own `allerleih-backend/.claude/skills/create-pr` for standalone use when working in that repo alone. |
 
 > **⚠️ Temporary double truth (until #487 Phase 3).** The integration diff/write logic now exists
-> **twice**: the Goja port in `Allerleih-Backend/pb_hooks/integrations/` (which runs the
-> **scheduled** per-item refresh — the backend `integration_refresh` cron no longer POSTs
-> `/api/refresh`) **and** the TS copy here in `src/lib/server/integrations/`, which still backs the
-> CSV import at `/user/import` and the manual `/api/sync` + `/api/refresh` endpoints. Keep the two
-> in lockstep: **`SYNCED_FIELDS`** (`core/types.ts` ↔ backend `integrations/types.js`) and
-> **`DESCRIPTION_PREFIX`** (`$lib/server/itemArchive.ts` ↔ backend `integrations/diff.js`) MUST
-> stay **byte-identical** across both repos — a prefix drift re-archives all existing stock (the
-> "already archived" skip matches on it). No frontend code is removed in Phase 1; Phase 3 removes
-> the frontend copy and this note.
+> **twice**: the Goja port in `Allerleih-Backend/pb_hooks/integrations/` (which runs **both**
+> **scheduled** cron jobs — the backend `integration_sync` + `integration_refresh` no longer POST
+> the frontend, and discover institutions from the new **`sync_config`** collection) **and** the TS
+> copy here in `src/lib/server/integrations/`, which still backs the CSV import at `/user/import`
+> and the **manual** `/api/sync` + `/api/refresh` endpoints (which still read
+> `users.leihbackendUrl`). Two consequences until Phase 3:
+> - **Keep the shared constants byte-identical across repos:** **`SYNCED_FIELDS`** (`core/types.ts`
+>   ↔ backend `integrations/types.js`) and **`DESCRIPTION_PREFIX`** (`$lib/server/itemArchive.ts` ↔
+>   backend `integrations/diff.js`) — a prefix drift re-archives all existing stock (the "already
+>   archived" skip matches on it).
+> - **Dual-truth discovery:** the cron reads `sync_config`; the manual endpoints read
+>   `users.leihbackendUrl`. A new partner needs **both** set, and `sync_config.enabled=false` pauses
+>   only the cron (the manual endpoints ignore it). See `docs/operations/onboarding-institutional-partner.md`.
+>
+> No frontend code is removed in Phase 2 (only the additive `SyncConfig` type in `models.ts`);
+> Phase 3 removes the frontend copy, `users.leihbackendUrl`, and this note.
 
 ## Project tooling (this repo's `.claude/`)
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -284,7 +284,19 @@ erDiagram
         date updated
     }
 
+    SYNC_CONFIG{
+        string id PK
+        User institution FK "cascadeDelete — the institution this config belongs to"
+        string integration "select: leihbackend | winbiap"
+        string baseUrl "source base URL (leihbackend origin, or WINBIAP WebOPAC base ending /webopac)"
+        string itemUrlTemplate "optional deep-link template, {id}/{iid} placeholders"
+        bool enabled "false → backend cron skips this institution (manual endpoints ignore it until Phase 3)"
+        date created
+        date updated
+    }
+
     ITEM 1 to zero or more OUTBOUND_CLICK: tracked by
+    USER 1 to zero or more SYNC_CONFIG: configures
 
     METRICS_DAILY{
         string id PK
@@ -333,6 +345,23 @@ metadata from the base column, so view migrations are never needed for a categor
 6. **Docs:** update this section and any doc citing the values or their count.
 7. Run both suites: frontend `npm run check && npm run lint && npx vitest run`; backend
    `npm test`.
+
+## sync_config
+
+Per-institution integration configuration (#487 Phase 2), the dedicated replacement for the
+overloaded `users.leihbackendUrl` discovery field. One row per source type per institution
+(unique index on `(institution, integration)`); `integration` is a select of
+`leihbackend | winbiap`. **Superuser-only** — all five API rules are `null` (not `""`), so no
+authenticated user can read or write it; rows are managed in the PocketBase admin UI (see
+`operations/onboarding-institutional-partner.md`). It is **not** exposed by any `*_public` view.
+
+As of Phase 2 the **backend cron** (`integration_sync` full pull + `integration_refresh` per-item)
+discovers institutions from `sync_config`. The **manual** frontend `/api/sync` + `/api/refresh` and
+the CSV import still read `users.leihbackendUrl` — a documented **dual-truth interim** until Phase 3
+drops `users.leihbackendUrl`/`leihbackendItemUrlTemplate`. `enabled=false` affects only the cron in
+Phase 2; the manual endpoints ignore it until Phase 3. A one-time backfill migration
+(`pb_hooks/services/syncConfig.js` → `backfillSyncConfigs`) seeds rows from the existing
+`users.leihbackendUrl` values (`/webopac` → `winbiap`, else `leihbackend`, `enabled=true`).
 
 ## user_geolocations
 

--- a/docs/operations/integration-sync.md
+++ b/docs/operations/integration-sync.md
@@ -13,14 +13,17 @@ Both are session-unauthenticated (listed in `hooks.server.ts`'s unprotected pref
 
 Each institution is first matched to the integrations serving its source (`claimsInstitution`, detected from the base URL — `/webopac` ⇒ WINBIAP), then each stored item is routed to whichever remaining integration `claimsItem(item)` recognizes (by `externalUrl`/`externalId`).
 
-> **⚠️ #487 Phase 1 — the scheduled per-item refresh now runs in the backend, not here.** The
-> `integration_refresh` cron job no longer POSTs `/api/refresh`; it executes the same logic
+> **⚠️ #487 Phase 2 — BOTH scheduled jobs now run in the backend, not here.** As of Phase 2 the
+> `integration_sync` (full pull) **and** `integration_refresh` (per-item) cron jobs execute
 > **locally inside PocketBase** (`Allerleih-Backend/pb_hooks/integrations/`, native `$app`, a
-> per-institution transaction, and a `$app.store()` overlap lock) — no bearer secret, no
-> superuser HTTP client. This frontend `/api/refresh` endpoint **still exists** and is unchanged
-> (use it for a manual `?institution=` trigger), but is no longer on the cron path. The full
-> `/api/sync` pull is **not** part of Phase 1 and still runs here (see below). See the backend
-> section under *Scheduling* for the current refresh config, lock caveat, pacing, and the redirect
+> per-institution transaction, a shared `$app.store()` overlap lock) — no HTTP POST, no bearer
+> secret, no superuser HTTP client. They discover institutions from the new **`sync_config`**
+> collection (see *Config source* below), not `users.leihbackendUrl`.
+>
+> These frontend `/api/sync` + `/api/refresh` endpoints **still exist and are unchanged** — use
+> them for a **manual** trigger (`/api/refresh?institution=<id>` for one institution). They still
+> read `users.leihbackendUrl` (dual-truth interim, Phase 3 removes them). See *Scheduling* below
+> for the backend config, the config source, `enabled`, the lock caveat, pacing, and the redirect
 > residual.
 
 ## Prerequisite: enable the PocketBase Batch API
@@ -81,31 +84,35 @@ curl -X POST "https://allerleih.org/api/refresh?institution=<users-id>" \
 
 ### Built-in PocketBase cron jobs (preferred)
 
-The backend (`allerleih-backend`, `pb_hooks/integration_sync.pb.js`) registers two cron jobs. As of **#487 Phase 1** the two jobs work **differently**:
+The backend (`allerleih-backend`, `pb_hooks/integration_sync.pb.js`) registers two cron jobs. As of **#487 Phase 2** **both** run **locally in the backend** — no HTTP POST to the frontend:
 
-- **`integration_sync`** (full pull) — still POSTs the frontend's `POST /api/sync` (needs `FRONTEND_URL` + `SYNC_SECRET`). Unchanged.
-- **`integration_refresh`** (per-item refresh) — now runs **locally in the backend** (`pb_hooks/integrations/refresh.js`): no HTTP call, no bearer secret, direct `$app` writes in a per-institution transaction. It needs only a valid `REFRESH_CRON`.
+- **`integration_sync`** (full pull) — `pb_hooks/integrations/sync.js`: pages each leihbackend institution's `item_public` feed and upserts/archives, direct `$app` writes in a per-institution transaction. Needs only a valid `SYNC_CRON`.
+- **`integration_refresh`** (per-item refresh) — `pb_hooks/integrations/refresh.js`: re-fetches each stored item one by one. Needs only a valid `REFRESH_CRON`.
 
-Configure in the **backend's** environment:
+Both **discover institutions from the `sync_config` collection** (not `users.leihbackendUrl` — see *Config source*). Configure in the **backend's** environment:
 
 | Variable | Example | Purpose |
 |---|---|---|
-| `SYNC_CRON` | `*/15 * * * *` | Schedule for the full pull (`POST /api/sync`); unset/empty = job disabled |
-| `REFRESH_CRON` | `0 * * * *` | Schedule for the **local** per-item refresh; unset/empty = job disabled |
-| `FRONTEND_URL` | `https://allerleih.org` | SvelteKit origin the **sync** cron calls (no trailing slash). **Sync only** — refresh no longer uses it |
-| `SYNC_SECRET` | — | Bearer token for the **sync** call; must equal the frontend's `SYNC_SECRET`. **Sync only** — refresh no longer uses it |
-| `SYNC_TIMEOUT_SECONDS` | `540` (default) | HTTP timeout of the **sync** cron's call. Refresh writes direct via `$app`, no HTTP timeout |
-| `INTEGRATION_ALLOW_INSECURE_URL` | `false` (default) | Refresh only: allow `http://` and private/loopback source base URLs, bypassing the SSRF guard. **Local dev / integration tests only — never set in production.** |
+| `SYNC_CRON` | `*/15 * * * *` | Schedule for the local full pull; unset/empty = job disabled. **No longer needs `FRONTEND_URL`/`SYNC_SECRET`.** |
+| `REFRESH_CRON` | `0 * * * *` | Schedule for the local per-item refresh; unset/empty = job disabled |
+| `INTEGRATION_ALLOW_INSECURE_URL` | `false` (default) | Allow `http://` and private/loopback source base URLs, bypassing the SSRF guard — applies to **both** jobs (refresh `fetchItemById` + sync `fetchAllItems`). **Local dev / integration tests only — never set in production.** |
+| `FRONTEND_URL`, `SYNC_SECRET`, `SYNC_TIMEOUT_SECONDS` | — | **No longer used by either cron job** (kept only for the frontend's *manual* `/api/sync` + `/api/refresh`; removed in Phase 3). |
 
-Schedules are standard 5-field cron expressions (minute granularity). The jobs appear as `integration_sync` / `integration_refresh` in the PocketBase admin UI (Settings → Crons), where a superuser can also fire them manually; `GET /api/crons` and `POST /api/crons/{id}` do the same over HTTP. **Fail-soft** is per job: an invalid expression (or, for sync, a missing `FRONTEND_URL`/`SYNC_SECRET`) logs an error at startup and leaves that job unscheduled without affecting the sibling. `DRY_MODE=true` makes **both** jobs skip their work (sync skips the outbound call; refresh logs and skips all upstream fetches + writes).
+Schedules are standard 5-field cron expressions (minute granularity). The jobs appear as `integration_sync` / `integration_refresh` in the PocketBase admin UI (Settings → Crons), where a superuser can also fire them manually; `GET /api/crons` and `POST /api/crons/{id}` do the same over HTTP. **Fail-soft** is per job: an invalid expression logs an error at startup and leaves that job unscheduled without affecting the sibling. `DRY_MODE=true` makes **both** jobs log and skip all upstream fetches + writes.
 
-> **⚠️ Interim two-lock-domain caveat (until Phase 3).** The backend refresh guards overlap with a `$app.store()` lock (`integrationRunLock`); the still-frontend `/api/sync` uses a *separate* process-wide in-flight lock. **The two cannot see each other.** So during Phase 1: do **not** overlap the `SYNC_CRON` and `REFRESH_CRON` windows, and do **not** fire a manual frontend `/api/sync` (or `/api/refresh`) while a backend refresh window is active — both write `items`. Within each domain, overlap is still safe (a second backend refresh tick skips with a warning; a second frontend call answers `429`).
+#### Config source — `sync_config` (Phase 2)
+
+Both cron jobs read a **`sync_config`** collection (superuser-only) instead of `users.leihbackendUrl`. One row per institution per integration: `institution` (→ users), `integration` (`leihbackend`|`winbiap`), `baseUrl`, `itemUrlTemplate`, `enabled`. The **full sync** processes only `leihbackend` rows (WINBIAP has no bulk feed, so it never appears in the pull — the old "WINBIAP picked up by the full sync and fails" footgun is gone); the **refresh** processes all enabled rows and routes each by `integration`. Manage rows in the PocketBase admin UI (see [onboarding-institutional-partner.md](onboarding-institutional-partner.md)). A one-time backfill migration seeded rows from existing `users.leihbackendUrl` values.
+
+> **Dual-truth interim (until Phase 3).** The **cron** reads `sync_config`; the **manual** frontend `/api/sync` + `/api/refresh` and the CSV import still read `users.leihbackendUrl`. A new partner therefore needs **both** set (onboarding double-step). `enabled=false` disables only the **cron** — a manual `/api/sync`/`/api/refresh` still processes the institution (it doesn't know about `enabled`) until Phase 3.
+
+> **⚠️ Interim two-lock-domain caveat (until Phase 3).** The backend cron jobs share one `$app.store()` lock (`integrationRunLock`) — a sync and a refresh tick never overlap, and a second tick of either skips with a warning. But the **manual** frontend `/api/sync`/`/api/refresh` use a *separate* process-wide in-flight lock that **cannot see** the backend lock. So do **not** fire a manual frontend sync/refresh while a backend cron window is active — both write `items`.
 
 > **Pacing (refresh).** WINBIAP's per-item WebOPAC courtesy pause (`pauseMsBetweenFetches: 500`) is preserved in the backend via the JSVM's blocking `sleep(ms)` (spike #487 §4.4). Per-item refresh makes one upstream request per stored item — heavier per institution than a bulk pull, and the WINBIAP pause adds ~0.5 s/item — so size `REFRESH_CRON` conservatively (a large WINBIAP catalogue takes minutes).
 
-> **Redirect residual (refresh, security).** The backend uses `$http.send`, which **follows** HTTP redirects and exposes neither the intermediate 3xx nor the final URL (no policy hook in the JSVM — spike #487 §4.4). The literal-URL SSRF guard (`urlGuard.js`) therefore **cannot** catch a source base URL that 302-redirects onto an internal host. Base URLs are admin-onboarded (bounded risk), but treat a partner-supplied URL as you would any server-side fetch target. The frontend `fetch` path used `redirect: 'manual'`; that exact semantics is not reproducible in Goja.
+> **Redirect residual (security).** The backend uses `$http.send`, which **follows** HTTP redirects and exposes neither the intermediate 3xx nor the final URL (no policy hook in the JSVM — spike #487 §4.4). The literal-URL SSRF guard (`urlGuard.js`) therefore **cannot** catch a source base URL that 302-redirects onto an internal host. Base URLs are admin-onboarded (bounded risk), but treat a partner-supplied URL as you would any server-side fetch target. The frontend `fetch` path used `redirect: 'manual'`; that exact semantics is not reproducible in Goja.
 
-> **Long first sync (sync only):** creates are batched 15-at-a-time with 5.5 s pauses (≈2.7 items/s), so a **first `/api/sync`** of a large catalogue can far exceed `SYNC_TIMEOUT_SECONDS` — 5000 items take ≈30 min. The backend cron then logs a timeout while the run **keeps completing server-side**; the frontend's in-flight lock 429s subsequent ticks until it finishes. For a first import of a big catalogue, prefer a manual `curl` without a timeout (see above). *(Refresh writes direct via `$app` in a transaction — no batching, no HTTP timeout.)*
+> **Backend sync writes are transactional, not batched.** The local full sync writes each institution's creates/updates/archives in one `$app` transaction (all-or-nothing) — no rate-limit batching, no HTTP timeout. The Batch-API prerequisite above and the "long first sync" batching caveat apply only to the **frontend** manual `/api/sync` + the CSV import.
 
 ### OS crontab (fallback)
 

--- a/docs/operations/onboarding-institutional-partner.md
+++ b/docs/operations/onboarding-institutional-partner.md
@@ -18,7 +18,22 @@ Short checklist for bringing a new institution onto AllerLeih.
 
 If the institution runs lending software AllerLeih supports, its catalogue can be kept in sync automatically instead of (or in addition to) manual CSV uploads. Configuration is a couple of fields on the institution's `users` record in the PocketBase admin dashboard. See [integration-sync.md](integration-sync.md) for how the sync runs operationally and [../integrations.md](../integrations.md) for the architecture.
 
-> **Heads-up — one shared field for now:** the base URL for *every* integration type currently goes into the `leihbackendUrl` field (it's overloaded as a generic base URL until a dedicated `sync_config` collection exists). Paste the appropriate URL below into `leihbackendUrl` regardless of the software.
+> **Heads-up — one shared field for now:** the base URL for *every* integration type currently goes into the `leihbackendUrl` field (it's overloaded as a generic base URL). Paste the appropriate URL below into `leihbackendUrl` regardless of the software.
+
+> **⚠️ Interim double-step (#487 Phase 2, until Phase 3).** Discovery is split during Phase 2: the
+> **scheduled backend cron** (full sync **and** per-item refresh) reads a dedicated **`sync_config`**
+> collection, while the **manual** `/api/sync` + `/api/refresh` endpoints and the CSV import still
+> read `users.leihbackendUrl`. **So a new partner needs BOTH, set by hand in the PocketBase admin UI:**
+>
+> 1. `users.leihbackendUrl` (+ optional `leihbackendItemUrlTemplate`) — as described below (frontend manual/CSV).
+> 2. A **`sync_config`** row — open the `sync_config` collection → *New record*:
+>    - `institution` → the institution's `users` record
+>    - `integration` → `leihbackend` **or** `winbiap`
+>    - `baseUrl` → the same URL as `leihbackendUrl`
+>    - `itemUrlTemplate` → same as `leihbackendItemUrlTemplate` (optional)
+>    - `enabled` → `true` (set `false` to pause **only** the cron; the manual endpoints ignore `enabled` until Phase 3)
+>
+> Keep the two in sync until Phase 3 unifies discovery on `sync_config` and removes `users.leihbackendUrl`.
 
 ### leihbackend (Leihladen software)
 
@@ -43,7 +58,7 @@ WINBIAP has no bulk feed, so the lifecycle is two-step:
 1. **Initial import:** the institution uploads its catalogue once via the CSV import at `/user/import` (this is what sets each item's `externalId` and `externalUrl`).
 2. **Keeping fresh:** the **per-item refresh** (`POST /api/refresh`) re-checks each stored item against the WebOPAC on a cron, updating changed items and archiving ones that disappear.
 
-> Do **not** rely on `POST /api/sync` for a WINBIAP institution — it will try (and fail) to fetch `item_public`. The failure is isolated and harmless, but WINBIAP institutions are kept current by `/api/refresh`, not the full sync.
+> For a WINBIAP institution, give its `sync_config` row `integration = winbiap` — the **backend cron** full sync then skips it entirely (it only pulls `leihbackend` rows), so the old "full sync tries and fails on WINBIAP" footgun no longer applies to the cron. The **manual** frontend `POST /api/sync` still reads `users.leihbackendUrl` and would still try (and harmlessly fail) to fetch `item_public` — so don't run the manual full sync against a WINBIAP institution. WINBIAP institutions are kept current by the refresh, not the full sync.
 
 ## Notes
 

--- a/src/lib/types/models.ts
+++ b/src/lib/types/models.ts
@@ -830,3 +830,33 @@ export interface MetricsDaily extends PocketBaseEntity {
 	date: string;
 	metrics: DailyMetrics;
 }
+
+/**
+ * Per-institution integration configuration (backend `sync_config` collection, #487 Phase 2).
+ * **Superuser-only**: no client CRUD — rows are managed in the PocketBase admin UI (see the
+ * onboarding runbook). Not exposed through any `*_public` view.
+ *
+ * As of Phase 2 the backend **cron** discovers institutions to sync/refresh from here. The
+ * frontend's *manual* `/api/sync` + `/api/refresh` (and the CSV import) still read
+ * `users.leihbackendUrl` — a documented dual-truth interim removed in Phase 3, when
+ * `users.leihbackendUrl`/`leihbackendItemUrlTemplate` are dropped.
+ */
+export interface SyncConfig extends PocketBaseEntity {
+	/** Foreign key: the institution `users` record this config belongs to (cascadeDelete). */
+	institution: UserId;
+
+	/** Which integration serves this institution's source. */
+	integration: 'leihbackend' | 'winbiap';
+
+	/** Source base URL — leihbackend origin, or a WINBIAP WebOPAC base ending in `/webopac`. */
+	baseUrl: string;
+
+	/** Optional human-facing deep-link template with `{id}`/`{iid}` placeholders. */
+	itemUrlTemplate?: string;
+
+	/**
+	 * When false the backend cron skips this institution. In Phase 2 this only affects the cron;
+	 * the manual frontend endpoints ignore it until Phase 3.
+	 */
+	enabled?: boolean;
+}


### PR DESCRIPTION
## Phase 2 of #487 — docs + type only (backend-local full sync + `sync_config`)

Documentation companion to the backend PR that ports the **full sync** into a
PocketBase `pb_hooks` cron and introduces the `sync_config` collection as the
discovery source. **No frontend runtime change** — only docs and one additive
type. The integration core (`src/lib/server/integrations/`) stays for the CSV
import and manual endpoints; it is torn down in phase 3.

> ⚠️ **Stacked on the phase-1 branch** `feat/487-refresh-to-backend` (base of this PR),
> because phase 1 (#563) is not merged yet. Rebase onto `main` once phase 1 lands.

### What changed
- **`docs/operations/integration-sync.md`**: full sync now runs locally in the backend;
  `sync_config` as the cron discovery source; the **dual-truth interim** (cron reads
  `sync_config`, the manual `/api/sync`+`/api/refresh` still read `users.leihbackendUrl`);
  `enabled=false` is cron-only until phase 3; shared-lock caveat.
- **`docs/operations/onboarding-institutional-partner.md`**: the **interim double step** —
  a new partner needs both `users.leihbackendUrl` (frontend manual/CSV) **and** a
  `sync_config` row (cron), created via the PocketBase admin UI, until phase 3.
- **`docs/data-model.md`**: `sync_config` collection (superuser-only).
- **`src/lib/types/models.ts`**: additive `SyncConfig` interface — no field removed
  (`users.leihbackendUrl` stays until phase 3).

### Cross-repo
Backend PR (the actual port + migration + tests): **https://github.com/share-open-sharing-infrastructure/allerleih-backend/pull/46**

Refs #487 (issue stays open until phase 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
