### PR TITLE
fix(items): guard item add/edit form against double-submit

### DIFF
--- a/src/routes/user/items/ItemModal.svelte
+++ b/src/routes/user/items/ItemModal.svelte
@@ -63,6 +63,9 @@
 	// top layer, which paints above any z-indexed toast overlay (#522). Local (not the
 	// shared page-level `form` prop) so it's scoped to THIS modal's own submit.
 	let submitError = $state<string | null>(null);
+	// In-flight guard against double-submit (slow connection + repeated taps firing
+	// duplicate ?/create requests, #445). Mirrors the bulk-add ReviewStep pattern.
+	let submitting = $state(false);
 	let fileInput = $state<HTMLInputElement | undefined>(undefined);
 	// Newly chosen images (a multi-file field). previews mirrors selectedFiles for display.
 	let selectedFiles = $state<File[]>([]);
@@ -163,6 +166,7 @@
 			form = null;
 			imageError = null;
 			submitError = null;
+			submitting = false;
 			clearPreviews();
 		}
 	});
@@ -186,6 +190,8 @@
 		oninput={() => (isDirty = true)}
 		onchange={() => (isDirty = true)}
 		use:enhance={async ({ formData, cancel }) => {
+			if (submitting) { cancel(); return; }
+			submitting = true;
 			submitError = null;
 			// Multi-file field: compress each chosen image and re-append under the same
 			// `itemImage` key. SVGs skip compression (canvas can't draw them reliably);
@@ -201,11 +207,13 @@
 					formData.append('itemImage', compressed, file.name);
 				} catch {
 					submitError = texts.bulkUpload.imageFormatUnsupported;
+					submitting = false;
 					cancel();
 					return;
 				}
 			}
 			return async ({ result, update }) => {
+				submitting = false;
 				if (result.type === 'success') {
 					isDirty = false;
 					isVisible = false;
@@ -448,7 +456,7 @@
 			{/if}
 
 			<!-- SUBMIT BUTTON -->
-			<Button type="submit">
+			<Button type="submit" loading={submitting}>
 				{type === 'edit' ? texts.buttons.save : texts.buttons.add}
 			</Button>
 		</div>


### PR DESCRIPTION
## What & why

On a spotty connection a user accidentally created ~30 copies of the same item (#445). The single-item add/edit dialog (`ItemModal.svelte`) had **no in-flight submit guard**: its `use:enhance` form left the submit button enabled while the request was pending, so repeated taps each fired a `?/create` request → duplicate items.

This adds an in-flight guard that mirrors the pattern the bulk-add flow (`ReviewStep.svelte`) already uses:

- new `submitting` state; the `use:enhance` callback cancels any re-entrant submit (`if (submitting) { cancel(); return; }`) and sets `submitting = true`
- the submit `Button` gets `loading={submitting}`, which disables it and shows a spinner
- `submitting` is reset on every exit path — image-compression failure, the result handler (so a failed submit re-enables the button), and the modal-close `$effect` (so a reopened modal starts clean)

Frontend-only; no backend/schema change. The delete form is intentionally out of scope.

## Test notes

- `npm run lint` ✓ · `npm run check` → only the 6 pre-existing `$env/static/private` sync-var errors (unrelated, present on `main`) · `npx vitest run` → 721/721 ✓
- `npm run build` fails locally **only** on the same pre-existing `$env` sync-var gap (CI injects those vars); unrelated to this diff.
- e2e `item-upload.spec.ts` → 14/14 ✓
- Manual browser check (Slow 3G): 3 rapid clicks on "Hinzufügen" produced exactly **one** `?/create` POST and one item; button correctly disabled during the request and re-enabled on reopen (add + edit).

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)