### PR TITLE
Consolidate search filters into a single Filter modal

### DIFF
--- a/docs/search-discovery.md
+++ b/docs/search-discovery.md
@@ -10,27 +10,36 @@ URL search params
    │  parseSearchParameters()        searchFilter.ts
    ▼
 SearchParameters  ──buildItemFilter()──►  PocketBase filter string
-   │                                          │
-   ▼                                          ▼
+   │                        │
+   │                        └─ sort ──sortToPbSort()──►  PocketBase sort string
+   ▼
 +page.server.ts load()  ──getList(page, perPage, { sort, filter })──►  items_searchable view
    │
    ▼
-+page.svelte  ──►  ResultsList → ItemCard      (+ Pagination, CategoryFilter, TravelTimeFilter)
++page.svelte  ──►  ResultsList → ItemCard   (+ Pagination, TravelTimeFilter, FilterModal)
 ```
 
 ## Pieces
 
 | Concern | File | Notes |
 |---|---|---|
-| Parse & validate URL params | [`searchFilter.ts`](../src/routes/search/searchFilter.ts) `parseSearchParameters` | Returns a fully-typed `SearchParameters`; clamps `page`/`perPage`, drops unknown categories. |
+| Parse & validate URL params | [`searchFilter.ts`](../src/routes/search/searchFilter.ts) `parseSearchParameters` | Returns a fully-typed `SearchParameters`; clamps `page`/`perPage`, drops unknown categories/sort values. |
 | Build the PB filter | [`searchFilter.ts`](../src/routes/search/searchFilter.ts) `buildItemFilter` / `buildSearchFilter` | Combines name, owner-exclusion, categories, availability, owner-type and group with `&&`. |
-| Server load | [`+page.server.ts`](../src/routes/search/+page.server.ts) | Reads the `items_searchable` view, sorts, paginates, logs non-empty queries. |
-| Page shell + client filters | [`+page.svelte`](../src/routes/search/+page.svelte) | Wires search bar, filters, results, pagination. |
+| Map sort → PB sort string | [`searchFilter.ts`](../src/routes/search/searchFilter.ts) `sortToPbSort` | `newest` → `-created` (default), `name_asc` → `name`, `name_desc` → `-name`. |
+| Server load | [`+page.server.ts`](../src/routes/search/+page.server.ts) | Reads the `items_searchable` view, sorts (via `sortToPbSort`), paginates, logs non-empty queries. |
+| Page shell | [`+page.svelte`](../src/routes/search/+page.svelte) | Wires search bar, the filter trigger + `TravelTimeFilter`, results, pagination. |
 | Results grid | [`ResultsList.svelte`](../src/routes/search/ResultsList.svelte) → [`ItemCard.svelte`](../src/routes/search/ItemCard.svelte) | Takes an `ItemPublic[]` and renders cards. |
-| Pagination UI | [`Pagination.svelte`](../src/routes/search/Pagination.svelte) | Page buttons + per-page selector; a GET form so no `goto()` is needed. |
+| Pagination UI | [`Pagination.svelte`](../src/routes/search/Pagination.svelte) | Page buttons + per-page selector; a GET form so no `goto()` is needed. Threads `sort` alongside the other params. |
 | URL building | [`searchUrl.ts`](../src/routes/search/searchUrl.ts) `buildSearchUrl` | Single source of truth for constructing `/search?...` links. |
-| Travel-time filter | [`TravelTimeFilter.svelte`](../src/routes/search/TravelTimeFilter.svelte) | Client-side; filters/sorts the **current page** by bucketed minutes (see below). |
-| Group filter | [`GroupFilter.svelte`](../src/routes/search/GroupFilter.svelte) | Single-select dropdown of the user's groups; navigates via `buildSearchUrl`. Rendered only when the user has groups (guests never see it). |
+| Consolidated filter trigger + modal | [`FilterModal.svelte`](../src/routes/search/FilterModal.svelte) | Opened from a "Filter" button (with an active-filter-count badge counting only what's settable inside the modal: Verfügbarkeit / Anbieter / Kategorien / Gruppe) on the search page. Holds Sortierung / Verfügbarkeit / Anbieter / Kategorien / Gruppe as local draft `$state`, seeded from the current (URL-derived) props whenever it opens. Nothing navigates until "Filter anwenden", which does one `buildSearchUrl` + `goto()` call committing every draft field at once; "Zurücksetzen" only resets the draft to app defaults, it does not navigate or close the modal. |
+| Generic segmented control | [`SegmentedControl.svelte`](../src/lib/components/ui/SegmentedControl.svelte) | Reusable `options[]` + bindable `value` pill-group primitive; used for the Anbieter control and the modal's sort options. |
+| Travel-time filter | [`TravelTimeFilter.svelte`](../src/routes/search/TravelTimeFilter.svelte) | Rendered inline next to Filter/Sort, not inside the modal. Client-side; filters/sorts the **current page** by bucketed minutes (see below). Its state (`transportMode`/`travelTimes`/`maxMinutes`) lives in `+page.svelte` and was never URL state; the slider itself is its own reset (drag back to the 30 min "no limit" default). |
+| Category filter | [`CategoryFilter.svelte`](../src/routes/search/CategoryFilter.svelte) | Rendered inside the modal's Kategorien section. Chip grid + AND/OR toggle; binds to the modal's draft state (`selectedCategories`/`op`) instead of navigating itself. |
+| Group filter | [`GroupFilter.svelte`](../src/routes/search/GroupFilter.svelte) | Rendered inside the modal's Gruppe section (only when the user has groups; guests never see it). Single-select dropdown of the user's groups; binds to the modal's draft state instead of navigating itself. |
+
+> **Deferred:** Bezirke, Sprachen and max. Leihdauer filters are intentionally not in the modal —
+> there are no backend fields for them yet. Adding them needs a schema change first (coordinate
+> via the `/schema-change` skill) before any filter UI is built.
 
 ## Which view it reads
 
@@ -57,6 +66,7 @@ All discovery state lives in the URL (deep-linkable, server-rendered). Defaults 
 | `onlyAvailable` | `true` (default); `false` includes unavailable items |
 | `ownerType` | `all` (default) / `institution` / `private` |
 | `group` | a single group id — restrict results to items shared with that group. Only groups the requester owns or is a member of are accepted (see the security note below); anything else is silently dropped |
+| `sort` | `newest` (default) / `name_asc` / `name_desc` — mapped to a PocketBase sort string by `sortToPbSort`. Omitted from the URL at the default; an unrecognised value falls back to `newest`. |
 | `page` (1), `perPage` (20, max 50) | pagination |
 
 ### Group filter (`group`) — security

--- a/src/lib/components/ui/SegmentedControl.svelte
+++ b/src/lib/components/ui/SegmentedControl.svelte
@@ -16,21 +16,39 @@
 
 	let { options, value = $bindable(), onchange, label, class: className = '' }: Props = $props();
 
+	// Roving tabindex + arrow-key selection, per the WAI-ARIA radio-group pattern: the group is a
+	// single Tab stop (only the checked radio is tabbable), and Arrow keys move focus *and*
+	// selection between options.
+	let buttons = $state<HTMLButtonElement[]>([]);
+
 	function select(next: T) {
 		value = next;
 		onchange?.(next);
 	}
+
+	function onKeydown(event: KeyboardEvent, index: number) {
+		const forward = event.key === 'ArrowRight' || event.key === 'ArrowDown';
+		const backward = event.key === 'ArrowLeft' || event.key === 'ArrowUp';
+		if (!forward && !backward) return;
+		event.preventDefault();
+		const delta = forward ? 1 : -1;
+		const nextIndex = (index + delta + options.length) % options.length;
+		select(options[nextIndex].value);
+		buttons[nextIndex]?.focus();
+	}
 </script>
 
-<!-- Roving tabindex / arrow-key navigation intentionally out of scope for this fix. -->
 <div role="radiogroup" aria-label={label} class="inline-flex flex-wrap gap-2 {className}">
-	{#each options as option (option.value)}
+	{#each options as option, index (option.value)}
 		{@const active = option.value === value}
 		<button
+			bind:this={buttons[index]}
 			type="button"
 			role="radio"
 			aria-checked={active}
+			tabindex={active ? 0 : -1}
 			onclick={() => select(option.value)}
+			onkeydown={(event) => onKeydown(event, index)}
 			class="rounded-full border px-3 py-1 text-sm font-medium transition-colors cursor-pointer
 				{active
 				? 'bg-primary border-primary text-white'

--- a/src/lib/components/ui/SegmentedControl.svelte
+++ b/src/lib/components/ui/SegmentedControl.svelte
@@ -1,0 +1,42 @@
+<script lang="ts" generics="T extends string">
+	interface Option {
+		value: T;
+		label: string;
+	}
+
+	interface Props {
+		options: Option[];
+		value: T;
+		onchange?: (value: T) => void;
+		/** Accessible name for the group (visually hidden if no visible legend is nearby). */
+		label: string;
+		/** Nur Layout-Klassen (Breite, Abstand, Positionierung) — nie Farben. */
+		class?: string;
+	}
+
+	let { options, value = $bindable(), onchange, label, class: className = '' }: Props = $props();
+
+	function select(next: T) {
+		value = next;
+		onchange?.(next);
+	}
+</script>
+
+<!-- Roving tabindex / arrow-key navigation intentionally out of scope for this fix. -->
+<div role="radiogroup" aria-label={label} class="inline-flex flex-wrap gap-2 {className}">
+	{#each options as option (option.value)}
+		{@const active = option.value === value}
+		<button
+			type="button"
+			role="radio"
+			aria-checked={active}
+			onclick={() => select(option.value)}
+			class="rounded-full border px-3 py-1 text-sm font-medium transition-colors cursor-pointer
+				{active
+				? 'bg-primary border-primary text-white'
+				: 'border-tinte-300 bg-papier text-tinte-700 hover:border-primary hover:text-primary dark:border-tinte-600 dark:bg-tinte-800 dark:text-tinte-300 dark:hover:border-primary dark:hover:text-primary'}"
+		>
+			{option.label}
+		</button>
+	{/each}
+</div>

--- a/src/lib/components/ui/SegmentedControl.test.ts
+++ b/src/lib/components/ui/SegmentedControl.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'svelte/server';
+import SegmentedControl from './SegmentedControl.svelte';
+
+const options = [
+	{ value: 'all', label: 'Alle' },
+	{ value: 'institution', label: 'Institutionen' },
+	{ value: 'private', label: 'Personen' },
+];
+
+function renderControl(props: Record<string, unknown> = {}) {
+	return render(SegmentedControl, {
+		props: { options, value: 'all', label: 'Anbieter', ...props },
+	}).body;
+}
+
+describe('SegmentedControl', () => {
+	it('renders one button per option with its label', () => {
+		const html = renderControl();
+		expect(html).toContain('Alle');
+		expect(html).toContain('Institutionen');
+		expect(html).toContain('Personen');
+	});
+
+	it('marks the active option with aria-checked="true" and the rest false', () => {
+		const html = renderControl({ value: 'institution' });
+		const buttons = html.split('<button').slice(1);
+		expect(buttons[0]).toContain('aria-checked="false"'); // Alle
+		expect(buttons[1]).toContain('aria-checked="true"'); // Institutionen
+		expect(buttons[2]).toContain('aria-checked="false"'); // Personen
+	});
+
+	it('applies the active styling classes only to the selected option', () => {
+		const html = renderControl({ value: 'private' });
+		const buttons = html.split('<button').slice(1);
+		expect(buttons[2]).toContain('bg-primary');
+		expect(buttons[0]).not.toContain('bg-primary');
+	});
+
+	it('exposes an accessible group label', () => {
+		const html = renderControl({ label: 'Anbieter' });
+		expect(html).toContain('role="radiogroup"');
+		expect(html).toContain('aria-label="Anbieter"');
+	});
+});

--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -235,6 +235,7 @@ export const texts = {
 		offerSomething: 'Biete selbst etwas an!',
 		newsletter: 'Für Newsletter registrieren',
 		search: 'Suchen',
+		clearSearch: 'Suche zurücksetzen',
 	},
 
 	// Groups feature

--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -235,7 +235,6 @@ export const texts = {
 		offerSomething: 'Biete selbst etwas an!',
 		newsletter: 'Für Newsletter registrieren',
 		search: 'Suchen',
-		showAll: 'Alles anzeigen',
 	},
 
 	// Groups feature
@@ -663,6 +662,7 @@ export const texts = {
 				maxMinutes: (n: number) => `<${n} min`,
 				paginationHidden:
 					'Entfernungsfilter aktiv – nur die aktuelle Seite wird gefiltert. Setze das Limit auf >30 min", um alle Seiten zu sehen.',
+				sliderLabel: 'Maximale Reisezeit in Minuten',
 			},
 			categoryFilterAnd: 'Alle Kategorien erfüllen (UND-Filter)',
 			perPage: 'Pro Seite:',
@@ -676,6 +676,24 @@ export const texts = {
 			ownerTypePrivate: 'Personen',
 			groupFilterLabel: 'Gruppe',
 			groupFilterAll: 'Alle Gruppen',
+			// Filter trigger button + modal (issue #505: consolidated filter modal)
+			filterButton: 'Filter',
+			filterButtonActive: (count: number) => `Filter (${count})`,
+			sortLabel: 'Sortierung',
+			sortOptions: {
+				newest: 'Neueste zuerst',
+				name_asc: 'Name A–Z',
+				name_desc: 'Name Z–A',
+			} as Record<string, string>,
+			filterModalTitle: 'Filter',
+			filterSectionAvailability: 'Verfügbarkeit',
+			filterAvailabilitySubtext: 'Zeigt nur Dinge, die aktuell verliehen werden können.',
+			filterSectionOwnerType: 'Anbieter',
+			filterSectionDistance: 'Entfernung',
+			filterSectionCategories: 'Kategorien',
+			filterSectionGroup: 'Gruppen',
+			filterReset: 'Zurücksetzen',
+			filterApply: 'Filter anwenden',
 		},
 		logout: {
 			message: 'Ausloggen...',

--- a/src/routes/search/+page.server.ts
+++ b/src/routes/search/+page.server.ts
@@ -1,6 +1,6 @@
 import { PUBLIC_PB_URL } from '../../hooks.server';
 import type { ItemPublic } from '$lib/types/models';
-import { parseSearchParameters, buildItemFilter, type SearchParameters } from './searchFilter';
+import { parseSearchParameters, buildItemFilter, sortToPbSort, type SearchParameters } from './searchFilter';
 import type { ListResult } from 'pocketbase';
 import { upsertUserPreferences } from '$lib/server/userPreferences';
 import { getAttachableGroups } from '$lib/server/groups';
@@ -28,12 +28,12 @@ export async function load({ locals, url }) {
 	// 3. Build PocketBase filter (group clause only present for a membership-validated id above)
 	const filter = buildItemFilter(searchParameters, locals.user?.id);
 
-	// 4. Fetch paginated items, newest listings first (by creation date, so edits don't
-	//    resurface old items). Empty-query browsing shows the same newest-first catalogue.
+	// 4. Fetch paginated items, sorted per `searchParameters.sort` (defaults to newest-first by
+	//    creation date, so edits don't resurface old items).
 	let result: ListResult<ItemPublic> = { page: 1, perPage: searchParameters.perPage, totalItems: 0, totalPages: 0, items: [] };
 	try {
 		result = await locals.pb.collection('items_searchable').getList<ItemPublic>(searchParameters.page, searchParameters.perPage, {
-			sort: '-created',
+			sort: sortToPbSort(searchParameters.sort),
 			filter,
 			// Explicit allowlist: the view carries an `items.groups` column purely so
 			// its row-level rule can traverse group membership; it must NOT be returned
@@ -66,6 +66,7 @@ export async function load({ locals, url }) {
 		onlyAvailable: searchParameters.onlyAvailable,
 		ownerType: searchParameters.ownerType,
 		selectedGroup: searchParameters.selectedGroup,
+		sort: searchParameters.sort,
 		// Only id + name reach the client — never the `groups` column of items.
 		attachableGroups: attachableGroups.map(({ id, name }) => ({ id, name })),
 		currentUser: locals.user ?? null,

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -11,11 +11,10 @@
 	import { FilterOutline } from 'flowbite-svelte-icons';
 	import { texts } from '$lib/texts';
 	import { buildSearchUrl } from './searchUrl';
-	import type { SortOption } from './searchFilter';
+	import type { OwnerType, FilterDraft } from './searchFilter';
 	import SeoHead from '$lib/components/SeoHead.svelte';
 
 	type TransportMode = 'foot' | 'bicycle' | 'car';
-	type OwnerType = 'all' | 'institution' | 'private';
 
 	const { data } = $props();
 
@@ -41,14 +40,7 @@
 			(data.selectedGroup ? 1 : 0)
 	);
 
-	function handleApply(draft: {
-		sort: SortOption;
-		onlyAvailable: boolean;
-		ownerType: OwnerType;
-		selectedCategories: string[];
-		op: 'or' | 'and';
-		selectedGroup: string | null;
-	}) {
+	function handleApply(draft: FilterDraft) {
 		filterModalOpen = false;
 		// Single navigation commits every draft field at once; page resets to default (omitted).
 		goto(
@@ -133,9 +125,9 @@
 <!-- HEADER -->
 <div class="mx-auto max-w-7xl">
 	<div class="mx-auto max-w-screen-sm text-center">
-		<h3 class="text-2xl tracking-tight font-extrabold text-tinte-900 dark:text-white">
+		<h2 class="text-2xl tracking-tight font-extrabold text-tinte-900 dark:text-white">
 			{texts.pages.search.title}
-		</h3>
+		</h2>
 	</div>
 </div>
 
@@ -166,14 +158,13 @@
 		onApply={handleApply}
 	/>
 
-	<!-- Commenting this out to try if the cleaner approach is better, maybe reintroduce later -->
-	<!-- <div class="w-full items-center justify-center text-center mt-2">
+	<div class="w-full items-center justify-center text-center mt-2" aria-live="polite">
 		{#if data.q || data.selectedCategories.length > 0 || data.selectedGroup}
-			<h5>{texts.ui.resultsFound(filterActive ? filteredItems.length : data.totalItems ?? 0)}</h5>
+			<h5>{texts.ui.resultsFound(filterActive ? filteredItems.length : (data.totalItems ?? 0))}</h5>
 		{:else}
 			<h5>{texts.pages.search.newestItemsHeading}</h5>
 		{/if}
-	</div> -->
+	</div>
 
 	{@render paginationControls()}
 

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -1,18 +1,21 @@
 <script lang="ts">
 	/* eslint-disable svelte/no-navigation-without-resolve */
+	import { goto } from '$app/navigation';
 	import { Section } from 'flowbite-svelte-blocks';
 	import SearchBar from './SearchBar.svelte';
 	import ResultsList from './ResultsList.svelte';
 	import Pagination from './Pagination.svelte';
-	import CategoryFilter from './CategoryFilter.svelte';
-	import GroupFilter from './GroupFilter.svelte';
+	import FilterModal from './FilterModal.svelte';
 	import TravelTimeFilter from './TravelTimeFilter.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import { FilterOutline } from 'flowbite-svelte-icons';
 	import { texts } from '$lib/texts';
-	import { ArrowsRepeatOutline } from 'flowbite-svelte-icons';
 	import { buildSearchUrl } from './searchUrl';
+	import type { SortOption } from './searchFilter';
 	import SeoHead from '$lib/components/SeoHead.svelte';
 
 	type TransportMode = 'foot' | 'bicycle' | 'car';
+	type OwnerType = 'all' | 'institution' | 'private';
 
 	const { data } = $props();
 
@@ -23,19 +26,44 @@
 	let transportMode = $state<TransportMode | null>(null);
 	let travelTimes = $state<Record<string, number>>({});
 	let maxMinutes = $state(30);
+	let filterModalOpen = $state(false);
 
 	const filterActive = $derived(maxMinutes < 30 && Object.keys(travelTimes).length > 0);
 
-	function searchUrl(overrides: { onlyAvailable?: boolean; ownerType?: string } = {}): string {
-		return buildSearchUrl({
-			q: data.q,
-			cats: data.selectedCategories,
-			op: data.op,
-			onlyAvailable: overrides.onlyAvailable ?? data.onlyAvailable,
-			ownerType: overrides.ownerType ?? data.ownerType,
-			group: data.selectedGroup ?? undefined,
-		});
+	// Active-filter count for the trigger button's badge. Only counts what's settable inside the
+	// modal — Entfernung lives inline with its own visible active state, so counting it here too
+	// would double-count. Sort isn't counted (it's an ordering preference, not a constraint on the
+	// result set).
+	const activeFilterCount = $derived(
+		(data.onlyAvailable ? 1 : 0) +
+			(data.ownerType !== 'all' ? 1 : 0) +
+			(data.selectedCategories.length > 0 ? 1 : 0) +
+			(data.selectedGroup ? 1 : 0)
+	);
+
+	function handleApply(draft: {
+		sort: SortOption;
+		onlyAvailable: boolean;
+		ownerType: OwnerType;
+		selectedCategories: string[];
+		op: 'or' | 'and';
+		selectedGroup: string | null;
+	}) {
+		filterModalOpen = false;
+		// Single navigation commits every draft field at once; page resets to default (omitted).
+		goto(
+			buildSearchUrl({
+				q: data.q,
+				sort: draft.sort,
+				onlyAvailable: draft.onlyAvailable,
+				ownerType: draft.ownerType,
+				cats: draft.selectedCategories,
+				op: draft.op,
+				group: draft.selectedGroup ?? undefined,
+			})
+		);
 	}
+
 	const filteredItems = $derived.by(() => {
 		const items = filterActive
 			? (data.items ?? []).filter((item) => {
@@ -59,6 +87,28 @@
 
 <SeoHead title={texts.seo.search.title} description={texts.seo.search.description} />
 
+{#snippet filterSlot()}
+	<Button
+		variant="primary"
+		onclick={() => (filterModalOpen = true)}
+		class="shrink-0"
+		aria-label={activeFilterCount > 0
+			? texts.pages.search.filterButtonActive(activeFilterCount)
+			: texts.pages.search.filterButton}
+	>
+		<span class="relative inline-flex items-center">
+			<FilterOutline class="shrink-0 h-6 w-6" />
+			{#if activeFilterCount > 0}
+				<span
+					class="absolute -top-2 -right-3 min-w-[1.1rem] h-[1.1rem] bg-primary text-white text-[10px] font-bold rounded-full flex items-center justify-center px-0.5 leading-none"
+				>
+					{activeFilterCount}
+				</span>
+			{/if}
+		</span>
+	</Button>
+{/snippet}
+
 {#snippet paginationControls()}
 	{#if filterActive}
 		<p class="text-center text-sm text-tinte-500 mt-2">
@@ -75,88 +125,55 @@
 			onlyAvailable={data.onlyAvailable}
 			ownerType={data.ownerType}
 			group={data.selectedGroup}
+			sort={data.sort}
 		/>
 	{/if}
 {/snippet}
 
 <!-- HEADER -->
-<div class="px-4 mx-auto max-w-7xl">
+<div class="mx-auto max-w-7xl">
 	<div class="mx-auto max-w-screen-sm text-center">
-		<h2 class="text-2xl tracking-tight font-extrabold text-tinte-900 dark:text-white">
+		<h3 class="text-2xl tracking-tight font-extrabold text-tinte-900 dark:text-white">
 			{texts.pages.search.title}
-		</h2>
+		</h3>
 	</div>
 </div>
 
-<Section class="max-w-5xl mx-auto py-0">
-	<SearchBar q={data.q} />
+<Section class="max-w-5xl mx-auto py-0 xs:py-0">
+	<SearchBar q={data.q} {filterSlot} />
 
-	<CategoryFilter
-		selectedCategories={data.selectedCategories}
-		op={data.op}
-		q={data.q}
-		perPage={data.perPage}
-		onlyAvailable={data.onlyAvailable}
-		ownerType={data.ownerType}
-		group={data.selectedGroup}
-	/>
-
-
-
-	<hr class="border-tinte-300 max-w-100! my-2 mx-auto"/>
-
-	{@const ownerTypeNext = { all: 'institution', institution: 'private', private: 'all' } as const}
-	{@const ownerTypeLabel = {
-		all: texts.pages.search.ownerTypeAll,
-		institution: texts.pages.search.ownerTypeInstitution,
-		private: texts.pages.search.ownerTypePrivate,
-	} as const}
-
-	<div class="flex flex-wrap justify-center items-center gap-1 my-3">
-		<a
-			href={searchUrl({ onlyAvailable: !data.onlyAvailable })}
-			class="rounded-full border px-3 py-1 text-sm font-medium transition-colors
-				{data.onlyAvailable
-				? 'bg-primary border-primary text-white'
-				: 'border-tinte-300 bg-papier text-tinte-700 hover:border-primary hover:text-primary dark:border-tinte-600 dark:bg-tinte-800 dark:text-tinte-300 dark:hover:border-primary dark:hover:text-primary'}"
-		>{texts.pages.search.onlyAvailable}</a>
-
-		<a
-			href={searchUrl({ ownerType: ownerTypeNext[data.ownerType as keyof typeof ownerTypeNext] })}
-			class="flex items-center rounded-full border px-3 py-1 text-sm font-medium transition-colors border-tinte-300 bg-papier text-tinte-700 hover:border-primary hover:text-primary dark:border-tinte-600 dark:bg-tinte-800 dark:text-tinte-300 dark:hover:border-primary dark:hover:text-primary"
-		><ArrowsRepeatOutline class="mr-1 h-4 w-4 shrink-0" />{texts.pages.search.ownerTypePrefix}: {ownerTypeLabel[data.ownerType as keyof typeof ownerTypeLabel]}</a>
-		{#if data.attachableGroups.length > 0}
-			<GroupFilter
-				groups={data.attachableGroups}
-				selectedGroup={data.selectedGroup}
-				q={data.q}
-				cats={data.selectedCategories}
-				op={data.op}
-				onlyAvailable={data.onlyAvailable}
-				ownerType={data.ownerType}
-			/>
-		{/if}
+	<div class="flex flex-wrap justify-center items-center gap-2 my-3">
+		<TravelTimeFilter
+			{preferredMode}
+			isLoggedIn={!!data.currentUser}
+			hasQuery={data.q.length > 0 || data.selectedCategories.length > 0 || !!data.selectedGroup}
+			items={data.items ?? []}
+			bind:transportMode
+			bind:travelTimes
+			bind:maxMinutes
+		/>
 	</div>
 
-	<hr class="border-tinte-300 max-w-100! my-2 mx-auto"/>
-
-	<TravelTimeFilter
-		{preferredMode}
-		isLoggedIn={!!data.currentUser}
-		hasQuery={data.q.length > 0 || data.selectedCategories.length > 0 || !!data.selectedGroup}
-		items={data.items ?? []}
-		bind:transportMode
-		bind:travelTimes
-		bind:maxMinutes
+	<FilterModal
+		bind:open={filterModalOpen}
+		sort={data.sort}
+		onlyAvailable={data.onlyAvailable}
+		ownerType={data.ownerType as OwnerType}
+		selectedCategories={data.selectedCategories}
+		op={data.op}
+		selectedGroup={data.selectedGroup}
+		groups={data.attachableGroups}
+		onApply={handleApply}
 	/>
 
-	<div class="w-full items-center justify-center text-center mt-2">
+	<!-- Commenting this out to try if the cleaner approach is better, maybe reintroduce later -->
+	<!-- <div class="w-full items-center justify-center text-center mt-2">
 		{#if data.q || data.selectedCategories.length > 0 || data.selectedGroup}
 			<h5>{texts.ui.resultsFound(filterActive ? filteredItems.length : data.totalItems ?? 0)}</h5>
 		{:else}
 			<h5>{texts.pages.search.newestItemsHeading}</h5>
 		{/if}
-	</div>
+	</div> -->
 
 	{@render paginationControls()}
 

--- a/src/routes/search/CategoryFilter.svelte
+++ b/src/routes/search/CategoryFilter.svelte
@@ -1,47 +1,36 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
 	import { Toggle } from 'flowbite-svelte';
 	import { ITEM_CATEGORIES } from '$lib/categories';
 	import { texts } from '$lib/texts';
-	import { buildSearchUrl } from './searchUrl';
 
+	// Rendered inside FilterModal (issue #505): holds no navigation of its own. Selections
+	// are local draft state, bound up to the modal, and only committed to the URL when
+	// "Filter anwenden" is clicked there.
 	interface Props {
 		selectedCategories: string[];
 		op: 'or' | 'and';
-		q: string;
-		perPage: number;
-		onlyAvailable: boolean;
-		ownerType: string;
-		group: string | null;
 	}
 
-	let { selectedCategories, op, q, perPage, onlyAvailable, ownerType, group }: Props = $props();
-
-	function buildUrl(newCats: string[], newOp: 'or' | 'and'): string {
-		// Always reset to page 1 when filter changes (omit page param).
-		return buildSearchUrl({ q, cats: newCats, op: newOp, onlyAvailable, ownerType, group: group ?? undefined, perPage: perPage !== 10 ? perPage : undefined });
-	}
+	let { selectedCategories = $bindable(), op = $bindable() }: Props = $props();
 
 	function toggleCat(cat: string) {
-		const next = selectedCategories.includes(cat) ? [] : [cat];
-		// eslint-disable-next-line svelte/no-navigation-without-resolve -- buildSearchUrl() already resolve()s the /search path; the rule can't see through the helper
-		goto(buildUrl(next, op));
+		selectedCategories = selectedCategories.includes(cat) ? [] : [cat];
 	}
 
 	function toggleOp() {
-		// eslint-disable-next-line svelte/no-navigation-without-resolve -- buildSearchUrl() already resolve()s the /search path; the rule can't see through the helper
-		goto(buildUrl(selectedCategories, op === 'or' ? 'and' : 'or'));
+		op = op === 'or' ? 'and' : 'or';
 	}
 
 	let andActive = $derived(op === 'and');
 </script>
 
 <div class="mt-3 space-y-2">
-	<div class="flex flex-wrap justify-center gap-2">
+	<div class="flex flex-wrap gap-2">
 		{#each ITEM_CATEGORIES as cat(cat)}
 			{@const active = selectedCategories.includes(cat)}
 			<button
 				type="button"
+				aria-pressed={active}
 				onclick={() => toggleCat(cat)}
 				class="rounded-full border px-3 py-1 text-sm font-medium transition-colors cursor-pointer
 					{active

--- a/src/routes/search/CategoryFilter.svelte
+++ b/src/routes/search/CategoryFilter.svelte
@@ -44,12 +44,11 @@
 
 	{#if selectedCategories.length >= 2}
 		<div class="flex justify-center">
-			<label class="flex items-center gap-2 cursor-pointer">
-				<Toggle checked={andActive} onchange={toggleOp} />
+			<Toggle checked={andActive} onchange={toggleOp}>
 				<span class="text-sm text-tinte-600 dark:text-tinte-400">
 					{texts.pages.search.categoryFilterAnd}
 				</span>
-			</label>
+			</Toggle>
 		</div>
 	{/if}
 </div>

--- a/src/routes/search/FilterModal.svelte
+++ b/src/routes/search/FilterModal.svelte
@@ -5,18 +5,7 @@
 	import CategoryFilter from './CategoryFilter.svelte';
 	import GroupFilter from './GroupFilter.svelte';
 	import { texts } from '$lib/texts';
-	import type { SortOption } from './searchFilter';
-
-	type OwnerType = 'all' | 'institution' | 'private';
-
-	interface Draft {
-		sort: SortOption;
-		onlyAvailable: boolean;
-		ownerType: OwnerType;
-		selectedCategories: string[];
-		op: 'or' | 'and';
-		selectedGroup: string | null;
-	}
+	import type { SortOption, OwnerType, FilterDraft } from './searchFilter';
 
 	interface Props {
 		open: boolean;
@@ -29,7 +18,7 @@
 		selectedGroup: string | null;
 		groups: { id: string; name: string }[];
 		// Committed once, in a single call, when "Filter anwenden" is clicked.
-		onApply: (draft: Draft) => void;
+		onApply: (draft: FilterDraft) => void;
 	}
 
 	let {
@@ -46,7 +35,7 @@
 
 	// App defaults — what "Zurücksetzen" restores the draft to (issue #505 scope: reset only
 	// touches the in-modal draft, it does not navigate; the user still applies to commit it).
-	const DEFAULTS: Draft = {
+	const DEFAULTS: FilterDraft = {
 		sort: 'newest',
 		onlyAvailable: false,
 		ownerType: 'all',
@@ -55,28 +44,25 @@
 		selectedGroup: null,
 	};
 
-	let draft = $state<Draft>({
-		sort,
-		onlyAvailable,
-		ownerType,
-		selectedCategories: [...selectedCategories],
-		op,
-		selectedGroup,
-	});
+	// Snapshot the current (URL-derived) props into a fresh draft. Used both for the initial
+	// state and to re-seed on every open, so the two can never drift apart.
+	function seedFromProps(): FilterDraft {
+		return {
+			sort,
+			onlyAvailable,
+			ownerType,
+			selectedCategories: [...selectedCategories],
+			op,
+			selectedGroup,
+		};
+	}
+
+	let draft = $state<FilterDraft>(seedFromProps());
 
 	// Re-seed the draft from the current (URL-derived) props every time the modal opens, so a
 	// previous "Zurücksetzen" (without Apply) or a stale draft never leaks into the next open.
 	$effect(() => {
-		if (open) {
-			draft = {
-				sort,
-				onlyAvailable,
-				ownerType,
-				selectedCategories: [...selectedCategories],
-				op,
-				selectedGroup,
-			};
-		}
+		if (open) draft = seedFromProps();
 	});
 
 	const sortOptions = Object.entries(texts.pages.search.sortOptions).map(([value, label]) => ({
@@ -90,9 +76,10 @@
 		{ value: 'private', label: texts.pages.search.ownerTypePrivate },
 	];
 
+	// Only resets the in-modal draft — it does NOT navigate or close the modal (the user still
+	// clicks "Filter anwenden" to commit). Matches the contract in docs/search-discovery.md.
 	function reset() {
 		draft = { ...DEFAULTS, selectedCategories: [...DEFAULTS.selectedCategories] };
-		apply();
 	}
 
 	function apply() {
@@ -104,9 +91,9 @@
 	<div class="flex flex-col gap-6">
 		<!-- Sortierung -->
 		<section>
-			<h3 class="mb-2 text-sm font-semibold text-tinte-700 dark:text-tinte-300">
+			<h4 class="mb-2 text-sm font-semibold text-tinte-700 dark:text-tinte-300">
 				{texts.pages.search.sortLabel}
-			</h3>
+			</h4>
 			<SegmentedControl
 				options={sortOptions}
 				bind:value={draft.sort}
@@ -116,12 +103,11 @@
 
 		<!-- Verfügbarkeit -->
 		<section>
-			<label class="flex items-center gap-2 cursor-pointer">
-				<Toggle bind:checked={draft.onlyAvailable} aria-describedby="availability-subtext" />
+			<Toggle bind:checked={draft.onlyAvailable} aria-describedby="availability-subtext">
 				<span class="text-sm text-tinte-600 dark:text-tinte-400">
 					{texts.pages.search.onlyAvailable}
 				</span>
-			</label>
+			</Toggle>
 			<p id="availability-subtext" class="sr-only">
 				{texts.pages.search.filterAvailabilitySubtext}
 			</p>
@@ -129,9 +115,9 @@
 
 		<!-- Anbieter -->
 		<section>
-			<h3 class="mb-2 text-sm font-semibold text-tinte-700 dark:text-tinte-300">
+			<h4 class="mb-2 text-sm font-semibold text-tinte-700 dark:text-tinte-300">
 				{texts.pages.search.filterSectionOwnerType}
-			</h3>
+			</h4>
 			<SegmentedControl
 				options={ownerTypeOptions}
 				bind:value={draft.ownerType}
@@ -141,18 +127,20 @@
 
 		<!-- Kategorien -->
 		<section>
-			<h3 class="mb-2 text-sm font-semibold text-tinte-700 dark:text-tinte-300">
+			<h4 id="filter-categories-heading" class="mb-2 text-sm font-semibold text-tinte-700 dark:text-tinte-300">
 				{texts.pages.search.filterSectionCategories}
-			</h3>
-			<CategoryFilter bind:selectedCategories={draft.selectedCategories} bind:op={draft.op} />
+			</h4>
+			<div role="group" aria-labelledby="filter-categories-heading">
+				<CategoryFilter bind:selectedCategories={draft.selectedCategories} bind:op={draft.op} />
+			</div>
 		</section>
 
 		<!-- Gruppe -->
 		{#if groups.length > 0}
 			<section>
-				<h3 class="mb-2 text-sm font-semibold text-tinte-700 dark:text-tinte-300">
+				<h4 class="mb-2 text-sm font-semibold text-tinte-700 dark:text-tinte-300">
 					{texts.pages.search.filterSectionGroup}
-				</h3>
+				</h4>
 				<GroupFilter {groups} bind:selectedGroup={draft.selectedGroup} />
 			</section>
 		{/if}

--- a/src/routes/search/FilterModal.svelte
+++ b/src/routes/search/FilterModal.svelte
@@ -1,0 +1,166 @@
+<script lang="ts">
+	import { Modal, Toggle } from 'flowbite-svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import SegmentedControl from '$lib/components/ui/SegmentedControl.svelte';
+	import CategoryFilter from './CategoryFilter.svelte';
+	import GroupFilter from './GroupFilter.svelte';
+	import { texts } from '$lib/texts';
+	import type { SortOption } from './searchFilter';
+
+	type OwnerType = 'all' | 'institution' | 'private';
+
+	interface Draft {
+		sort: SortOption;
+		onlyAvailable: boolean;
+		ownerType: OwnerType;
+		selectedCategories: string[];
+		op: 'or' | 'and';
+		selectedGroup: string | null;
+	}
+
+	interface Props {
+		open: boolean;
+		// Current URL-derived state — used only to seed the local draft whenever the modal opens.
+		sort: SortOption;
+		onlyAvailable: boolean;
+		ownerType: OwnerType;
+		selectedCategories: string[];
+		op: 'or' | 'and';
+		selectedGroup: string | null;
+		groups: { id: string; name: string }[];
+		// Committed once, in a single call, when "Filter anwenden" is clicked.
+		onApply: (draft: Draft) => void;
+	}
+
+	let {
+		open = $bindable(),
+		sort,
+		onlyAvailable,
+		ownerType,
+		selectedCategories,
+		op,
+		selectedGroup,
+		groups,
+		onApply,
+	}: Props = $props();
+
+	// App defaults — what "Zurücksetzen" restores the draft to (issue #505 scope: reset only
+	// touches the in-modal draft, it does not navigate; the user still applies to commit it).
+	const DEFAULTS: Draft = {
+		sort: 'newest',
+		onlyAvailable: false,
+		ownerType: 'all',
+		selectedCategories: [],
+		op: 'or',
+		selectedGroup: null,
+	};
+
+	let draft = $state<Draft>({
+		sort,
+		onlyAvailable,
+		ownerType,
+		selectedCategories: [...selectedCategories],
+		op,
+		selectedGroup,
+	});
+
+	// Re-seed the draft from the current (URL-derived) props every time the modal opens, so a
+	// previous "Zurücksetzen" (without Apply) or a stale draft never leaks into the next open.
+	$effect(() => {
+		if (open) {
+			draft = {
+				sort,
+				onlyAvailable,
+				ownerType,
+				selectedCategories: [...selectedCategories],
+				op,
+				selectedGroup,
+			};
+		}
+	});
+
+	const sortOptions = Object.entries(texts.pages.search.sortOptions).map(([value, label]) => ({
+		value: value as SortOption,
+		label,
+	}));
+
+	const ownerTypeOptions: { value: OwnerType; label: string }[] = [
+		{ value: 'all', label: texts.pages.search.ownerTypeAll },
+		{ value: 'institution', label: texts.pages.search.ownerTypeInstitution },
+		{ value: 'private', label: texts.pages.search.ownerTypePrivate },
+	];
+
+	function reset() {
+		draft = { ...DEFAULTS, selectedCategories: [...DEFAULTS.selectedCategories] };
+		apply();
+	}
+
+	function apply() {
+		onApply({ ...draft });
+	}
+</script>
+
+<Modal title={texts.pages.search.filterModalTitle} bind:open size="md" outsideclose>
+	<div class="flex flex-col gap-6">
+		<!-- Sortierung -->
+		<section>
+			<h3 class="mb-2 text-sm font-semibold text-tinte-700 dark:text-tinte-300">
+				{texts.pages.search.sortLabel}
+			</h3>
+			<SegmentedControl
+				options={sortOptions}
+				bind:value={draft.sort}
+				label={texts.pages.search.sortLabel}
+			/>
+		</section>
+
+		<!-- Verfügbarkeit -->
+		<section>
+			<label class="flex items-center gap-2 cursor-pointer">
+				<Toggle bind:checked={draft.onlyAvailable} aria-describedby="availability-subtext" />
+				<span class="text-sm text-tinte-600 dark:text-tinte-400">
+					{texts.pages.search.onlyAvailable}
+				</span>
+			</label>
+			<p id="availability-subtext" class="sr-only">
+				{texts.pages.search.filterAvailabilitySubtext}
+			</p>
+		</section>
+
+		<!-- Anbieter -->
+		<section>
+			<h3 class="mb-2 text-sm font-semibold text-tinte-700 dark:text-tinte-300">
+				{texts.pages.search.filterSectionOwnerType}
+			</h3>
+			<SegmentedControl
+				options={ownerTypeOptions}
+				bind:value={draft.ownerType}
+				label={texts.pages.search.filterSectionOwnerType}
+			/>
+		</section>
+
+		<!-- Kategorien -->
+		<section>
+			<h3 class="mb-2 text-sm font-semibold text-tinte-700 dark:text-tinte-300">
+				{texts.pages.search.filterSectionCategories}
+			</h3>
+			<CategoryFilter bind:selectedCategories={draft.selectedCategories} bind:op={draft.op} />
+		</section>
+
+		<!-- Gruppe -->
+		{#if groups.length > 0}
+			<section>
+				<h3 class="mb-2 text-sm font-semibold text-tinte-700 dark:text-tinte-300">
+					{texts.pages.search.filterSectionGroup}
+				</h3>
+				<GroupFilter {groups} bind:selectedGroup={draft.selectedGroup} />
+			</section>
+		{/if}
+
+
+		<div class="flex justify-between gap-3 border-t border-tinte-200 pt-4 dark:border-tinte-700">
+			<Button variant="accent" onclick={reset}>{texts.pages.search.filterReset}</Button>
+			<Button variant="primary" onclick={apply}>{texts.pages.search.filterApply}</Button>
+		</div>
+	</div>
+</Modal>

--- a/src/routes/search/GroupFilter.svelte
+++ b/src/routes/search/GroupFilter.svelte
@@ -1,33 +1,26 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
 	import { ChevronDownOutline } from 'flowbite-svelte-icons';
 	import { texts } from '$lib/texts';
-	import { buildSearchUrl } from './searchUrl';
 
+	// Rendered inside FilterModal (issue #505): holds no navigation of its own. The selection
+	// is local draft state, bound up to the modal, and only committed to the URL when
+	// "Filter anwenden" is clicked there.
 	interface Props {
 		groups: { id: string; name: string }[];
 		selectedGroup: string | null;
-		// All other active search params, threaded through so switching group preserves them.
-		q: string;
-		cats: string[];
-		op: 'or' | 'and';
-		onlyAvailable: boolean;
-		ownerType: string;
 	}
 
-	let { groups, selectedGroup, q, cats, op, onlyAvailable, ownerType }: Props = $props();
+	let { groups, selectedGroup = $bindable() }: Props = $props();
 
 	function onChange(event: Event) {
 		const value = (event.currentTarget as HTMLSelectElement).value;
-		// Reset to page 1 (page param omitted, matching CategoryFilter). An empty value clears
-		// the filter (group left undefined).
-		// eslint-disable-next-line svelte/no-navigation-without-resolve -- buildSearchUrl() already resolve()s the /search path; the rule can't see through the helper
-		goto(buildSearchUrl({ q, cats, op, onlyAvailable, ownerType, group: value || undefined }));
+		selectedGroup = value || null;
 	}
 </script>
 
 <!-- Only rendered when the user has groups (implies logged in); guests never see it. -->
-<div class="flex flex-wrap items-center justify-center gap-2">
+<div class="flex flex-wrap gap-2">
+	<label for="group-filter" class="sr-only">{texts.pages.search.groupFilterLabel}</label>
 	<!-- Styled as a pill matching the category chips / owner-type toggle: highlighted (primary)
 	     when a group is active, native arrow removed via appearance-none + custom chevron. -->
 	<div class="relative inline-flex">

--- a/src/routes/search/Pagination.svelte
+++ b/src/routes/search/Pagination.svelte
@@ -14,14 +14,15 @@
 		onlyAvailable: boolean;
 		ownerType: string;
 		group: string | null;
+		sort: string;
 	}
 
-	let { page, totalPages, perPage, q, selectedCategories, op, onlyAvailable, ownerType, group }: Props = $props();
+	let { page, totalPages, perPage, q, selectedCategories, op, onlyAvailable, ownerType, group, sort }: Props = $props();
 
 	const perPageOptions = [10, 20, 50];
 
 	function pageUrl(n: number): string {
-		return buildSearchUrl({ q, page: n, perPage, cats: selectedCategories, op, onlyAvailable, ownerType, group: group ?? undefined });
+		return buildSearchUrl({ q, page: n, perPage, cats: selectedCategories, op, onlyAvailable, ownerType, group: group ?? undefined, sort });
 	}
 
 	function getPages(): (number | '...')[] {
@@ -102,6 +103,9 @@
 			{/if}
 			{#if group}
 				<input type="hidden" name="group" value={group} />
+			{/if}
+			{#if sort !== 'newest'}
+				<input type="hidden" name="sort" value={sort} />
 			{/if}
 			<span>{texts.pages.search.perPage}</span>
 			<select

--- a/src/routes/search/SearchBar.svelte
+++ b/src/routes/search/SearchBar.svelte
@@ -94,7 +94,6 @@
 
 <form method="GET" action="/search" class="flex gap-2" onsubmit={handleSubmit}>
 	<div class="relative flex-1">
-		
 		<input
 			bind:this={inputEl}
 			bind:value={inputValue}
@@ -110,8 +109,8 @@
 				<button
 					type="button"
 					onclick={clearSearch}
-					aria-label="Suche zurücksetzen"
-					class="flex items-center text-tinte-400 hover:text-tinte-600 dark:hover:text-tinte-200"
+					aria-label={texts.buttons.clearSearch}
+					class="flex items-center p-1 text-tinte-500 hover:text-tinte-600 dark:text-tinte-400 dark:hover:text-tinte-200"
 				>
 					<svg class="h-4 w-4" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
 						<path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18 18 6M6 6l12 12" />

--- a/src/routes/search/SearchBar.svelte
+++ b/src/routes/search/SearchBar.svelte
@@ -1,16 +1,14 @@
 <script lang="ts">
-	import Button from '$lib/components/ui/Button.svelte';
 	import { SearchOutline } from 'flowbite-svelte-icons';
 	import { resolve } from '$app/paths';
 	import { goto, beforeNavigate } from '$app/navigation';
 	import { texts } from '$lib/texts';
+	import type { Snippet } from 'svelte';
 
 	const SEARCH_DELAY_MS = 1200;
 	const MINIMAL_SEARCHSTRING_LENGTH = 3;
 
-	let { q = '' }: { q: string } = $props();
-
-	const browseAllUrl = resolve('/search') + '?q=*';
+	let { q = '', filterSlot }: { q: string; filterSlot?: Snippet } = $props();
 
 	let inputValue = $state(q);
 	let inputEl = $state<HTMLInputElement | null>(null);
@@ -77,7 +75,7 @@
 		isDebouncing = false;
 		const value = inputValue.trim();
 		// eslint-disable-next-line svelte/no-navigation-without-resolve
-		await goto(value ? `/search?q=${encodeURIComponent(value)}` : browseAllUrl, {
+		await goto(value ? `/search?q=${encodeURIComponent(value)}` : resolve('/search'), {
 			keepFocus: true,
 			noScroll: true
 		});
@@ -96,23 +94,7 @@
 
 <form method="GET" action="/search" class="flex gap-2" onsubmit={handleSubmit}>
 	<div class="relative flex-1">
-		<div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-			<svg
-				class="h-4 w-4 text-tinte-500 dark:text-tinte-400"
-				aria-hidden="true"
-				xmlns="http://www.w3.org/2000/svg"
-				fill="none"
-				viewBox="0 0 20 20"
-			>
-				<path
-					stroke="currentColor"
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					stroke-width="2"
-					d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"
-				/>
-			</svg>
-		</div>
+		
 		<input
 			bind:this={inputEl}
 			bind:value={inputValue}
@@ -121,30 +103,39 @@
 			autocomplete="off"
 			name="q"
 			placeholder={texts.forms.searchPlaceholder}
-			class="search-bar pulse-shadow block w-full rounded-lg border border-tinte-300 bg-papier p-2.5 pl-10 pr-8 text-sm text-tinte-900 focus:border-primary focus:ring-primary dark:border-tinte-600 dark:bg-tinte-700 dark:text-white dark:placeholder-tinte-400 [&::-webkit-search-cancel-button]:hidden"
+			class="search-bar pulse-shadow block w-full rounded-lg border border-tinte-300 bg-papier p-2.5 pl-6.5 pr-14 text-sm text-tinte-900 focus:border-primary focus:ring-primary dark:border-tinte-600 dark:bg-tinte-700 dark:text-white dark:placeholder-tinte-400 [&::-webkit-search-cancel-button]:hidden"
 		/>
-		{#if inputValue && isDebouncing}
-			<div class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2.5 text-tinte-400">
-				<svg class="h-4 w-4 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
-					<circle class="opacity-75" cx="12" cy="12" r="10" stroke="green" stroke-width="4"></circle>
-				<path class="opacity-100" fill="green" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
-				</svg>
-			</div>
-		{:else if inputValue}
+		<div class="absolute inset-y-0 left-2 flex items-center gap-1 pr-2">
+			{#if inputValue}
+				<button
+					type="button"
+					onclick={clearSearch}
+					aria-label="Suche zurücksetzen"
+					class="flex items-center text-tinte-400 hover:text-tinte-600 dark:hover:text-tinte-200"
+				>
+					<svg class="h-4 w-4" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+						<path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18 18 6M6 6l12 12" />
+					</svg>
+				</button>
+			{/if}
+		</div>
+		<div class="absolute inset-y-0 right-0 flex items-center gap-1 pr-2">
+			{#if inputValue && isDebouncing}
+				<div class="pointer-events-none flex items-center text-tinte-400">
+					<svg class="h-4 w-4 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+						<circle class="opacity-75" cx="12" cy="12" r="10" stroke="green" stroke-width="4"></circle>
+					<path class="opacity-100" fill="green" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+					</svg>
+				</div>
+			{/if}
 			<button
-				type="button"
-				onclick={clearSearch}
-				aria-label="Suche zurücksetzen"
-				class="absolute inset-y-0 right-0 flex items-center pr-2.5 text-tinte-400 hover:text-tinte-600 dark:hover:text-tinte-200"
+				type="submit"
+				aria-label={texts.buttons.search}
+				class="flex items-center mr-1 hover:cursor-pointer text-tinte-500 hover:text-primary dark:text-tinte-400 dark:hover:text-primary"
 			>
-				<svg class="h-4 w-4" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-					<path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18 18 6M6 6l12 12" />
-				</svg>
+				<SearchOutline class="h-6 w-6" />
 			</button>
-		{/if}
+		</div>
 	</div>
-	<Button type="submit" aria-label={inputValue.trim() ? texts.buttons.search : texts.buttons.showAll} class="shrink-0">
-		<SearchOutline class="h-5 w-5" /><span>{inputValue.trim() ? texts.buttons.search : texts.buttons.showAll}</span>
-	</Button>
-
+	{@render filterSlot?.()}
 </form>

--- a/src/routes/search/TravelTimeFilter.svelte
+++ b/src/routes/search/TravelTimeFilter.svelte
@@ -212,6 +212,10 @@
 					max="30"
 					step="5"
 					bind:value={maxMinutes}
+					aria-label={texts.pages.search.durationFilter.sliderLabel}
+					aria-valuetext={maxMinutes >= 30
+						? texts.pages.search.durationFilter.noLimit
+						: texts.pages.search.durationFilter.maxMinutes(maxMinutes)}
 					class="w-full h-2 accent-primary cursor-pointer"
 				/>
 				<span class="text-sm text-tinte-600 dark:text-tinte-300 w-28">

--- a/src/routes/search/page.server.test.ts
+++ b/src/routes/search/page.server.test.ts
@@ -106,3 +106,40 @@ describe('search load — group filter', () => {
 		expect(JSON.stringify(payload)).not.toContain(MEMBER_GROUP);
 	});
 });
+
+describe('search load — sort', () => {
+	it.each([
+		['newest', '-created'],
+		['name_asc', 'name'],
+		['name_desc', '-name'],
+	])('maps sort=%s to getList sort "%s"', async (sortParam, pbSort) => {
+		getAttachableGroupsMock.mockResolvedValue([]);
+		const { locals, getList } = makeLocals(null);
+
+		const res = await run(locals, `?sort=${sortParam}`);
+
+		const opts = getList.mock.calls[0][2];
+		expect(opts.sort).toBe(pbSort);
+		expect(res.sort).toBe(sortParam);
+	});
+
+	it('defaults to -created when sort is absent', async () => {
+		getAttachableGroupsMock.mockResolvedValue([]);
+		const { locals, getList } = makeLocals(null);
+
+		await run(locals, '');
+
+		const opts = getList.mock.calls[0][2];
+		expect(opts.sort).toBe('-created');
+	});
+
+	it('defaults to -created when sort is invalid', async () => {
+		getAttachableGroupsMock.mockResolvedValue([]);
+		const { locals, getList } = makeLocals(null);
+
+		await run(locals, '?sort=bogus');
+
+		const opts = getList.mock.calls[0][2];
+		expect(opts.sort).toBe('-created');
+	});
+});

--- a/src/routes/search/searchFilter.test.ts
+++ b/src/routes/search/searchFilter.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { buildSearchFilter, buildItemFilter, parseSearchParameters, type SearchParameters } from './searchFilter';
+import {
+	buildSearchFilter,
+	buildItemFilter,
+	parseSearchParameters,
+	sortToPbSort,
+	type SearchParameters,
+} from './searchFilter';
 
 describe('buildSearchFilter', () => {
 	it('returns null for blank input or the wildcard', () => {
@@ -38,6 +44,7 @@ describe('buildItemFilter', () => {
 		onlyAvailable: true,
 		ownerType: 'all',
 		selectedGroup: null,
+		sort: 'newest',
 	};
 
 	it('includes the username clause when a query is present', () => {
@@ -117,5 +124,37 @@ describe('parseSearchParameters', () => {
 			url.searchParams.set('group', bad);
 			expect(parseSearchParameters(url).selectedGroup).toBeNull();
 		}
+	});
+
+	it('defaults sort to "newest" when the param is missing', () => {
+		expect(parseSearchParameters(new URL('https://x.test/search')).sort).toBe('newest');
+	});
+
+	it('parses each valid sort value', () => {
+		for (const sort of ['newest', 'name_asc', 'name_desc']) {
+			const url = new URL('https://x.test/search');
+			url.searchParams.set('sort', sort);
+			expect(parseSearchParameters(url).sort).toBe(sort);
+		}
+	});
+
+	it('falls back to "newest" for an unknown sort value', () => {
+		const url = new URL('https://x.test/search');
+		url.searchParams.set('sort', 'bogus');
+		expect(parseSearchParameters(url).sort).toBe('newest');
+	});
+});
+
+describe('sortToPbSort', () => {
+	it('maps newest to -created', () => {
+		expect(sortToPbSort('newest')).toBe('-created');
+	});
+
+	it('maps name_asc to name', () => {
+		expect(sortToPbSort('name_asc')).toBe('name');
+	});
+
+	it('maps name_desc to -name', () => {
+		expect(sortToPbSort('name_desc')).toBe('-name');
 	});
 });

--- a/src/routes/search/searchFilter.ts
+++ b/src/routes/search/searchFilter.ts
@@ -1,6 +1,8 @@
 import { ITEM_CATEGORIES, type ItemCategory } from '$lib/categories';
 import type { ItemPublic } from '$lib/types/models';
 
+export type SortOption = 'newest' | 'name_asc' | 'name_desc';
+
 export type SearchParameters = {
 	query: string;
 	page: number;
@@ -17,7 +19,27 @@ export type SearchParameters = {
 	 * a validated value is therefore the caller's responsibility.
 	 */
 	selectedGroup: string | null;
+	sort: SortOption;
 };
+
+const SORT_OPTIONS: SortOption[] = ['newest', 'name_asc', 'name_desc'];
+
+/**
+ * Maps a validated `SortOption` to the PocketBase `sort` query string for the
+ * `items_searchable` view. `newest` (the default) sorts by creation date, descending, so edits
+ * don't resurface old items.
+ */
+export function sortToPbSort(sort: SortOption): string {
+	switch (sort) {
+		case 'name_asc':
+			return 'name';
+		case 'name_desc':
+			return '-name';
+		case 'newest':
+		default:
+			return '-created';
+	}
+}
 
 /**
  * Returns the field name as a string, validated at compile time against the `items_public` view schema.
@@ -79,7 +101,12 @@ export function parseSearchParameters(url: URL): SearchParameters {
 	const groupParam = url.searchParams.get('group')?.trim() ?? '';
 	const selectedGroup = /^[a-z0-9]{15}$/i.test(groupParam) ? groupParam : null;
 
-	return { query, page, perPage, selectedCategories, op, onlyAvailable, ownerType, selectedGroup };
+	const sortParam = url.searchParams.get('sort') ?? 'newest';
+	const sort: SortOption = SORT_OPTIONS.includes(sortParam as SortOption)
+		? (sortParam as SortOption)
+		: 'newest';
+
+	return { query, page, perPage, selectedCategories, op, onlyAvailable, ownerType, selectedGroup, sort };
 }
 
 /**

--- a/src/routes/search/searchFilter.ts
+++ b/src/routes/search/searchFilter.ts
@@ -3,6 +3,18 @@ import type { ItemPublic } from '$lib/types/models';
 
 export type SortOption = 'newest' | 'name_asc' | 'name_desc';
 
+export type OwnerType = 'all' | 'institution' | 'private';
+
+/** The full set of filter fields `FilterModal` edits as a local draft before committing them. */
+export interface FilterDraft {
+	sort: SortOption;
+	onlyAvailable: boolean;
+	ownerType: OwnerType;
+	selectedCategories: string[];
+	op: 'or' | 'and';
+	selectedGroup: string | null;
+}
+
 export type SearchParameters = {
 	query: string;
 	page: number;
@@ -10,7 +22,7 @@ export type SearchParameters = {
 	selectedCategories: ItemCategory[];
 	op: 'or' | 'and';
 	onlyAvailable: boolean;
-	ownerType: 'all' | 'institution' | 'private';
+	ownerType: OwnerType;
 	/**
 	 * Raw, format-plausible group id parsed from the URL (or `null`). This is NOT yet a
 	 * proven-membership id: `parseSearchParameters` stays pure/sync and only shape-checks it.
@@ -91,7 +103,7 @@ export function parseSearchParameters(url: URL): SearchParameters {
 	const onlyAvailable = url.searchParams.get('onlyAvailable') === 'true';
 
 	const ownerTypeParam = url.searchParams.get('ownerType') ?? 'all';
-	const ownerType: 'all' | 'institution' | 'private' =
+	const ownerType: OwnerType =
 		ownerTypeParam === 'institution' || ownerTypeParam === 'private' ? ownerTypeParam : 'all';
 
 	// Shape-check only: a PocketBase record id is 15 alphanumerics. Garbage is dropped to `null`

--- a/src/routes/search/searchUrl.test.ts
+++ b/src/routes/search/searchUrl.test.ts
@@ -37,6 +37,19 @@ describe('buildSearchUrl', () => {
 	it('returns the bare search path when no params are set', () => {
 		expect(buildSearchUrl({})).toBe('/search');
 	});
+
+	it('includes sort when non-default', () => {
+		const url = buildSearchUrl({ sort: 'name_asc' });
+		expect(url).toBe('/search?sort=name_asc');
+	});
+
+	it('omits sort entirely when "newest" (the default)', () => {
+		expect(buildSearchUrl({ sort: 'newest' })).toBe('/search');
+	});
+
+	it('omits sort entirely when undefined', () => {
+		expect(buildSearchUrl({ sort: undefined })).toBe('/search');
+	});
 });
 
 // Roundtrip invariant: buildSearchUrl and parseSearchParameters MUST agree on every default.
@@ -69,5 +82,11 @@ describe('buildSearchUrl ↔ parseSearchParameters roundtrip', () => {
 		expect(parsed.ownerType).toBe('institution');
 		expect(parsed.page).toBe(3);
 		expect(parsed.perPage).toBe(50);
+	});
+
+	it('preserves sort for every option, including the default', () => {
+		expect(roundtrip({ sort: 'newest' }).sort).toBe('newest');
+		expect(roundtrip({ sort: 'name_asc' }).sort).toBe('name_asc');
+		expect(roundtrip({ sort: 'name_desc' }).sort).toBe('name_desc');
 	});
 });

--- a/src/routes/search/searchUrl.ts
+++ b/src/routes/search/searchUrl.ts
@@ -7,6 +7,7 @@ export interface SearchUrlParams {
 	onlyAvailable?: boolean;
 	ownerType?: string;
 	group?: string;
+	sort?: string;
 	page?: number;
 	perPage?: number;
 }
@@ -21,5 +22,6 @@ export function buildSearchUrl(params: SearchUrlParams): string {
 	if (params.onlyAvailable) parts.push('onlyAvailable=true');
 	if (params.ownerType && params.ownerType !== 'all') parts.push(`ownerType=${params.ownerType}`);
 	if (params.group) parts.push(`group=${encodeURIComponent(params.group)}`);
+	if (params.sort && params.sort !== 'newest') parts.push(`sort=${encodeURIComponent(params.sort)}`);
 	return resolve('/search') + (parts.length ? '?' + parts.join('&') : '');
 }


### PR DESCRIPTION
## What

Replaces the always-visible filter chip row on `/search` with a single "Filter" button that opens a modal grouping all filter dimensions into clear sections: Sortierung, Verfügbarkeit, Anbieter, Kategorien, Gruppe. Distance/travel-time filtering stays as its own always-visible inline control next to the search bar (unchanged mechanism, just relocated).

Also, along the way:
- Adds `sort` as a new first-class, URL-persisted search parameter (`newest` (default) / `name_asc` / `name_desc`).
- Adds a reusable `SegmentedControl` UI primitive (single-select pill group, `role="radiogroup"`/`role="radio"`) used for the Anbieter and Sortierung controls.
- Removes the now-obsolete `?q=*` "search all" wildcard workaround from the search bar — an empty query has meant "search all" by default for a while, so the client no longer needs to inject the sentinel (the backend still accepts `?q=*` for old bookmarked links).
- Moves the search-submit magnifying glass inline into the right side of the search input (previously a separate button below/beside it), and swaps the "Filter" trigger's text label for a `FilterSolid` icon with an active-filter-count badge (mirroring the existing notification-bell badge pattern), keeping the German label as `aria-label` for accessibility.

Why: the previous chip row consumed significant vertical space on desktop with no single place to see or reset all active filters at once (see #505 for the original ask and design discussion — km-based distance and Bezirke/Sprachen/max. Leihdauer sections were explicitly descoped after issue discussion: distance stays minutes/transport-mode-based, and the three missing-schema sections are deferred pending a `/schema-change`).

Closes #505

## Test notes

Preflight run on this branch, all green:
- `npm run lint` — clean
- `npm run check` — 0 errors, 16 pre-existing warnings unrelated to this change
- `npx vitest run` — 71 files / 740 tests passed
- `npm run build` — succeeds

Manually verified in a browser against a local dev stack (real-schema PocketBase + seeded data): Filter modal opens/closes correctly with all sections in the right order and correct ARIA roles (`radiogroup`/`radio` for Anbieter and Sortierung, `aria-describedby`-linked subtext on the Verfügbarkeit toggle), "Filter anwenden" commits all draft selections in a single navigation, "Zurücksetzen" only resets the in-modal draft (doesn't navigate), the active-filter-count badge updates correctly, the inline magnifying-glass submit button and Filter icon sit correctly inside/next to the search bar with no overlap at desktop and mobile widths, and an empty search now lands on bare `/search` (no `?q=*`).

Ran the affected Playwright e2e specs (`search.spec.ts`, `search-focus.spec.ts`) — 12/12 passed, including trust-visibility checks (unaffected by this change).

Reviewed via four parallel reviewer roles (security/PB, code quality, accessibility, conventions) with a fix-and-reverify loop — no Blocking findings; two accessibility issues (ARIA role mismatch on `SegmentedControl`, missing `aria-describedby` association) and one code-quality issue (draft-state triplication in `FilterModal`) were found and fixed in round 1, reverified clean in round 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)