### PR TITLE
Add shared PocketBase test helper (mockFilter + makeMockPb)

### DIFF
--- a/.claude/skills/write-tests/SKILL.md
+++ b/.claude/skills/write-tests/SKILL.md
@@ -20,13 +20,20 @@ Co-locate the test with its target, same basename + `.test.ts`:
 - `src/lib/server/items.ts` → `src/lib/server/items.test.ts`
 - `src/routes/legal/accept/+page.server.ts` → `src/routes/legal/accept/page.server.test.ts`
 
-## 2. Mock PocketBase with a small factory
+## 2. Mock PocketBase with the shared helper
 
-There's no real DB in unit tests. Build a `pb` whose `collection(name)` returns an object of
-`vi.fn()` stubs for only the methods the code under test calls — e.g. `getOne`, `getFirstListItem`,
-`getFullList`, `create`, `update`, `delete`. Distinguish multiple calls to the same collection by
-inspecting the args (e.g. the `filter` string), and expose the stubs so you can assert on them
-afterwards.
+There's no real DB in unit tests. Don't hand-roll a `filter` mock or a `collection(name)` dispatch
+skeleton — both live in `$lib/server/test-helpers`:
+
+```ts
+export function mockFilter(raw: string, params?: Record<string, unknown>): string;
+export function makeMockPb(impls: Record<string, Record<string, ReturnType<typeof vi.fn>>>): PocketBase;
+```
+
+`makeMockPb` builds a `pb` whose `collection(name)` returns the matching entry of `impls` (only
+stub the methods the code under test calls — e.g. `getOne`, `getFirstListItem`, `getFullList`,
+`create`, `update`, `delete`) and whose `filter` is an assertable spy mirroring the real
+`pb.filter()`. Destructure the `vi.fn()`s you need to assert on before passing them into `impls`.
 
 Many helpers signal "not found" by **rejecting** rather than returning null — `getOne` and
 `getFirstListItem` throw when nothing matches, and the code wraps them in `try/catch`. Drive that
@@ -35,6 +42,7 @@ branch with `vi.fn().mockRejectedValue(new Error('not found'))` so you actually 
 ```ts
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { deleteItem } from './items';
+import { makeMockPb } from '$lib/server/test-helpers';
 
 function makePb({ item, openConversations = [] }) {
   const getOne = vi.fn().mockResolvedValue(item);
@@ -43,20 +51,19 @@ function makePb({ item, openConversations = [] }) {
     Promise.resolve(filter?.includes('lendingStatus') ? openConversations : [])
   );
   const pb = {
-    collection: vi.fn((name: string) =>
-      name === 'items' ? { getOne, delete: deleteRecord } : { getFullList }
-    ),
-    // Mirror the real pb.filter() so the code under test can interpolate params.
-    filter: (raw: string, params?: Record<string, unknown>) =>
-      params ? Object.entries(params).reduce((a, [k, v]) => a.replace(`{:${k}}`, String(v)), raw) : raw,
+    ...makeMockPb({ items: { getOne, delete: deleteRecord }, conversations: { getFullList } }),
     _deleteRecord: deleteRecord, // handles surfaced for assertions
   };
   return pb as unknown as Parameters<typeof deleteItem>[0] & typeof pb;
 }
 ```
 
-Always provide `pb.filter` — production code builds every filter through it (never with template
-literals), so a missing mock throws. Reset state between tests with `beforeEach(() => vi.clearAllMocks())`.
+Distinguish multiple calls to the same collection by inspecting the args (e.g. the `filter`
+string) inside the stub, and expose the underlying `vi.fn()`s so you can assert on them
+afterwards. `pb.filter` always works out of the box — production code builds every filter
+through it (never with template literals), and an unstubbed collection resolves to `undefined`
+so a test that touches it fails loudly. Reset state between tests with
+`beforeEach(() => vi.clearAllMocks())`.
 
 **Not everything routes through `collection()`.** Some `$lib/server/*` helpers reach a privileged
 backend hook via the root-level `pb.send('/api/…')`, and a few read `pb.authStore`. Stub those as

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -46,11 +46,48 @@ there would couple every frontend PR to the backend repo's current state. Lint a
 however, **do** run on every PR via [`.github/workflows/lint.yaml`](/.github/workflows/lint.yaml)
 (`npm run lint` + `npm run check`), alongside the existing Vitest + build workflow.
 
+## Mocking PocketBase
+
+Every unit test needs two small building blocks: a `filter` mock (production code always
+builds filters via `pb.filter(raw, {params})`, never template-literal interpolation — see
+`.claude/CLAUDE.md`) and a `collection(name) → stubs` dispatch skeleton for the mock `pb`. Don't
+hand-roll these — import them from `$lib/server/test-helpers`:
+
+```ts
+export function mockFilter(raw: string, params?: Record<string, unknown>): string;
+export function makeMockPb(impls: Record<string, Record<string, ReturnType<typeof vi.fn>>>): PocketBase;
+```
+
+`mockFilter` mirrors the real `pb.filter()`: it quotes and escapes string params and substitutes
+every occurrence of each `{:param}` placeholder (numbers/booleans stay unquoted). `makeMockPb`
+builds a minimal `pb` whose `collection(name)` dispatches to the matching entry of `impls` and
+whose `filter` is an assertable spy delegating to `mockFilter`. A collection you didn't stub
+resolves to `undefined`, so a test that touches it fails loudly instead of silently no-opping.
+
+```ts
+import { makeMockPb } from '$lib/server/test-helpers';
+
+const getOne = vi.fn().mockResolvedValue({ id: 'item1' });
+const pb = makeMockPb({ items: { getOne } });
+```
+
+Destructure the `vi.fn()`s you need to assert on *before* passing them into `impls` — per-test
+spy access stays local to the test, the helper only owns the dispatch shape. If a scenario needs
+more than plain method stubs (e.g. picking a response based on the incoming `filter` string, or a
+reusable scenario factory), build that on top of `makeMockPb` rather than duplicating its
+dispatch/filter logic — see `deleteItem`'s `makePb(opts)` in
+[`items.test.ts`](/src/lib/server/items.test.ts) for the pattern. Some `$lib/server/*` helpers
+also reach a privileged backend hook via `pb.send('/api/…')` or read `pb.authStore` — stub those
+as siblings on the object returned by `makeMockPb` (`{ ...makeMockPb({...}), send: vi.fn() }`),
+not inside `collection()`.
+
 ## Practice
 
 Test files currently live next to their target. For example, for testing conversation functionality, the test file lives directly next to [/src/routes/conversations/[conversationId]/+page.server.ts](/src/routes/conversations/[conversationId]/+page.server.ts). It should NOT have a leading +, this is reserved for Svelte files only.
 
-To test a page and its functions, use Vitest like so:
+To test a page and its functions, use Vitest like so (the `mockLocals.pb` below is a simplified
+sketch — for a real `pb.filter`/`collection()` mock use `makeMockPb` from the "Mocking
+PocketBase" section above):
 
 ```javascript
 

--- a/src/lib/server/items.test.ts
+++ b/src/lib/server/items.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { deleteItem, deleteMultipleItems, setItemStatus } from './items';
+import { makeMockPb } from './test-helpers';
 
 vi.mock('../../routes/conversations/[conversationId]/conversation.server', () => ({
 	deleteConversation: vi.fn().mockResolvedValue(undefined),
@@ -43,18 +44,10 @@ function makePb({
 	);
 
 	const pb = {
-		collection: vi.fn((name: string) => {
-			if (name === 'items') return { getOne, delete: deleteRecord, update };
-			if (name === 'conversations') return { getFullList };
-			return {};
+		...makeMockPb({
+			items: { getOne, delete: deleteRecord, update },
+			conversations: { getFullList },
 		}),
-		filter: (raw: string, params?: Record<string, unknown>) => {
-			if (!params) return raw;
-			return Object.entries(params).reduce(
-				(acc, [k, v]) => acc.replace(`{:${k}}`, String(v)),
-				raw
-			);
-		},
 		_deleteRecord: deleteRecord,
 		_update: update,
 		_getOne: getOne,
@@ -130,38 +123,24 @@ describe('deleteMultipleItems', () => {
 			item2: [{ id: 'conv-open' }],
 		};
 
-		const pb = {
-			collection: vi.fn((name: string) => {
-				if (name === 'items') {
-					return {
-						getOne: vi.fn((id: string) => Promise.resolve(itemMap[id])),
-						delete: vi.fn().mockResolvedValue(undefined),
-					};
-				}
-				if (name === 'conversations') {
-					return {
-						getFullList: vi.fn(({ filter }: { filter?: string } = {}) => {
-							if (typeof filter === 'string' && filter.includes('lendingStatus')) {
-								// Open guard — derive item ID from the filter string
-								for (const [itemId, convs] of Object.entries(openConvsByItemId)) {
-									if (filter.includes(itemId)) return Promise.resolve(convs);
-								}
-								return Promise.resolve([]);
-							}
-							return Promise.resolve([]); // cascade — no remaining convs
-						}),
-					};
-				}
-				return {};
-			}),
-			filter: (raw: string, params?: Record<string, unknown>) => {
-				if (!params) return raw;
-				return Object.entries(params).reduce(
-					(acc, [k, v]) => acc.replace(`{:${k}}`, String(v)),
-					raw
-				);
+		const pb = makeMockPb({
+			items: {
+				getOne: vi.fn((id: string) => Promise.resolve(itemMap[id])),
+				delete: vi.fn().mockResolvedValue(undefined),
 			},
-		} as unknown as Parameters<typeof deleteMultipleItems>[0];
+			conversations: {
+				getFullList: vi.fn(({ filter }: { filter?: string } = {}) => {
+					if (typeof filter === 'string' && filter.includes('lendingStatus')) {
+						// Open guard — derive item ID from the filter string
+						for (const [itemId, convs] of Object.entries(openConvsByItemId)) {
+							if (filter.includes(itemId)) return Promise.resolve(convs);
+						}
+						return Promise.resolve([]);
+					}
+					return Promise.resolve([]); // cascade — no remaining convs
+				}),
+			},
+		}) as unknown as Parameters<typeof deleteMultipleItems>[0];
 
 		const { deleted, blocked } = await deleteMultipleItems(pb, ['item1', 'item2'], OWNER_ID);
 

--- a/src/lib/server/test-helpers.test.ts
+++ b/src/lib/server/test-helpers.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mockFilter, makeMockPb } from './test-helpers';
+
+describe('mockFilter', () => {
+	it('returns raw unchanged when no params are given', () => {
+		expect(mockFilter('id = {:id}')).toBe('id = {:id}');
+	});
+
+	it('quotes and escapes string params', () => {
+		expect(mockFilter('name = {:name}', { name: "O'Brien" })).toBe("name = 'O\\'Brien'");
+	});
+
+	it('leaves numbers and booleans unquoted', () => {
+		expect(mockFilter('count > {:n} && active = {:b}', { n: 3, b: true })).toBe(
+			'count > 3 && active = true'
+		);
+	});
+
+	it('substitutes every occurrence of a repeated placeholder', () => {
+		expect(mockFilter('a = {:x} || b = {:x}', { x: 'v1' })).toBe("a = 'v1' || b = 'v1'");
+	});
+
+	it('leaves unknown placeholders untouched', () => {
+		expect(mockFilter('a = {:known} && b = {:unknown}', { known: 'v' })).toBe(
+			"a = 'v' && b = {:unknown}"
+		);
+	});
+});
+
+describe('makeMockPb', () => {
+	it('dispatches collection() to the matching impl', () => {
+		const getOne = vi.fn().mockResolvedValue({ id: 'item1' });
+		const pb = makeMockPb({ items: { getOne } });
+
+		expect(pb.collection('items')).toEqual({ getOne });
+	});
+
+	it('returns undefined for an unstubbed collection', () => {
+		const pb = makeMockPb({ items: { getOne: vi.fn() } });
+
+		expect(pb.collection('conversations')).toBeUndefined();
+	});
+
+	it('exposes pb.filter as an assertable spy delegating to mockFilter', () => {
+		const pb = makeMockPb({});
+
+		const result = pb.filter('id = {:id}', { id: 'abc' });
+
+		expect(result).toBe("id = 'abc'");
+		expect(pb.filter).toHaveBeenCalledWith('id = {:id}', { id: 'abc' });
+	});
+});

--- a/src/lib/server/test-helpers.ts
+++ b/src/lib/server/test-helpers.ts
@@ -1,0 +1,23 @@
+import { vi } from 'vitest';
+import type PocketBase from 'pocketbase';
+
+/** Mirror of the real pb.filter(): quotes + escapes strings, substitutes {:param} placeholders. */
+export function mockFilter(raw: string, params?: Record<string, unknown>): string {
+	if (!params) return raw;
+	let result = raw;
+	for (const [key, value] of Object.entries(params)) {
+		const escaped = typeof value === 'string' ? `'${value.replace(/'/g, "\\'")}'` : `${value}`;
+		result = result.replaceAll(`{:${key}}`, escaped);
+	}
+	return result;
+}
+
+/** Minimal mock pb: collection-name → method-stubs dispatch + the shared filter mock. */
+export function makeMockPb(
+	impls: Record<string, Record<string, ReturnType<typeof vi.fn>>>
+): PocketBase {
+	return {
+		collection: vi.fn((name: string) => impls[name]),
+		filter: vi.fn(mockFilter),
+	} as unknown as PocketBase;
+}

--- a/src/routes/conversations/[conversationId]/conversation.server.test.ts
+++ b/src/routes/conversations/[conversationId]/conversation.server.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import type PocketBase from 'pocketbase';
+import { makeMockPb } from '$lib/server/test-helpers';
 
 // Avoid loading the real notifications module (web-push + VAPID env) at import time.
 vi.mock('$lib/server/notifications.js', () => ({
@@ -9,23 +9,6 @@ vi.mock('$lib/server/notifications.js', () => ({
 }));
 
 import { deleteConversation, sendMessage } from './conversation.server';
-
-function mockFilter(raw: string, params?: Record<string, unknown>): string {
-	if (!params) return raw;
-	let result = raw;
-	for (const [key, value] of Object.entries(params)) {
-		const escaped = typeof value === 'string' ? `'${value.replace(/'/g, "\\'")}'` : `${value}`;
-		result = result.replaceAll(`{:${key}}`, escaped);
-	}
-	return result;
-}
-
-function makeMockPb(impls: Record<string, Record<string, ReturnType<typeof vi.fn>>>): PocketBase {
-	return {
-		collection: vi.fn((name: string) => impls[name]),
-		filter: vi.fn(mockFilter),
-	} as unknown as PocketBase;
-}
 
 describe('deleteConversation', () => {
 	it('deletes the conversation and every notification referencing it', async () => {


### PR DESCRIPTION
## What & why

Every new unit-test file re-implemented two building blocks by hand: a `pb.filter` mock (substituting `{:param}` placeholders) and a `collection(name) → impls[name]` dispatch skeleton for the mock `pb`. This had already drifted into ~15 hand-copied variants with diverging semantics (some without quoting, some replacing only the first placeholder occurrence).

This extracts the canonical variant into a single shared helper (issue's recommended **Option A**):

- **New `src/lib/server/test-helpers.ts`** — exactly two exports:
  - `mockFilter(raw, params?)` — mirror of the real `pb.filter()` (quotes + escapes strings, substitutes all `{:param}` occurrences via `replaceAll`).
  - `makeMockPb(impls)` — minimal mock `pb`: collection-name → method-stub dispatch plus the shared filter mock as an assertable spy (`vi.fn(mockFilter)`).
- **New `src/lib/server/test-helpers.test.ts`** — pins the helper's semantics (quoting/escaping, repeated-placeholder substitution, unknown-collection → `undefined`, spy delegation).
- **Migrated** `conversation.server.test.ts` and `items.test.ts` onto the shared helper (the scenario factory `makePb` in `items.test.ts` now builds on `makeMockPb`).
- **Docs**: new "Mocking PocketBase" section in `docs/testing-strategy.md`; the `write-tests` skill now points at the shared helper instead of propagating inline copies.

Deliberate scope decisions (per issue): no `overrides`/options param (YAGNI), unknown collection returns `undefined` (no silent `{}` fallback). Migrating the remaining ~9–13 files with their own filter-mock copies is a deferred follow-up.

Pure test/doc change — no production code, no backend, no schema, no UI.

## Test notes

- `npx vitest run` → 72 files / **748 tests pass**.
- `npm run lint` → clean.
- `npm run check` / `npm run build` → fail only on 6 pre-existing `$env` errors (`SYNC_SECRET`, `PB_SUPERUSER_EMAIL`, `PB_SUPERUSER_PASSWORD`) in unrelated `integrations/`/`sync` files (local env gap; CI has these set). No error touches the diff, and no production file imports `test-helpers.ts`.

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)