### PR TITLE
fix(search): restore "Nur Verfügbare" toggle after default flip

### DIFF
--- a/src/routes/search/Pagination.svelte
+++ b/src/routes/search/Pagination.svelte
@@ -94,8 +94,8 @@
 			{#if op === 'and'}
 				<input type="hidden" name="op" value="and" />
 			{/if}
-			{#if !onlyAvailable}
-				<input type="hidden" name="onlyAvailable" value="false" />
+			{#if onlyAvailable}
+				<input type="hidden" name="onlyAvailable" value="true" />
 			{/if}
 			{#if ownerType !== 'all'}
 				<input type="hidden" name="ownerType" value={ownerType} />

--- a/src/routes/search/searchUrl.test.ts
+++ b/src/routes/search/searchUrl.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildSearchUrl } from './searchUrl';
+
+vi.mock('$app/paths', () => ({ resolve: (path: string) => path }));
+
+describe('buildSearchUrl', () => {
+	it('encodes onlyAvailable=true when the override is active', () => {
+		const url = buildSearchUrl({ onlyAvailable: true });
+		expect(url).toContain('onlyAvailable=true');
+	});
+
+	it('omits the onlyAvailable param entirely when false (the default)', () => {
+		const url = buildSearchUrl({ onlyAvailable: false });
+		expect(url).not.toContain('onlyAvailable');
+	});
+
+	it('omits the onlyAvailable param entirely when undefined', () => {
+		const url = buildSearchUrl({ onlyAvailable: undefined });
+		expect(url).not.toContain('onlyAvailable');
+	});
+
+	it('combines q and onlyAvailable with an "&"', () => {
+		const url = buildSearchUrl({ q: 'bohrer', onlyAvailable: true });
+		expect(url).toBe('/search?q=bohrer&onlyAvailable=true');
+	});
+
+	it('encodes cats, op and page alongside each other', () => {
+		const url = buildSearchUrl({ cats: ['Werkzeug', 'Garten'], op: 'and', page: 3 });
+		expect(url).toBe('/search?page=3&cats=Werkzeug%2CGarten&op=and');
+	});
+
+	it('returns the bare search path when no params are set', () => {
+		expect(buildSearchUrl({})).toBe('/search');
+	});
+});

--- a/src/routes/search/searchUrl.test.ts
+++ b/src/routes/search/searchUrl.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { buildSearchUrl } from './searchUrl';
+import { parseSearchParameters } from './searchFilter';
 
 vi.mock('$app/paths', () => ({ resolve: (path: string) => path }));
 
@@ -25,11 +26,48 @@ describe('buildSearchUrl', () => {
 	});
 
 	it('encodes cats, op and page alongside each other', () => {
-		const url = buildSearchUrl({ cats: ['Werkzeug', 'Garten'], op: 'and', page: 3 });
+		const url = buildSearchUrl({
+			cats: ['Werkzeug', 'Garten'],
+			op: 'and',
+			page: 3,
+		});
 		expect(url).toBe('/search?page=3&cats=Werkzeug%2CGarten&op=and');
 	});
 
 	it('returns the bare search path when no params are set', () => {
 		expect(buildSearchUrl({})).toBe('/search');
+	});
+});
+
+// Roundtrip invariant: buildSearchUrl and parseSearchParameters MUST agree on every default.
+// This is the guard that #556 was missing — a future default flip on only one side (as PR #536
+// did) breaks one of these cases immediately instead of silently.
+describe('buildSearchUrl ↔ parseSearchParameters roundtrip', () => {
+	const roundtrip = (params: Parameters<typeof buildSearchUrl>[0]) =>
+		parseSearchParameters(new URL(buildSearchUrl(params), 'https://x.test'));
+
+	it('preserves onlyAvailable for both true and false', () => {
+		expect(roundtrip({ onlyAvailable: true }).onlyAvailable).toBe(true);
+		expect(roundtrip({ onlyAvailable: false }).onlyAvailable).toBe(false);
+	});
+
+	it('preserves the rest of the param family', () => {
+		const parsed = roundtrip({
+			q: 'bohrer',
+			cats: ['Werkzeug und Garten', 'Elektronik'],
+			op: 'and',
+			ownerType: 'institution',
+			page: 3,
+			perPage: 50,
+		});
+		expect(parsed.query).toBe('bohrer');
+		expect(parsed.selectedCategories).toEqual([
+			'Werkzeug und Garten',
+			'Elektronik',
+		]);
+		expect(parsed.op).toBe('and');
+		expect(parsed.ownerType).toBe('institution');
+		expect(parsed.page).toBe(3);
+		expect(parsed.perPage).toBe(50);
 	});
 });

--- a/src/routes/search/searchUrl.ts
+++ b/src/routes/search/searchUrl.ts
@@ -18,7 +18,7 @@ export function buildSearchUrl(params: SearchUrlParams): string {
 	if (params.perPage !== undefined) parts.push(`perPage=${params.perPage}`);
 	if (params.cats && params.cats.length > 0) parts.push(`cats=${encodeURIComponent(params.cats.join(','))}`);
 	if (params.op === 'and') parts.push('op=and');
-	if (params.onlyAvailable === false) parts.push('onlyAvailable=false');
+	if (params.onlyAvailable) parts.push('onlyAvailable=true');
 	if (params.ownerType && params.ownerType !== 'all') parts.push(`ownerType=${params.ownerType}`);
 	if (params.group) parts.push(`group=${encodeURIComponent(params.group)}`);
 	return resolve('/search') + (parts.length ? '?' + parts.join('&') : '');


### PR DESCRIPTION
## Summary
- PR #536 flipped the default of `onlyAvailable` (the "Nur Verfügbare" search filter) from `true` to `false`, but two places that encode `onlyAvailable` into a URL query string were left on the old logic (only ever writing `onlyAvailable=false`), so the now-relevant override case (`true`) was never written into the URL — the button appeared dead.
- `src/routes/search/searchUrl.ts`: `buildSearchUrl()` now emits `onlyAvailable=true` when active, omits the param when inactive.
- `src/routes/search/Pagination.svelte`: the non-JS `<form>` fallback for the "Einträge pro Seite" selector had the identical inverted pattern — changing page size while the filter was active silently dropped it. Fixed the same way.
- Added `src/routes/search/searchUrl.test.ts` (no prior coverage existed for `buildSearchUrl`).

Fixes #556.

## Test plan
- [x] `npx vitest run src/routes/search/searchUrl.test.ts src/routes/search/searchFilter.test.ts` — 27/27 passed
- [x] Playwright e2e `e2e/tests/search.spec.ts` — 3/3 passed
- [x] Manual browser click-through (Chrome DevTools MCP): toggle on/off via `/search`, confirmed URL param + filtered results + no console/network errors; confirmed filter survives changing "Einträge pro Seite" while active

🤖 Generated with [Claude Code](https://claude.com/claude-code)