### PR TITLE
fix(toast): render toasts above open modals (#523)

### DIFF
--- a/e2e/tests/toast-over-modal.spec.ts
+++ b/e2e/tests/toast-over-modal.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Toasts over modals (#523) — the ToastHost is portalled into the topmost open modal
+ * `<dialog>` while one is open, so its toasts paint above the dialog's ::backdrop (a
+ * body-level overlay can't — the modal backdrop wins). Runs in the `authenticated`
+ * project ('/' requires auth). We open the real feedback modal (same opener as
+ * feedback.spec.ts, retried for the dev hydration race), push a toast while it's open,
+ * and assert the toast is both visible and the top-most element hit at its own centre.
+ * Note the host is now NESTED inside the dialog, so it's expected to be within the dialog
+ * DOM — the meaningful check is that the toast host wins the hit-test.
+ */
+
+test.describe('toast over modal', () => {
+	test('a toast pushed while a modal is open paints above the modal', async ({ page }) => {
+		await page.goto('/');
+
+		// Open the feedback modal exactly as feedback.spec.ts does (retry the opener
+		// until the dialog is visible — handles the dev-server hydration race).
+		const dialog = page.getByRole('dialog');
+		await expect(async () => {
+			await page.getByRole('button', { name: 'Feedback' }).first().click();
+			await expect(dialog).toBeVisible({ timeout: 1000 });
+		}).toPass({ timeout: 15_000 });
+
+		// Push a toast while the modal is open. duration 0 = no auto-dismiss so the
+		// assertions can't race the timer. pushToast(type, message, duration).
+		await page.evaluate(async () => {
+			const m = await import('/src/lib/stores/toast.svelte.ts');
+			m.pushToast('success', 'E2E toast over modal', 0);
+		});
+
+		const toast = page.getByText('E2E toast over modal');
+		await expect(toast).toBeVisible();
+
+		// Stacking check: the element hit-tested at the toast's own centre must belong to
+		// the ToastHost subtree (`[data-toast-host]`). That the toast host is the top-most
+		// hit — rather than the dialog's backdrop/content — proves the toast paints above
+		// the modal, which is the whole point of #523.
+		const hitInsideHost = await toast.evaluate((el) => {
+			const rect = el.getBoundingClientRect();
+			const cx = rect.left + rect.width / 2;
+			const cy = rect.top + rect.height / 2;
+			const hit = document.elementFromPoint(cx, cy);
+			return !!hit?.closest('[data-toast-host]');
+		});
+
+		expect(hitInsideHost).toBe(true);
+	});
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -58,6 +58,7 @@ export default defineConfig({
 				'tests/item-upload.spec.ts',
 				'tests/trust.spec.ts',
 				'tests/feedback.spec.ts',
+				'tests/toast-over-modal.spec.ts',
 			],
 		},
 		{

--- a/src/lib/components/ToastHost.svelte
+++ b/src/lib/components/ToastHost.svelte
@@ -17,13 +17,86 @@
 		error: 'red',
 		warn: 'yellow',
 	};
+
+	// A body-level fixed overlay can't beat a modal <dialog>: the dialog's full-viewport
+	// ::backdrop paints above everything outside the dialog (even the Popover top-layer
+	// trick — the backdrop still wins). The one thing that paints above the backdrop is a
+	// node *nested inside the open dialog*. So we portal this container into the topmost
+	// open modal dialog while one is open, and keep it at <body> level otherwise. The
+	// target depends only on which modals are OPEN (not on toasts), so relocation is keyed
+	// to modal open/close via a single document-level observer — not to toast add/remove.
+	let containerEl = $state<HTMLDivElement>();
+
+	// Open modal dialogs in the order they entered the top layer (showModal order): the LAST
+	// entry is the topmost. DOM order is NOT reliable for stacked modals, so we maintain order
+	// explicitly (append when a dialog becomes :modal, drop when it closes/detaches). Plain
+	// `let` — never read reactively, only mutated inside these DOM callbacks.
+	let openModalOrder: HTMLDialogElement[] = [];
+
+	// Move the host under the topmost open modal dialog, or back to <body> when none is open.
+	// Only touches the DOM when the parent actually changes, so it's idempotent.
+	function relocate(): void {
+		if (!containerEl) return;
+		const target: HTMLElement = openModalOrder[openModalOrder.length - 1] ?? document.body;
+		if (containerEl.parentElement !== target) target.appendChild(containerEl);
+	}
+
+	// Rebuild the open-order list from the DOM (pruning closed/detached dialogs but preserving
+	// the order of those still open, appending newly opened ones), then relocate.
+	function refresh(): void {
+		let open: HTMLDialogElement[] = [];
+		try {
+			open = [...document.querySelectorAll<HTMLDialogElement>('dialog:modal')];
+		} catch {
+			open = []; // browser without the `:modal` selector → treat as no modal (body host)
+		}
+		const openSet = new Set(open);
+		openModalOrder = openModalOrder.filter((d) => openSet.has(d));
+		for (const d of open) if (!openModalOrder.includes(d)) openModalOrder.push(d);
+		relocate();
+	}
+
+	// True when a mutation record actually concerns a <dialog> — an `open` attribute flip on a
+	// <dialog> (note <details> also carries `open`, so match the tag, not just the attr name),
+	// or a <dialog> added/removed (possibly nested inside an inserted/removed subtree). Lets us
+	// skip the querySelector pass on the unrelated DOM churn a body-subtree observer sees.
+	function isDialogMutation(record: MutationRecord): boolean {
+		if (record.type === 'attributes') {
+			return record.target instanceof HTMLElement && record.target.tagName === 'DIALOG';
+		}
+		return [...record.addedNodes, ...record.removedNodes].some(
+			(n) => n instanceof HTMLElement && (n.tagName === 'DIALOG' || !!n.querySelector('dialog')),
+		);
+	}
+
+	// A single document-level observer catches EVERY modal open (`open` attr added), close
+	// (`open` removed / `close` event flips it), and removal (childList). Refreshing only on a
+	// mutation that involves a <dialog> keeps the querySelector work rare on a busy DOM.
+	$effect(() => {
+		const observer = new MutationObserver((records) => {
+			if (records.some(isDialogMutation)) refresh();
+		});
+		observer.observe(document.body, {
+			subtree: true,
+			childList: true,
+			attributes: true,
+			attributeFilter: ['open'],
+		});
+		refresh(); // initial placement on mount
+		return () => observer.disconnect();
+	});
 </script>
 
 <!-- Fixed, bottom-centred stack that overlays the app so feedback is always visible
      without scrolling back up. The container is a persistent (always-mounted) polite
      live region so success/info toasts inserted into it are reliably announced; error
-     toasts additionally carry role="alert" so they interrupt (assertive). -->
+     toasts additionally carry role="alert" so they interrupt (assertive). It is portalled
+     into the topmost open modal dialog while one is open (see the script) so toasts paint
+     above the dialog's ::backdrop; the Tailwind fixed positioning keeps it bottom-centred
+     regardless of which parent it currently lives under. -->
 <div
+	bind:this={containerEl}
+	data-toast-host
 	class="fixed inset-x-0 bottom-4 z-50 flex flex-col items-center gap-2 px-4 pointer-events-none sm:bottom-6"
 	aria-live="polite"
 	aria-atomic="false"

--- a/src/lib/components/ToastHost.test.ts
+++ b/src/lib/components/ToastHost.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'svelte/server';
+import ToastHost from './ToastHost.svelte';
+
+describe('ToastHost', () => {
+	// Attribute-level check only: the container must carry the stable `data-toast-host`
+	// relocation hook (#523 — it's portalled into open modal dialogs so toasts paint above
+	// the dialog backdrop) and be a persistent polite live region. SSR render is used
+	// deliberately — the portal $effect never runs server-side, and jsdom has no modal
+	// dialog / ::backdrop to exercise the relocation anyway.
+	it('renders the container with the data-toast-host hook as a polite live region', () => {
+		const html = render(ToastHost).body;
+		expect(html).toContain('data-toast-host');
+		expect(html).toContain('aria-live="polite"');
+	});
+});


### PR DESCRIPTION
## What & why

`pushToast` / `ToastHost` rendered as a body-level `position: fixed` overlay with `z-index: 50`. Flowbite's `Modal` is a native `<dialog>` opened via `showModal()`, whose full-viewport `::backdrop` lives in the browser **top layer** and paints above *any* z-indexed content. So a toast fired while a modal was open was swallowed behind the modal + backdrop.

A `popover`-based top-layer hoist does **not** fix this: verified in Chrome 150 (isolated repro) that a modal dialog's `::backdrop` paints above a `popover="manual"` regardless of insertion order — a click at the toast's position even lands on the backdrop and closes the modal. The one thing that reliably paints above the backdrop is a node **nested inside the open dialog**.

## Approach

Portal the `ToastHost` container into the topmost open modal `<dialog>` while one is open (where it paints above the backdrop), and keep it at `<body>` level otherwise. Relocation is driven by a single document-level `MutationObserver` keyed to modal **open/close** (not to toast state), tracking true **open-order** so stacked modals target the actually-topmost dialog. The host is moved in at modal-open time (while empty), so a later toast is a pure in-place mutation on the already-stable `aria-live` region and is announced normally.

Existing non-modal behaviour is unchanged: bottom placement, `MAX_TOASTS` cap, auto-dismiss, `aria-live="polite"` / `role="alert"` on errors.

## Test notes

- Preflight: `npm run lint` clean; `npx vitest run` **720/720 pass**. `npm run check` / `npm run build` fail only on the 6 pre-existing `$env/static/private` sync-var errors (`SYNC_SECRET`, `PB_SUPERUSER_EMAIL`, `PB_SUPERUSER_PASSWORD`) unrelated to this diff (values present in CI/prod).
- New `src/lib/components/ToastHost.test.ts` (SSR: container carries `data-toast-host` + `aria-live="polite"`).
- New e2e `e2e/tests/toast-over-modal.spec.ts` (authenticated project): opens the real feedback modal, pushes a toast, asserts `document.elementFromPoint` at the toast center resolves inside `[data-toast-host]` — the toast wins the hit-test over the modal backdrop.
- Manual browser verification (Chrome DevTools MCP): toast visible above modal (both push-after-open and modal-opens-over-existing-toast), returns to body on modal close without vanishing, non-modal stacking/auto-dismiss unaffected, console/network clean.

Closes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)