### PR TITLE
chore: align Claude Code setup with best practices

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,10 +6,10 @@ detailed docs/skills that load on demand. Read the linked doc before structural 
 
 ## Project overview
 
-**AllerLeih** is an item-sharing platform. Users list items to share or lend and browse/request others'. 
-The platform's purpose is to provide free and open-source infrastructure for the sharing economy. 
-It integrates peer-2-peer-lending as well as institutional lending (either directly on the platform for small institutions or via integrations).
-**The UI is entirely in German.**
+**AllerLeih** is an item-sharing platform. Users list items to share or lend and browse/request
+others'. It integrates peer-2-peer lending as well as institutional lending (directly on the
+platform for small institutions, or via integrations — see `docs/integrations.md` and `README.md`
+for the mission/milestones). **The UI is entirely in German.**
 
 ## Tech stack
 
@@ -58,6 +58,8 @@ Required in `.env` (see `docs/architecture.md` for what each does; template: `.e
 `PUBLIC_PB_URL`, `PUBLIC_VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`, `ORS_API_KEY`,
 `MISTRAL_API_KEY` (prod only). Integration sync (`/api/sync`, `/api/refresh`; see
 `docs/operations/integration-sync.md`): `SYNC_SECRET`, `PB_SUPERUSER_EMAIL`, `PB_SUPERUSER_PASSWORD`.
+For personal local overrides (local ports, sandbox creds) that shouldn't be shared with the team,
+use a gitignored `CLAUDE.local.md` at the repo root — it loads alongside this file.
 
 ## Guardrails (always apply)
 
@@ -122,6 +124,7 @@ These prevent the most common bugs/security issues here — follow them without 
 | Push notifications (VAPID helpers, subscription CRUD, service worker) | `docs/architecture.md` → "Real-time Architecture"; helpers in `$lib/server/notifications.ts`, `$lib/server/pushSubscriptions.ts` |
 | Business metrics (`/admin/metrics`, `/misc/stats`, the nightly `metrics_daily` snapshot) | `docs/operations/metrics.md`; helper in `$lib/server/metrics.ts` |
 | Institutional onboarding & other runbooks | `docs/operations/` |
+| A backend-only issue (no frontend changes) | Still drive it through `/issue-to-pr` + `/create-pr` **here** — the plan gate and review dispatch (`sveltekit-pb-reviewer` covers `pb_hooks`/`pb_migrations`) live in this repo. The backend also has its own `allerleih-backend/.claude/skills/create-pr` for standalone use when working in that repo alone. |
 
 ## Project tooling (this repo's `.claude/`)
 

--- a/.claude/agents/allerleih-coder.md
+++ b/.claude/agents/allerleih-coder.md
@@ -1,5 +1,6 @@
 ---
 name: allerleih-coder
+model: sonnet
 description: Expert implementation agent for the AllerLeih platform — SvelteKit 2 + Svelte 5 (runes) frontend and PocketBase (JS hooks + migrations) backend, German UI. Use to implement an approved plan or a well-scoped code change across the frontend and/or backend, honouring every project guardrail and using the project skills + Svelte MCP + Context7. Does NOT commit, push, or open PRs — that is the orchestrator's job.
 ---
 

--- a/.claude/hooks/block-env-stage.js
+++ b/.claude/hooks/block-env-stage.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+// PreToolUse hook: refuse Bash commands that `git add` the real .env file (secrets), as a
+// deterministic backstop on top of .gitignore.
+let input = ''
+process.stdin.on('data', (d) => (input += d))
+process.stdin.on('end', () => {
+  let payload
+  try {
+    payload = JSON.parse(input)
+  } catch {
+    process.exit(0)
+  }
+
+  const command = (payload.tool_input && payload.tool_input.command) || ''
+  const stagesEnv =
+    /\bgit\s+add\b/.test(command) &&
+    /(^|[\s"'])\.env(\s|["'`]|$)/.test(command) &&
+    !/\.env\.(example|sample|template)\b/.test(command)
+
+  if (!stagesEnv) process.exit(0)
+
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason:
+          'Refusing to stage .env — it holds real secrets/credentials. Stage it yourself outside Claude Code if this is genuinely intentional.',
+      },
+    })
+  )
+  process.exit(0)
+})

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,5 +20,18 @@
       "Bash(gh pr list *)",
       "Bash(gh pr diff *)"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR}/.claude/hooks/block-env-stage.js\""
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ dist
 !.env.example
 .vscode
 .claude/worktrees
-.claude/CLAUDE.md
+CLAUDE.local.md
 
 # Playwright e2e
 /test-results/


### PR DESCRIPTION
## Summary
- Removed the dead `.claude/CLAUDE.md` line from `.gitignore` — the file is already tracked (added before the ignore rule was), so the entry only misleads readers into thinking it's not team-shared; it is, and stays tracked.
- Added a `PreToolUse` hook blocking `git add` of the real `.env` file, as a deterministic backstop on top of `.gitignore`.
- Noted in `CLAUDE.md` that backend-only issues should still be driven via `/issue-to-pr` + `/create-pr` **here** (the plan gate and `sveltekit-pb-reviewer` already cover `pb_hooks`/`pb_migrations` diffs), and pointed at the backend's own new `/create-pr` skill for standalone backend-repo use.
- Documented the `CLAUDE.local.md` convention for personal local overrides (added to `.gitignore`).
- Pinned `model: sonnet` on the `allerleih-coder` implementation agent, matching the explicit model choice already made for every reviewer/tester agent.

Companion PR in `allerleih-backend`: (opening alongside this one)

## Test plan
- [x] Smoke-tested the `.env`-staging hook logic against sample `tool_input` payloads
- [x] `node -e "JSON.parse(...)"` on `.claude/settings.json` (valid JSON)
- [ ] No app code changed — `npm run lint`/`check`/`test`/`build` not required, but worth a sanity run if reviewing

🤖 Generated with [Claude Code](https://claude.com/claude-code)