### PR TITLE
refactor(conversations): restructure /conversations route, fix message-spoofing and PII-leak bugs

### DIFF
--- a/.claude/skills/write-tests/SKILL.md
+++ b/.claude/skills/write-tests/SKILL.md
@@ -58,6 +58,11 @@ function makePb({ item, openConversations = [] }) {
 Always provide `pb.filter` — production code builds every filter through it (never with template
 literals), so a missing mock throws. Reset state between tests with `beforeEach(() => vi.clearAllMocks())`.
 
+If the code under test only needs `pb.collection(name)` + `pb.filter` (no `pb.send`/`authStore`),
+reach for the shared `mockFilter`/`makeMockPb` in `src/lib/test-utils/pocketbase.ts` instead of
+hand-rolling the snippet above — it's the same shape, already used by the `conversations` route's
+tests. Only write a custom factory (like the one above) when you need `send`/`authStore` too.
+
 **Not everything routes through `collection()`.** Some `$lib/server/*` helpers reach a privileged
 backend hook via the root-level `pb.send('/api/…')`, and a few read `pb.authStore`. Stub those as
 siblings of `pb.filter` on the `pb` object — `send: vi.fn().mockResolvedValue({ … })` — not inside

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,9 +119,19 @@ AllerLeih uses PocketBase's built-in realtime (SSE) subscriptions for live chat 
 
 Domain-specific reconciliation lives next to its route in rune-free helper modules rather than in the components themselves:
 
-- `src/routes/conversations/conversationListRealtime.ts` — keeps the conversation sidebar list in sync.
-- `src/routes/conversations/[conversationId]/conversationRealtime.ts` — keeps a single open conversation in sync (lending status, counterfactual, and the fetch/dedupe of newly appended messages). State is read/written through accessor closures so the page keeps ownership of the reactive state.
+- `src/routes/conversations/conversationListRealtime.ts` — keeps the conversation sidebar list in sync: `update` events sync `readByOwner`/`readByRequester`/`lastMessageAt`/`lendingStatus` and re-sort (mirroring the server's `-lastMessageAt,-updated` sort), `create` events insert the fetched record at its sorted position, `delete` events remove the entry.
+- `src/routes/conversations/[conversationId]/conversationRealtime.ts` — keeps a single open conversation in sync (lending status, counterfactual, and the fetch/dedupe of every newly appended message id in a coalesced/batched event, not just the last one). State is read/written through accessor closures so the page keeps ownership of the reactive state.
 
 Pages hold "server-load data that a realtime handler also writes to" in a `realtimeSynced()` box (`src/lib/stores/realtimeSynced.svelte.ts`) — a writable `$derived` that re-syncs from `load()` while staying directly assignable by the handler (issue #469).
+
+### Conversations: server-helper layout
+
+The `/conversations` area's server logic is split by ownership, following the "libs never import from routes" rule:
+
+- `src/lib/server/conversations.ts` — `deleteConversation()`, shared by the route's `?/deleteConversation` action and `$lib/server/items.ts`'s cascade-on-item-delete (an item's conversations are deleted with it).
+- `src/lib/server/items.ts` — `toggleItemStatus()` (flips an item's availability from the conversation header) alongside the existing `setItemStatus`/`deleteItem`/`deleteMultipleItems`.
+- `src/lib/server/notifications.ts` — `notifyAndPush()` bundles the create-notification + send-push pair every call site needs; `sendMessage` (route-local `conversation.server.ts`) and the 6 lending transitions (`[conversationId]/lending.server.ts`) both call it.
+- `[conversationId]/lending.server.ts` — the 6 `?/actionName` transitions are table-driven: `$lib/lending.ts`'s `LENDING_TRANSITIONS` supplies the role/from/to per action, and a local `TRANSITION_EFFECTS` table supplies the per-action item/notification side effects, both consumed by a single `executeLendingTransition()`.
+- `[conversationId]/conversationDetail.ts` — `toConversationDetail()` maps the raw `conversations` wire record (ids + optional `expand`) to the flattened, dangling-item-safe view-model the detail page and its header render from.
 
 Push notifications (for events that happen when the user is not on the site) use the Web Push standard via the `web-push` npm package — these are one-way server → browser messages, not WebSocket connections.

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -12,6 +12,10 @@ For now, we aim to build test coverage up as we go to achieve a reasonable balan
 
 Currently, this means that we gradually implement unit tests for server-side functions. Browser-level end-to-end tests (Playwright) now cover a first set of full flows — see [End-to-end tests](#end-to-end-tests-playwright) below.
 
+Shared PocketBase mock helpers (`mockFilter` + `makeMockPb`, extracted from duplicated per-file
+copies) live in [`src/lib/test-utils/pocketbase.ts`](/src/lib/test-utils/pocketbase.ts) — prefer
+importing them over hand-rolling a new copy when a test needs a mock `PocketBase` client.
+
 ## End-to-end tests (Playwright)
 
 The unit tests above mock PocketBase; the end-to-end suite (in [`/e2e`](/e2e)) instead drives

--- a/src/lib/components/InitialsAvatar.svelte
+++ b/src/lib/components/InitialsAvatar.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	/**
+	 * Local, privacy-preserving fallback avatar for users without a `profileImage` —
+	 * renders their initials instead of calling a third-party avatar service (which
+	 * would otherwise leak the username to that service).
+	 */
+	let { name, class: cls = '' }: { name: string; class?: string } = $props();
+
+	const initials = $derived(
+		name
+			.trim()
+			.split(/\s+/)
+			.slice(0, 2)
+			.map((part) => part[0]?.toUpperCase() ?? '')
+			.join('') || '?'
+	);
+</script>
+
+<div
+	class="flex items-center justify-center bg-tinte-200 dark:bg-tinte-700 text-tinte-600 dark:text-tinte-300 font-semibold select-none {cls}"
+	role="img"
+	aria-label={name}
+>
+	{initials}
+</div>

--- a/src/lib/conversationPartnerFields.test.ts
+++ b/src/lib/conversationPartnerFields.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { conversationFieldsWithSafePartners } from './conversationPartnerFields';
+
+describe('conversationFieldsWithSafePartners', () => {
+	it('appends the safe requester/itemOwner partner fields to the base fields', () => {
+		expect(conversationFieldsWithSafePartners('*')).toBe(
+			'*,expand.requester.id,expand.itemOwner.id,' +
+				'expand.requester.username,expand.itemOwner.username,' +
+				'expand.requester.deleted,expand.itemOwner.deleted,' +
+				'expand.requester.profileImage,expand.itemOwner.profileImage,' +
+				'expand.requester.verified,expand.itemOwner.verified,' +
+				'expand.requester.created,expand.itemOwner.created'
+		);
+	});
+
+	it('never includes email, regardless of the base fields passed in', () => {
+		const result = conversationFieldsWithSafePartners('*,expand.requestedItem.*');
+		expect(result).not.toMatch(/email/i);
+	});
+});

--- a/src/lib/conversationPartnerFields.ts
+++ b/src/lib/conversationPartnerFields.ts
@@ -1,0 +1,37 @@
+import type { ConversationPartner } from '$lib/types/models';
+
+/**
+ * Safe subset of `User` fields to expand for a conversation's `requester`/`itemOwner` —
+ * excludes `email` and other PII (see `models.ts`'s `User.email` doc: "should not be visible
+ * publicly"). Typed against `ConversationPartner` (rather than a plain `string[]`) so removing
+ * or renaming a field on that interface is a compile error here instead of a silent runtime gap.
+ * Keep in sync with what `ConversationHeader.svelte` (id, username, deleted, profileImage,
+ * verified, created) and `ConversationListItem.svelte` (username, deleted, both via
+ * `displayName()`) actually read.
+ *
+ * Lives outside `$lib/server` (unlike the two server `load()`s that also use this) because
+ * `conversationListRealtime.ts` needs it client-side, and SvelteKit forbids importing
+ * `$lib/server/*` from client code.
+ */
+const CONVERSATION_PARTNER_FIELDS: (keyof ConversationPartner)[] = [
+	'id',
+	'username',
+	'deleted',
+	'profileImage',
+	'verified',
+	'created',
+];
+
+/**
+ * Builds a PocketBase `fields` param that restricts the `requester`/`itemOwner` expands to
+ * {@link CONVERSATION_PARTNER_FIELDS} (never the full `User` record, in particular never
+ * `email`), while leaving `baseFields` — the conversation's own fields plus any other
+ * expand (e.g. `requestedItem`, `messages`) — unrestricted.
+ */
+export function conversationFieldsWithSafePartners(baseFields: string): string {
+	const partnerFields = CONVERSATION_PARTNER_FIELDS.flatMap((field) => [
+		`expand.requester.${field}`,
+		`expand.itemOwner.${field}`,
+	]).join(',');
+	return `${baseFields},${partnerFields}`;
+}

--- a/src/lib/lending.test.ts
+++ b/src/lib/lending.test.ts
@@ -2,10 +2,15 @@ import { describe, it, expect } from 'vitest';
 import {
 	LENDING_LIFECYCLE,
 	LENDING_STATUSES,
+	LENDING_ACTIONS,
+	LENDING_TRANSITIONS,
 	ACTIVE_LENDING_STATES,
 	OPEN_LENDING_STATES,
+	ABORTABLE_LENDING_STATES,
 	isLendingStatusIn,
 	lendingStatusFilter,
+	canTransition,
+	canAbortUi,
 	type LendingStatus,
 } from './lending';
 import { texts } from './texts';
@@ -108,6 +113,74 @@ describe('isLendingStatusIn', () => {
 		expect(isLendingStatusIn(ACTIVE_LENDING_STATES, 42)).toBe(false);
 		expect(isLendingStatusIn(ACTIVE_LENDING_STATES, null)).toBe(false);
 		expect(isLendingStatusIn(ACTIVE_LENDING_STATES, { s: 'active' })).toBe(false);
+	});
+});
+
+describe('LENDING_TRANSITIONS', () => {
+	it('has exactly one row per LENDING_ACTIONS entry', () => {
+		expect(new Set(Object.keys(LENDING_TRANSITIONS))).toEqual(new Set(LENDING_ACTIONS));
+	});
+
+	it("reuses ABORTABLE_LENDING_STATES for abortRequest's `from` (not a re-derived equivalent list)", () => {
+		expect(LENDING_TRANSITIONS.abortRequest.from).toBe(ABORTABLE_LENDING_STATES);
+	});
+});
+
+describe('canTransition', () => {
+	it('allows the owner to accept a pending request', () => {
+		expect(canTransition('acceptRequest', { isOwner: true, isRequester: false }, 'pending')).toBe(true);
+	});
+
+	it('denies the requester from accepting their own request', () => {
+		expect(canTransition('acceptRequest', { isOwner: false, isRequester: true }, 'pending')).toBe(false);
+	});
+
+	it('denies an accept from a non-pending state', () => {
+		expect(canTransition('acceptRequest', { isOwner: true, isRequester: false }, 'accepted')).toBe(false);
+	});
+
+	it('denies when currentStatus is undefined', () => {
+		expect(canTransition('acceptRequest', { isOwner: true, isRequester: false }, undefined)).toBe(false);
+	});
+
+	it('allows the requester (not the owner) to request a return of an active loan', () => {
+		expect(canTransition('requestReturn', { isOwner: false, isRequester: true }, 'active')).toBe(true);
+		expect(canTransition('requestReturn', { isOwner: true, isRequester: false }, 'active')).toBe(false);
+	});
+
+	it("allows EITHER participant to abort — role: 'participant' matches owner or requester", () => {
+		expect(canTransition('abortRequest', { isOwner: true, isRequester: false }, 'pending')).toBe(true);
+		expect(canTransition('abortRequest', { isOwner: false, isRequester: true }, 'accepted')).toBe(true);
+		expect(canTransition('abortRequest', { isOwner: false, isRequester: false }, 'pending')).toBe(false);
+	});
+
+	it('allows the owner to confirm a return from either active or return_requested', () => {
+		expect(canTransition('confirmReturn', { isOwner: true, isRequester: false }, 'active')).toBe(true);
+		expect(canTransition('confirmReturn', { isOwner: true, isRequester: false }, 'return_requested')).toBe(true);
+		expect(canTransition('confirmReturn', { isOwner: true, isRequester: false }, 'pending')).toBe(false);
+	});
+});
+
+describe('canAbortUi (#373 — intentionally divergent from the server-side abort rule)', () => {
+	it('shows abort to the requester (not the owner) while pending', () => {
+		expect(canAbortUi('pending', false)).toBe(true);
+		expect(canAbortUi('pending', true)).toBe(false);
+	});
+
+	it('shows abort to either party once accepted', () => {
+		expect(canAbortUi('accepted', false)).toBe(true);
+		expect(canAbortUi('accepted', true)).toBe(true);
+	});
+
+	it('hides abort for every other status', () => {
+		for (const status of ['active', 'return_requested', 'completed', 'rejected', 'aborted'] as const) {
+			expect(canAbortUi(status, false)).toBe(false);
+			expect(canAbortUi(status, true)).toBe(false);
+		}
+	});
+
+	it('hides abort when status is undefined', () => {
+		expect(canAbortUi(undefined, false)).toBe(false);
 	});
 });
 

--- a/src/lib/lending.ts
+++ b/src/lib/lending.ts
@@ -64,3 +64,70 @@ export function isLendingStatusIn(states: readonly LendingStatus[], value: unkno
 export function lendingStatusFilter(states: readonly LendingStatus[]): string {
 	return '(' + states.map((s) => `lendingStatus = "${s}"`).join(' || ') + ')';
 }
+
+// --- Transition table ---
+// Every server-side lending action as data: which role may call it, from which
+// status(es), and which status it lands on. `[conversationId]/lending.server.ts`'s
+// `executeLendingTransition()` looks entries up here instead of hardcoding the
+// role/state guard per function.
+
+/** The 6 server-side mutations exposed as `?/actionName` form actions. */
+export const LENDING_ACTIONS = [
+	'acceptRequest',
+	'rejectRequest',
+	'abortRequest',
+	'confirmHandover',
+	'requestReturn',
+	'confirmReturn',
+] as const;
+
+export type LendingAction = (typeof LENDING_ACTIONS)[number];
+
+/** Matches `loadAndValidateConversation`'s `requiredRole` parameter. */
+export type LendingRole = 'owner' | 'requester' | 'participant';
+
+export interface LendingTransition {
+	role: LendingRole;
+	from: readonly LendingStatus[];
+	to: LendingStatus;
+}
+
+export const LENDING_TRANSITIONS: Record<LendingAction, LendingTransition> = {
+	acceptRequest: { role: 'owner', from: ['pending'], to: 'accepted' },
+	rejectRequest: { role: 'owner', from: ['pending'], to: 'rejected' },
+	// Reuses ABORTABLE_LENDING_STATES rather than re-deriving an equivalent state list.
+	abortRequest: { role: 'participant', from: ABORTABLE_LENDING_STATES, to: 'aborted' },
+	confirmHandover: { role: 'owner', from: ['accepted'], to: 'active' },
+	requestReturn: { role: 'requester', from: ['active'], to: 'return_requested' },
+	confirmReturn: { role: 'owner', from: ['active', 'return_requested'], to: 'completed' },
+};
+
+/**
+ * Pure predicate over `LENDING_TRANSITIONS`: could `action` be performed by a caller in
+ * `role` given the conversation's `currentStatus`? Mirrors exactly what
+ * `loadAndValidateConversation` enforces server-side.
+ */
+export function canTransition(
+	action: LendingAction,
+	role: { isOwner: boolean; isRequester: boolean },
+	currentStatus: LendingStatus | undefined
+): boolean {
+	const transition = LENDING_TRANSITIONS[action];
+	if (!currentStatus || !isLendingStatusIn(transition.from, currentStatus)) return false;
+	if (transition.role === 'owner') return role.isOwner;
+	if (transition.role === 'requester') return role.isRequester;
+	return role.isOwner || role.isRequester;
+}
+
+/**
+ * UI-only rule for showing the "Anfrage abbrechen" button (#373 decision 1) —
+ * INTENTIONALLY DIFFERENT from `LENDING_TRANSITIONS.abortRequest`'s server-side rule.
+ * The server allows either party to abort in `pending` OR `accepted`
+ * (`ABORTABLE_LENDING_STATES`, `role: 'participant'`); the UI additionally hides the
+ * button from the OWNER while `pending`, since the owner has a dedicated "Ablehnen"
+ * action for that state instead. Do NOT collapse this into `canTransition` — the
+ * divergence between the two is deliberate, not a bug to "fix" into one predicate.
+ */
+export function canAbortUi(status: LendingStatus | undefined, isOwner: boolean): boolean {
+	return status === 'accepted' || (status === 'pending' && !isOwner);
+}

--- a/src/lib/server/conversations.test.ts
+++ b/src/lib/server/conversations.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { makeMockPb } from '$lib/test-utils/pocketbase';
+import { deleteConversation } from './conversations';
+
+describe('deleteConversation', () => {
+	it('deletes the conversation and every notification referencing it', async () => {
+		const convDelete = vi.fn().mockResolvedValue(true);
+		const notifDelete = vi.fn().mockResolvedValue(true);
+		const pb = makeMockPb({
+			conversations: { delete: convDelete },
+			notifications: {
+				getFullList: vi.fn().mockResolvedValue([{ id: 'n1' }, { id: 'n2' }]),
+				delete: notifDelete,
+			},
+		});
+
+		await deleteConversation(pb, 'conv1');
+
+		expect(convDelete).toHaveBeenCalledWith('conv1');
+		expect(notifDelete).toHaveBeenCalledTimes(2);
+		expect(notifDelete).toHaveBeenCalledWith('n1');
+		expect(notifDelete).toHaveBeenCalledWith('n2');
+	});
+
+	it('deletes the conversation even when no notifications reference it', async () => {
+		const convDelete = vi.fn().mockResolvedValue(true);
+		const notifDelete = vi.fn();
+		const pb = makeMockPb({
+			conversations: { delete: convDelete },
+			notifications: { getFullList: vi.fn().mockResolvedValue([]), delete: notifDelete },
+		});
+
+		await deleteConversation(pb, 'conv1');
+
+		expect(convDelete).toHaveBeenCalledWith('conv1');
+		expect(notifDelete).not.toHaveBeenCalled();
+	});
+
+	it('swallows a notification-cleanup failure (does not rethrow)', async () => {
+		const pb = makeMockPb({
+			conversations: { delete: vi.fn().mockResolvedValue(true) },
+			notifications: { getFullList: vi.fn().mockRejectedValue(new Error('boom')), delete: vi.fn() },
+		});
+
+		await expect(deleteConversation(pb, 'conv1')).resolves.toBeUndefined();
+	});
+
+	it('propagates a conversation-deletion failure (it is outside the cleanup try/catch)', async () => {
+		const pb = makeMockPb({
+			conversations: { delete: vi.fn().mockRejectedValue(new Error('cannot delete')) },
+			notifications: { getFullList: vi.fn(), delete: vi.fn() },
+		});
+
+		await expect(deleteConversation(pb, 'conv1')).rejects.toThrow('cannot delete');
+	});
+});

--- a/src/lib/server/conversations.ts
+++ b/src/lib/server/conversations.ts
@@ -1,0 +1,32 @@
+import type PocketBase from 'pocketbase';
+
+/**
+ * Re-exported for the two server `load()`s in this route (`+layout.server.ts`,
+ * `[conversationId]/+page.server.ts`) that historically imported it from here. The
+ * implementation now lives in `$lib/conversationPartnerFields.ts` (outside `$lib/server`) so
+ * that `conversationListRealtime.ts` — which runs client-side — can use it too, since
+ * SvelteKit forbids importing `$lib/server/*` from client code.
+ */
+export { conversationFieldsWithSafePartners } from '$lib/conversationPartnerFields';
+
+/**
+ * Deletes a conversation and every notification referencing it.
+ *
+ * Lives here (rather than in the `[conversationId]` route) because `$lib/server/items.ts`
+ * needs it too when cascading item deletion to its conversations — libs must never import
+ * from routes, so this is the shared home both the route action and `items.ts` call into.
+ *
+ * Throws on failure — caller is responsible for catching and returning fail().
+ */
+export async function deleteConversation(pb: PocketBase, conversationId: string): Promise<void> {
+	await pb.collection('conversations').delete(conversationId);
+
+	try {
+		const orphaned = await pb.collection('notifications').getFullList({
+			filter: pb.filter('relatedId={:conversationId}', { conversationId }),
+		});
+		await Promise.all(orphaned.map((n) => pb.collection('notifications').delete(n.id)));
+	} catch (err) {
+		console.error('Failed to clean up orphaned notifications for conversation', err);
+	}
+}

--- a/src/lib/server/items.test.ts
+++ b/src/lib/server/items.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { deleteItem, deleteMultipleItems, setItemStatus } from './items';
+import { deleteItem, deleteMultipleItems, setItemStatus, toggleItemStatus } from './items';
 
-vi.mock('../../routes/conversations/[conversationId]/conversation.server', () => ({
+vi.mock('./conversations', () => ({
 	deleteConversation: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { deleteConversation } from '../../routes/conversations/[conversationId]/conversation.server';
+import { deleteConversation } from './conversations';
 
 const OWNER_ID = 'user123';
 const OTHER_ID = 'user999';
@@ -25,7 +25,7 @@ function makePb({
 	openConversations = [],
 	allConversations = [],
 }: {
-	item?: { id: string; owner: string } | null;
+	item?: ({ id: string; owner: string } & Record<string, unknown>) | null;
 	openConversations?: { id: string }[];
 	allConversations?: { id: string }[];
 }) {
@@ -205,5 +205,52 @@ describe('setItemStatus', () => {
 		const result = await setItemStatus(pb, 'nonexistent', OWNER_ID, 'available');
 
 		expect(result).toBe(false);
+	});
+});
+
+describe('toggleItemStatus', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('flips an available item to unavailable when caller is the owner', async () => {
+		const pb = makePb({ item: { id: 'item1', owner: OWNER_ID, status: 'available' } });
+
+		const result = await toggleItemStatus(pb, 'item1', OWNER_ID);
+
+		expect(result).toEqual({ status: 'ok', newStatus: 'unavailable' });
+		expect(pb._update).toHaveBeenCalledWith('item1', { status: 'unavailable' });
+	});
+
+	it('flips an unavailable item to available when caller is the owner', async () => {
+		const pb = makePb({ item: { id: 'item1', owner: OWNER_ID, status: 'unavailable' } });
+
+		const result = await toggleItemStatus(pb, 'item1', OWNER_ID);
+
+		expect(result).toEqual({ status: 'ok', newStatus: 'available' });
+		expect(pb._update).toHaveBeenCalledWith('item1', { status: 'available' });
+	});
+
+	it('returns not_owner and does not update when caller is not the owner', async () => {
+		const pb = makePb({ item: { id: 'item1', owner: OWNER_ID, status: 'available' } });
+
+		const result = await toggleItemStatus(pb, 'item1', OTHER_ID);
+
+		expect(result).toEqual({ status: 'not_owner' });
+		expect(pb._update).not.toHaveBeenCalled();
+	});
+
+	it('returns not_found when the item does not exist', async () => {
+		const pb = makePb({ item: null });
+
+		const result = await toggleItemStatus(pb, 'nonexistent', OWNER_ID);
+
+		expect(result).toEqual({ status: 'not_found' });
+		expect(pb._update).not.toHaveBeenCalled();
+	});
+
+	it('propagates an update failure instead of swallowing it (so the caller can fail() the action)', async () => {
+		const pb = makePb({ item: { id: 'item1', owner: OWNER_ID, status: 'available' } });
+		pb._update.mockRejectedValueOnce(new Error('write failed'));
+
+		await expect(toggleItemStatus(pb, 'item1', OWNER_ID)).rejects.toThrow('write failed');
 	});
 });

--- a/src/lib/server/items.ts
+++ b/src/lib/server/items.ts
@@ -1,6 +1,6 @@
 import type PocketBase from 'pocketbase';
 import { OPEN_LENDING_STATES, lendingStatusFilter } from '$lib/lending';
-import { deleteConversation } from '../../routes/conversations/[conversationId]/conversation.server';
+import { deleteConversation } from './conversations';
 
 export type DeleteItemResult =
 	| { status: 'deleted' }
@@ -101,4 +101,37 @@ export async function setItemStatus(
 
 	await pb.collection('items').update(itemId, { status: newStatus });
 	return true;
+}
+
+export type ToggleItemStatusResult =
+	| { status: 'ok'; newStatus: 'available' | 'unavailable' }
+	| { status: 'not_found' }
+	| { status: 'not_owner' };
+
+/**
+ * Flips an item's status between `available`/`unavailable` after verifying ownership.
+ *
+ * Unlike the item-agnostic {@link setItemStatus}, this reads the current status itself to
+ * compute the flip, and — importantly — lets a failed update `throw` instead of swallowing
+ * it: the previous route-local copy of this logic caught and only `console.error`'d an update
+ * failure, so the form action reported success (no `fail()`) even when the write didn't
+ * happen. Callers are expected to catch and translate a thrown error into `fail()`.
+ */
+export async function toggleItemStatus(
+	pb: PocketBase,
+	itemId: string,
+	ownerUserId: string
+): Promise<ToggleItemStatusResult> {
+	let item;
+	try {
+		item = await pb.collection('items').getOne(itemId);
+	} catch {
+		return { status: 'not_found' };
+	}
+
+	if (item.owner !== ownerUserId) return { status: 'not_owner' };
+
+	const newStatus = item.status === 'available' ? 'unavailable' : 'available';
+	await pb.collection('items').update(itemId, { status: newStatus });
+	return { status: 'ok', newStatus };
 }

--- a/src/lib/server/notifications.ts
+++ b/src/lib/server/notifications.ts
@@ -2,6 +2,7 @@ import webpush from 'web-push';
 import { VAPID_PRIVATE_KEY, VAPID_SUBJECT } from '$env/static/private';
 import { PUBLIC_VAPID_PUBLIC_KEY } from '$env/static/public';
 import type { NotificationType } from '$lib/types/models.js';
+import { texts } from '$lib/texts';
 import type PocketBase from 'pocketbase';
 
 webpush.setVapidDetails(VAPID_SUBJECT, PUBLIC_VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY);
@@ -58,6 +59,30 @@ export async function createNotification(
 	} catch (err) {
 		console.error('Failed to create notification:', err);
 	}
+}
+
+/**
+ * Creates an in-app notification AND sends the matching push to a recipient in one call —
+ * the pairing every call site needs (previously duplicated between `lending.server.ts`'s
+ * `notifyUser` helper and an inline notification+push pair in `conversation.server.ts`'s
+ * `sendMessage`). Defaults `url` to the conversation the notification is `relatedId` to,
+ * which covers every current call site (all conversation-scoped notification types).
+ */
+export async function notifyAndPush(
+	pb: PocketBase,
+	params: {
+		recipient: string;
+		sender?: string;
+		type: NotificationType;
+		relatedId: string;
+		body: string;
+		url?: string;
+	}
+): Promise<void> {
+	const { recipient, sender, type, relatedId, body } = params;
+	const url = params.url ?? `/conversations/${relatedId}`;
+	await createNotification(pb, recipient, sender, type, relatedId, body);
+	await sendPushToUser(pb, recipient, texts.notifications.pushTitle, body, url);
 }
 
 /**

--- a/src/lib/test-utils/pocketbase.ts
+++ b/src/lib/test-utils/pocketbase.ts
@@ -1,0 +1,44 @@
+import { vi } from 'vitest';
+import type PocketBase from 'pocketbase';
+
+/**
+ * Test-only stand-in for PocketBase's `pb.filter(raw, params)` templating: substitutes each
+ * `{:key}` placeholder with its (string-quoted) value, mirroring the real SDK closely enough
+ * for assertions like `expect(someCollection.getOne).toHaveBeenCalledWith(...)` to see the same
+ * filter string production code would build. NOT a full reimplementation (no real escaping
+ * guarantees) — good enough because tests never feed it attacker-controlled input.
+ *
+ * Extracted from the ~15 test files across the repo that hand-rolled an identical copy of this
+ * function (see e.g. the pre-refactor `conversation.server.test.ts` / `lending.server.test.ts`).
+ */
+export function mockFilter(raw: string, params?: Record<string, unknown>): string {
+	if (!params) return raw;
+	let result = raw;
+	for (const [key, value] of Object.entries(params)) {
+		const escaped = typeof value === 'string' ? `'${value.replace(/'/g, "\\'")}'` : `${value}`;
+		result = result.replaceAll(`{:${key}}`, escaped);
+	}
+	return result;
+}
+
+/**
+ * Builds a minimal mock PocketBase client from per-collection method stubs.
+ *
+ * `impls` maps a collection name to an object of `vi.fn()` mocks for the methods that
+ * collection needs (e.g. `getOne`, `update`, `create`, `getFullList`) — whatever the code
+ * under test calls. `pb.filter` is wired to {@link mockFilter}.
+ *
+ * @example
+ * const pb = makeMockPb({
+ *   conversations: { getOne: vi.fn().mockResolvedValue(conv), update: vi.fn() },
+ *   items: { getOne: vi.fn().mockResolvedValue(item) },
+ * });
+ */
+export function makeMockPb(
+	impls: Record<string, Record<string, ReturnType<typeof vi.fn>>>
+): PocketBase {
+	return {
+		collection: vi.fn((name: string) => impls[name]),
+		filter: vi.fn(mockFilter),
+	} as unknown as PocketBase;
+}

--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -750,6 +750,10 @@ export const texts = {
 			noActiveConversations: 'Keine aktiven Unterhaltungen.',
 			noLendingConversations: 'Keine Anfragen für deine Sachen.',
 			noBorrowingConversations: 'Du hast noch nichts angefragt.',
+			backToConversations: '← Zurück zu deinen Anfragen',
+			noConversationSelectedTitle: 'Kein Gespräch ausgewählt',
+			noConversationSelectedBody: 'Wähle eine Unterhaltung aus der Liste oder starte eine neue über die Suche.',
+			goToSearch: 'Zur Suche',
 		},
 		items: {
 			title: 'Meine Dinge',
@@ -1102,11 +1106,17 @@ export const texts = {
 			confirmReturn: 'Rückgabe bestätigen',
 			abort: 'Anfrage abbrechen',
 		},
-		// Confirmation modal shown before aborting (mirrors the delete modal).
+		// Confirmation modal shown before aborting (mirrors confirmDelete below).
 		confirmAbort: {
 			title: 'Anfrage abbrechen',
 			body: 'Willst du diese Anfrage wirklich abbrechen? Die andere Person wird benachrichtigt und der Gegenstand wird wieder freigegeben.',
 			confirm: 'Anfrage abbrechen',
+		},
+		// Confirmation modal shown before deleting a conversation (mirrors confirmAbort above).
+		confirmDelete: {
+			title: 'Anfrage löschen',
+			body: 'Willst du diese Anfrage wirklich löschen? Alle Nachrichten dieser Unterhaltung gehen dabei verloren.',
+			confirm: 'Anfrage löschen',
 		},
 		statusDescription: {
 			pending: {

--- a/src/lib/types/models.ts
+++ b/src/lib/types/models.ts
@@ -473,15 +473,58 @@ export type CounterfactualAnswer =
 	| 'unsure'
 	| 'skipped';
 
+/**
+ * The valid non-'pending' answers a participant can actually submit for
+ * `submitCounterfactual` — 'pending' is the server-assigned initial sentinel, never a
+ * submittable answer. Single source of truth for that action's validation; the UI-only
+ * 'other' sentinel (replaced by free text before it reaches the server) is intentionally
+ * NOT included here — see `CounterfactualAnswer`'s `(string & {})` widening below.
+ */
+export const COUNTERFACTUAL_ANSWERS = [
+	'would_buy',
+	'not_important',
+	'too_expensive',
+	'borrow_elsewhere',
+	'unsure',
+	'skipped',
+] as const satisfies readonly Exclude<CounterfactualAnswer, 'pending'>[];
+
+/**
+ * Safe subset of `User` fields for a conversation's `requester`/`itemOwner` expand —
+ * deliberately excludes `email` and other PII (`User.email` is documented as "should not
+ * be visible publicly"). The conversations `load()`s restrict the expand to exactly this
+ * shape via PocketBase's `fields` param (see `$lib/conversationPartnerFields.ts`'s
+ * `conversationFieldsWithSafePartners()`) — keep both in sync with what `ConversationHeader.svelte`
+ * and `ConversationListItem.svelte` actually read from the expanded user.
+ */
+export interface ConversationPartner {
+	id: string;
+	username: string;
+	/** True if this account has been deleted/anonymized — used by `displayName()`. */
+	deleted?: boolean;
+	profileImage?: string;
+	verified?: boolean;
+	created: string;
+}
+
+/**
+ * Honest wire/record shape of the `conversations` collection: relations are plain ids,
+ * matching what PocketBase actually returns. Expanded relations (when requested via
+ * `expand: '...'`) are available under `expand`, each individually optional since an
+ * expand can be omitted or fail to resolve (e.g. a dangling/deleted `requestedItem`).
+ * For a flattened, dangling-item-safe view-model, see `toConversationDetail()` in
+ * `src/routes/conversations/[conversationId]/conversationDetail.ts`.
+ */
 export interface Conversation extends PocketBaseEntity {
-	requester: User;
-	itemOwner: User;
-	requestedItem: Item;
-	messages: Message[];
+	requester: UserId;
+	itemOwner: UserId;
+	requestedItem: ItemId;
+	messages: MessageId[];
 	readByRequester: boolean;
 	readByOwner: boolean;
 	lendingStatus?: LendingStatus;
-	counterfactual?: CounterfactualAnswer;
+	/** Free text is allowed for the 'other' answer — see `COUNTERFACTUAL_ANSWERS`. */
+	counterfactual?: CounterfactualAnswer | (string & {});
 	lastMessageAt?: string;
 	requesterLastSeenAt?: string;
 	ownerLastSeenAt?: string;
@@ -496,6 +539,13 @@ export interface Conversation extends PocketBaseEntity {
 
 	/** Same as `acceptedAt`, for the first transition into 'completed'. */
 	completedAt?: string;
+
+	expand?: {
+		requester?: ConversationPartner;
+		itemOwner?: ConversationPartner;
+		requestedItem?: Item;
+		messages?: Message[];
+	};
 }
 
 // --- NOTIFICATION ---

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -133,11 +133,12 @@ export function buildMailtoHref(email: string, subject: string, body: string): s
 }
 
 /**
- * Build the item-detail outbound-link href, routed through `/api/redirect` (which
- * enforces https + records the click). Used for external-item deep links and for an
- * owner's off-platform contact link (issue #438). The destination is URL-encoded so it
- * rides safely as a query param; `/api/redirect` is the authoritative https guard.
+ * Build an outbound-link href routed through `/api/redirect` (which enforces https +
+ * records the click, tagged with `source` for analytics). Used for external-item deep
+ * links, an owner's off-platform contact link (issue #438), and the conversation header's
+ * messenger buttons. The destination is URL-encoded so it rides safely as a query param;
+ * `/api/redirect` is the authoritative https guard.
  */
-export function buildItemRedirectHref(target: string, itemId: string): string {
-	return `/api/redirect?to=${encodeURIComponent(target)}&source=item-detail&item=${itemId}`;
+export function buildItemRedirectHref(target: string, itemId: string, source: string = 'item-detail'): string {
+	return `/api/redirect?to=${encodeURIComponent(target)}&source=${source}&item=${itemId}`;
 }

--- a/src/routes/conversations/+layout.server.ts
+++ b/src/routes/conversations/+layout.server.ts
@@ -1,6 +1,7 @@
 import type { Conversation } from '$lib/types/models.js';
 import { error } from '@sveltejs/kit';
 import { PUBLIC_PB_URL } from '$env/static/public';
+import { conversationFieldsWithSafePartners } from '$lib/server/conversations.js';
 
 export async function load({ locals }) {
 	const currentUserId = locals.user.id;
@@ -8,11 +9,19 @@ export async function load({ locals }) {
 
 	try {
 		allConversations = await locals.pb.collection('conversations').getFullList({
-			// TODO: Check if this even needs the filter given PocketBase should only return records the user has access to based on API rules
+			// The `conversations` collection's listRule already restricts results to
+			// `itemOwner`/`requester` matches (see the backend migration), so this filter is
+			// redundant against a well-behaved API rule — it's kept anyway as deliberate
+			// defense-in-depth: it documents the same constraint explicitly here, so a future
+			// change that accidentally loosens the API rule fails safe (an empty/narrower
+			// result set) instead of silently leaking other users' conversations.
 			filter: locals.pb.filter('requester = {:userId} || itemOwner = {:userId}', {
 				userId: currentUserId,
 			}),
 			expand: 'requester, itemOwner, requestedItem',
+			// requester/itemOwner are restricted to a safe field subset (never the full
+			// User, in particular never `email`) — see conversationFieldsWithSafePartners().
+			fields: conversationFieldsWithSafePartners('*,expand.requestedItem.*'),
 			sort: '-lastMessageAt,-updated', // sort by latest message, fall back to updated for conversations without messages yet
 		});
 	} catch (err) {

--- a/src/routes/conversations/+layout.svelte
+++ b/src/routes/conversations/+layout.svelte
@@ -3,134 +3,83 @@
 	import ConversationList from './ConversationList.svelte';
 	import { getClientPB } from '$lib/client-pb';
 	import { subscribeConversationList } from './conversationListRealtime';
+	import { scrollLock, viewportHeight } from './chatViewport';
+	import {
+		matchesRole,
+		matchesActive,
+		emptyReason as computeEmptyReason,
+		type ConversationRoleFilter,
+	} from './conversationFilters';
+	import { realtimeSynced } from '$lib/stores/realtimeSynced.svelte';
 	import { page } from '$app/state';
 	import { invalidateAll } from '$app/navigation';
 	import { onMount } from 'svelte';
-	import type { Conversation } from '$lib/types/models';
-	import { OPEN_LENDING_STATES, isLendingStatusIn } from '$lib/lending';
 
 	let { data, children } = $props();
 
 	// Filter state — written ONLY by the click handlers below, never by effects or
 	// navigation. The filters affect the sidebar list only: the open conversation stays
 	// open even when they hide it from the list.
-	// null = no filter selected, show both lending and borrowing conversations.
-	let activeFilter: 'lending' | 'borrowing' | null = $state(null);
+	let activeFilter: ConversationRoleFilter = $state(null);
 	let showOnlyActive = $state(true);
 
 	const hasConversation = $derived(!!page.params.conversationId);
 
 	let outerEl: HTMLDivElement | undefined = $state();
 
-	// Lock the document while a conversation route is mounted so the page itself can
-	// never scroll: the chat is a fixed-height app shell, and a scrollable document is
-	// what let the mobile keyboard scroll the whole page down (revealing the footer)
-	// instead of just reflowing the chat. The footer and the root <main> padding still
-	// exist in flow but are simply clipped below the fold. Scoped here (rather than in
-	// the root layout) via mount/unmount, the same pattern modals use for scroll-locking.
-	$effect(() => {
-		const html = document.documentElement;
-		const body = document.body;
-		const prevHtml = html.style.overflow;
-		const prevBody = body.style.overflow;
-		// Reset to the top before locking: on a cold load the document can already be
-		// scrolled down (e.g. the input focus dragging the too-tall page into view), and
-		// locking `overflow: hidden` would otherwise freeze it there — footer showing,
-		// view trapped (#529). The input now focuses with preventScroll, this is the belt.
-		window.scrollTo(0, 0);
-		html.style.overflow = 'hidden';
-		body.style.overflow = 'hidden';
-		return () => {
-			html.style.overflow = prevHtml;
-			body.style.overflow = prevBody;
-		};
-	});
+	// Server-load data that the realtime handler below also writes to directly (clearing
+	// unread dots, syncing status changes) — re-syncs from load() whenever it reruns (e.g.
+	// invalidateAll() on realtime reconnect), same pattern as the detail page's messages/
+	// lendingStatus/counterfactual boxes (issue #469).
+	const conversations = realtimeSynced(() => data.conversations);
 
-	// Size the chat container to fill the *visual* viewport below the navbar.
-	// Using visualViewport.height (rather than 100dvh) means the on-screen mobile
-	// keyboard shrinks the container: the message list (flex-1) absorbs the shrink
-	// and the input bar rides up just above the keyboard, matching native chat apps.
-	// The scroll-lock above keeps the page itself from scrolling, so the keyboard only
-	// reflows this container.
-	// On a cold load (push/share link, reload) the mobile visual viewport isn't settled
-	// yet — the browser toolbar is still expanded, so a single mount-time measurement
-	// fixes too small a height and the scroll-lock stops a correcting event from firing.
-	// So we re-measure across the settle window: after first paint (rAF), after the
-	// toolbar collapses (timeout), and on window `load` / `orientationchange`, on top of
-	// the live resize/scroll listeners. On internal navigation the viewport is already
-	// settled → the extra passes are harmless no-ops.
-	$effect(() => {
-		if (!outerEl) return;
+	// Segmented filter control config — literal Tailwind classes per tab/state (never
+	// interpolated, e.g. no `text-${color}`) so the two near-identical buttons collapse
+	// into one data-driven `{#each}` instead of duplicated markup.
+	const FILTER_TABS: {
+		key: 'borrowing' | 'lending';
+		label: string;
+		activeClasses: string;
+		inactiveClasses: string;
+		badgeActiveClasses: string;
+	}[] = [
+		{
+			key: 'borrowing',
+			label: texts.pages.conversations.borrowing,
+			activeClasses: 'bg-white dark:bg-tinte-700 text-primary shadow-sm',
+			inactiveClasses: 'text-primary-300 dark:text-primary-400/70 hover:text-primary',
+			badgeActiveClasses: 'bg-primary text-white',
+		},
+		{
+			key: 'lending',
+			label: texts.pages.conversations.lending,
+			activeClasses: 'bg-white dark:bg-tinte-700 text-accent shadow-sm',
+			inactiveClasses: 'text-accent-300 dark:text-accent-400/70 hover:text-accent',
+			badgeActiveClasses: 'bg-accent text-white',
+		},
+	];
+	const BADGE_INACTIVE_CLASSES = 'bg-tinte-300 dark:bg-tinte-600 text-tinte-600 dark:text-tinte-300';
 
-		const vv = window.visualViewport;
-
-		const update = () => {
-			const top = outerEl!.getBoundingClientRect().top + window.scrollY;
-			const viewportHeight = vv ? vv.height : window.innerHeight;
-			outerEl!.style.height = `${viewportHeight - top}px`;
-		};
-
-		update();
-		const rafId = requestAnimationFrame(update);
-		const timeoutId = setTimeout(update, 250);
-		window.addEventListener('load', update);
-		window.addEventListener('orientationchange', update);
-		window.addEventListener('resize', update);
-		vv?.addEventListener('resize', update);
-		vv?.addEventListener('scroll', update);
-		return () => {
-			cancelAnimationFrame(rafId);
-			clearTimeout(timeoutId);
-			window.removeEventListener('load', update);
-			window.removeEventListener('orientationchange', update);
-			window.removeEventListener('resize', update);
-			vv?.removeEventListener('resize', update);
-			vv?.removeEventListener('scroll', update);
-		};
-	});
-
-	// Local writable derived: re-derives from data.conversations whenever load() reruns
-	// (e.g. invalidateAll on realtime reconnect) and also accepts direct writes from the
-	// realtime handler below (clearing unread dots).
-	let conversations: Conversation[] = $derived([...data.conversations]);
-
-	// Role/status predicates shared by the tab counts and the visibility filter.
-	const isLending = (c: Conversation) => c.itemOwner === data.currentUser.id;
-	// Plain chats without lending status count as active; terminal states
-	// (rejected/aborted/completed) do not.
-	const isActive = (c: Conversation) =>
-		!c.lendingStatus || isLendingStatusIn(OPEN_LENDING_STATES, c.lendingStatus);
-	const matchesRole = (c: Conversation) =>
-		activeFilter === null || (activeFilter === 'lending') === isLending(c);
-	const matchesActive = (c: Conversation) => !showOnlyActive || isActive(c);
-
-	// Tab badge counts respect the active-only checkbox so the badge always matches
-	// what selecting that tab would show in the list.
-	const lendingConversations = $derived(
-		conversations.filter((c) => isLending(c) && matchesActive(c))
-	);
-	const borrowingConversations = $derived(
-		conversations.filter((c) => !isLending(c) && matchesActive(c))
-	);
+	// Per-tab count, respecting the active-only checkbox so the badge always matches what
+	// selecting that tab would show in the list.
+	function tabCount(key: 'borrowing' | 'lending'): number {
+		return conversations.value.filter(
+			(c) => matchesRole(c, data.currentUser.id, key) && matchesActive(c, showOnlyActive)
+		).length;
+	}
 
 	// Conversations after the lending/borrowing filter, before the "only active" checkbox —
 	// used to tell whether an empty result is due to the active-only filter or to genuinely
 	// having no conversations of that type.
-	const conversationsByFilter = $derived(conversations.filter(matchesRole));
+	const conversationsByRole = $derived(
+		conversations.value.filter((c) => matchesRole(c, data.currentUser.id, activeFilter))
+	);
 
 	// The filters apply strictly to the list — a conversation they hide stays open in the
 	// chat panel but is not shown (or highlighted) in the sidebar.
-	const visibleConversations = $derived(conversationsByFilter.filter(matchesActive));
+	const visibleConversations = $derived(conversationsByRole.filter((c) => matchesActive(c, showOnlyActive)));
 
-	const emptyReason = $derived(
-		conversationsByFilter.length > 0
-			? 'active'
-			: activeFilter === 'lending'
-				? 'lending'
-				: activeFilter === 'borrowing'
-					? 'borrowing'
-					: 'none'
-	);
+	const emptyReason = $derived(computeEmptyReason(conversationsByRole.length > 0, activeFilter));
 
 	function toggleFilter(filter: 'lending' | 'borrowing') {
 		activeFilter = activeFilter === filter ? null : filter;
@@ -143,18 +92,19 @@
 		// and #435.
 		return subscribeConversationList(
 			getClientPB(),
-			() => conversations,
-			(next) => (conversations = next),
+			() => conversations.value,
+			(next) => (conversations.value = next),
 			() => invalidateAll()
 		);
 	});
 </script>
 
-<!-- Height is set dynamically via $effect to fill viewport below the navbar; the
-	100dvh inline baseline covers the JS-lag window on cold load (before the $effect
-	measures) so the footer never blitzes through — the $effect then overwrites
-	style.height with the exact px value. -->
-<div bind:this={outerEl} class="flex flex-col" style="height: 100dvh">
+<!-- Height is set dynamically via the viewportHeight action to fill viewport below the
+	navbar; the 100dvh inline baseline covers the JS-lag window on cold load (before the
+	action measures) so the footer never blitzes through — the action then overwrites
+	style.height with the exact px value. scrollLock keeps the document itself from
+	scrolling while this layout is mounted (see chatViewport.ts for both). -->
+<div bind:this={outerEl} use:scrollLock use:viewportHeight class="flex flex-col" style="height: 100dvh">
 	<div class="flex-1 min-h-0 mx-auto w-full max-w-5xl flex gap-3 px-3 py-3">
 		<!-- SIDEBAR — full width on mobile when no conversation open, fixed width on desktop -->
 		<div
@@ -177,44 +127,25 @@
 				already-selected one deselects it back to "show all" -->
 			<div class="px-3 py-2.5 shrink-0">
 				<div class="flex p-1 bg-tinte-100 dark:bg-tinte-800 rounded-xl gap-1">
-					<button
-						onclick={() => toggleFilter('borrowing')}
-						class="flex-1 flex items-center justify-center gap-1.5 py-1.5 px-2 text-sm font-medium rounded-lg transition-all hover:cursor-pointer
-							{activeFilter === 'borrowing'
-							? 'bg-white dark:bg-tinte-700 text-primary shadow-sm'
-							: 'text-primary-300 dark:text-primary-400/70 hover:text-primary'}"
-					>
-						{texts.pages.conversations.borrowing}
-						{#if borrowingConversations.length > 0}
-							<span
-								class="w-4 h-4 rounded-full text-[10px] font-bold leading-none flex items-center justify-center shrink-0
-								{activeFilter === 'borrowing'
-									? 'bg-primary text-white'
-									: 'bg-tinte-300 dark:bg-tinte-600 text-tinte-600 dark:text-tinte-300'}"
-							>
-								{borrowingConversations.length}
-							</span>
-						{/if}
-					</button>
-					<button
-						onclick={() => toggleFilter('lending')}
-						class="flex-1 flex items-center justify-center gap-1.5 py-1.5 px-2 text-sm font-medium rounded-lg transition-all hover:cursor-pointer
-							{activeFilter === 'lending'
-							? 'bg-white dark:bg-tinte-700 text-accent shadow-sm'
-							: 'text-accent-300 dark:text-accent-400/70 hover:text-accent'}"
-					>
-						{texts.pages.conversations.lending}
-						{#if lendingConversations.length > 0}
-							<span
-								class="w-4 h-4 rounded-full text-[10px] font-bold leading-none flex items-center justify-center shrink-0
-								{activeFilter === 'lending'
-									? 'bg-accent text-white'
-									: 'bg-tinte-300 dark:bg-tinte-600 text-tinte-600 dark:text-tinte-300'}"
-							>
-								{lendingConversations.length}
-							</span>
-						{/if}
-					</button>
+					{#each FILTER_TABS as tab (tab.key)}
+						{@const count = tabCount(tab.key)}
+						<button
+							onclick={() => toggleFilter(tab.key)}
+							class="flex-1 flex items-center justify-center gap-1.5 py-1.5 px-2 text-sm font-medium rounded-lg transition-all hover:cursor-pointer
+								{activeFilter === tab.key ? tab.activeClasses : tab.inactiveClasses}"
+							aria-pressed={activeFilter === tab.key}
+						>
+							{tab.label}
+							{#if count > 0}
+								<span
+									class="w-4 h-4 rounded-full text-[10px] font-bold leading-none flex items-center justify-center shrink-0
+									{activeFilter === tab.key ? tab.badgeActiveClasses : BADGE_INACTIVE_CLASSES}"
+								>
+									{count}
+								</span>
+							{/if}
+						</button>
+					{/each}
 				</div>
 			</div>
 

--- a/src/routes/conversations/+page.svelte
+++ b/src/routes/conversations/+page.svelte
@@ -13,10 +13,10 @@
 		<MessageDotsOutline class="w-7 h-7 text-tinte-400 dark:text-tinte-500" />
 	</div>
 	<div class="flex flex-col gap-1">
-		<p class="text-sm font-semibold text-tinte-700 dark:text-tinte-200">Kein Gespräch ausgewählt</p>
+		<p class="text-sm font-semibold text-tinte-700 dark:text-tinte-200">{texts.pages.conversations.noConversationSelectedTitle}</p>
 		<p class="text-xs text-tinte-400 dark:text-tinte-500 max-w-48">
-			Wähle eine Unterhaltung aus der Liste oder starte eine neue über die Suche.
+			{texts.pages.conversations.noConversationSelectedBody}
 		</p>
 	</div>
-	<Button href={resolve('/search')}>Zur Suche</Button>
+	<Button href={resolve('/search')}>{texts.pages.conversations.goToSearch}</Button>
 </div>

--- a/src/routes/conversations/ConversationListItem.svelte
+++ b/src/routes/conversations/ConversationListItem.svelte
@@ -3,8 +3,17 @@
 	import { page } from '$app/state';
 	import { texts } from '$lib/texts';
 	import { displayName } from '$lib/utils/utils';
+	import type { Conversation } from '$lib/types/models';
 
-	let { conversation, currentUser, PB_IMG_URL } = $props();
+	let {
+		conversation,
+		currentUser,
+		PB_IMG_URL,
+	}: {
+		conversation: Conversation;
+		currentUser: { id: string };
+		PB_IMG_URL: string;
+	} = $props();
 
 	const isActive = $derived(page.params.conversationId === conversation.id);
 
@@ -17,8 +26,8 @@
 
 	const otherUser = $derived(
 		conversation.requester === currentUser.id
-			? conversation.expand.itemOwner
-			: conversation.expand.requester
+			? conversation.expand?.itemOwner
+			: conversation.expand?.requester
 	);
 
 	const isUnread = $derived(
@@ -35,7 +44,7 @@
 	// `image` is a multi-file field; the first entry is the cover.
 	const itemCover = $derived(Array.isArray(item?.image) ? item.image[0] : (item?.image ?? null));
 	const itemImage = $derived(
-		itemCover ? `${PB_IMG_URL}api/files/${item.collectionId}/${item.id}/${itemCover}` : null
+		item && itemCover ? `${PB_IMG_URL}api/files/${item.collectionId}/${item.id}/${itemCover}` : null
 	);
 
 	const lendingStatusLabel = $derived(

--- a/src/routes/conversations/[conversationId]/+error.svelte
+++ b/src/routes/conversations/[conversationId]/+error.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { page } from '$app/state';
 	import { texts } from '$lib/texts';
 	import { resolve } from '$app/paths';
@@ -7,8 +7,8 @@
 <div class="max-w-2xl mx-auto px-4 py-16 text-center">
 	{#if page.status === 404}
 		<p class="text-lg font-semibold text-tinte-700">{texts.errors.conversationNotFound}</p>
-		<a href={resolve("/conversations")} class="mt-4 inline-block text-sm text-primary-600 hover:underline">
-			← Zurück zu deinen Anfragen
+		<a href={resolve('/conversations')} class="mt-4 inline-block text-sm text-primary-600 hover:underline">
+			{texts.pages.conversations.backToConversations}
 		</a>
 	{:else}
 		<p class="text-lg font-semibold text-tinte-700">{texts.errors.somethingWentWrong}</p>

--- a/src/routes/conversations/[conversationId]/+page.server.ts
+++ b/src/routes/conversations/[conversationId]/+page.server.ts
@@ -113,15 +113,12 @@ export const actions = {
 
 		const recipientId = isRequester ? conversation.itemOwner : conversation.requester;
 		const senderName = displayName(locals.user);
-		return sendMessage(
-			locals.pb,
-			params.conversationId,
-			content,
-			locals.user.id,
-			recipientId,
+		return sendMessage(locals.pb, params.conversationId, content, {
+			fromUserId: locals.user.id,
+			toUserId: recipientId,
 			senderName,
-			/* recipientIsRequester */ isOwner
-		);
+			recipientIsRequester: isOwner,
+		});
 	},
 
 	toggleStatus: async ({ locals, params }) => {

--- a/src/routes/conversations/[conversationId]/+page.server.ts
+++ b/src/routes/conversations/[conversationId]/+page.server.ts
@@ -1,20 +1,36 @@
 import { error, fail, redirect } from '@sveltejs/kit';
 import type { ClientResponseError } from 'pocketbase';
-import { PUBLIC_PB_URL } from '$env/static/public';
-import type { Conversation, CounterfactualAnswer } from '$lib/types/models.js';
+import type { Conversation } from '$lib/types/models.js';
+import { COUNTERFACTUAL_ANSWERS } from '$lib/types/models.js';
 import { texts } from '$lib/texts';
+import { displayName } from '$lib/utils/utils';
+import { deleteConversation, conversationFieldsWithSafePartners } from '$lib/server/conversations.js';
+import { toggleItemStatus } from '$lib/server/items.js';
 import * as lending from './lending.server.js';
-import * as messaging from './conversation.server.js';
+import { sendMessage } from './conversation.server.js';
+import { toConversationDetail } from './conversationDetail.js';
 import { fetchPartnerContact } from '$lib/server/contacts';
+
+/** Cap on a chat message's length (mirrors the backend's max, keeps failures explicit). */
+const MAX_MESSAGE_LENGTH = 5000;
+
+/** Cap on the free-text answer for the 'other' counterfactual option. */
+const MAX_COUNTERFACTUAL_TEXT_LENGTH = 1000;
+
+/** UI-only sentinel for "I'll type my own answer" — replaced by the free-text field's value. */
+const COUNTERFACTUAL_OTHER_SENTINEL = 'other';
 
 export async function load({ params, locals }) {
 	const conversationId: string = params.conversationId;
-	let conversationRecord;
+	let conversationRecord: Conversation;
 	try {
 		conversationRecord = await locals.pb
 			.collection('conversations')
-			.getOne(conversationId, {
+			.getOne<Conversation>(conversationId, {
 				expand: 'requester, itemOwner, requestedItem, messages',
+				// requester/itemOwner are restricted to a safe field subset (never the full
+				// User, in particular never `email`) — see conversationFieldsWithSafePartners().
+				fields: conversationFieldsWithSafePartners('*,expand.requestedItem.*,expand.messages.*'),
 			});
 	} catch (err) {
 		const e = err as Partial<ClientResponseError>;
@@ -26,19 +42,7 @@ export async function load({ params, locals }) {
 		locals.user?.id === conversationRecord.itemOwner;
 	if (!isParticipant) error(403, texts.errors.noPermission);
 
-	const conversation: Conversation = {
-		id: conversationRecord.id,
-		requester: conversationRecord.expand?.requester,
-		itemOwner: conversationRecord.expand?.itemOwner,
-		requestedItem: conversationRecord.expand?.requestedItem,
-		messages: conversationRecord.expand?.messages,
-		readByRequester: conversationRecord.readByRequester,
-		readByOwner: conversationRecord.readByOwner,
-		lendingStatus: conversationRecord.lendingStatus ?? undefined,
-		counterfactual: conversationRecord.counterfactual ?? undefined,
-		created: conversationRecord.created,
-		updated: conversationRecord.updated,
-	};
+	const conversation = toConversationDetail(conversationRecord);
 
 	// Mark the conversation as read for the current viewer
 	if (locals.user) {
@@ -80,7 +84,7 @@ export async function load({ params, locals }) {
 			: conversationRecord.requester;
 	const partnerContact = await fetchPartnerContact(locals.pb, partnerId);
 
-	return { conversation, PB_URL: PUBLIC_PB_URL, partnerContact };
+	return { conversation, partnerContact };
 }
 
 export const actions = {
@@ -88,34 +92,70 @@ export const actions = {
 		const data = await request.formData();
 		const content = data.get('messageContent')?.toString().trim();
 		if (!content) return fail(400, { fail: true, message: texts.errors.somethingWentWrong });
-		if (content.length > 5000) return fail(400, { fail: true, message: texts.errors.somethingWentWrong });
-		const senderName = locals.user.username ?? locals.user.name ?? 'Jemand';
-		return messaging.sendMessage(
+		if (content.length > MAX_MESSAGE_LENGTH) return fail(400, { fail: true, message: texts.errors.somethingWentWrong });
+
+		// The recipient must be derived server-side from the conversation's actual
+		// participants — never trust a client-supplied identity here (a hidden
+		// `chatPartnerId` field used to let any participant spoof an arbitrary
+		// recipient for messaging/push-notification purposes).
+		let conversation: Pick<Conversation, 'requester' | 'itemOwner'>;
+		try {
+			conversation = await locals.pb
+				.collection('conversations')
+				.getOne(params.conversationId, { fields: 'requester,itemOwner' });
+		} catch (err) {
+			const e = err as Partial<ClientResponseError>;
+			return fail(e.status ?? 500, { fail: true, message: texts.lending.errors.notFound });
+		}
+		const isRequester = conversation.requester === locals.user.id;
+		const isOwner = conversation.itemOwner === locals.user.id;
+		if (!isRequester && !isOwner) return fail(403, { fail: true, message: texts.errors.noPermission });
+
+		const recipientId = isRequester ? conversation.itemOwner : conversation.requester;
+		const senderName = displayName(locals.user);
+		return sendMessage(
 			locals.pb,
 			params.conversationId,
 			content,
 			locals.user.id,
-			data.get('chatPartnerId') as string,
-			senderName
+			recipientId,
+			senderName,
+			/* recipientIsRequester */ isOwner
 		);
 	},
 
-	toggleStatus: async ({ locals, request }) => {
-		const data = await request.formData();
-		return messaging.toggleItemStatus(locals.pb, data.get('itemId')?.toString() ?? '', locals.user.id);
+	toggleStatus: async ({ locals, params }) => {
+		// Derived from the conversation's own item relation — never trusts a client-supplied
+		// itemId (a hidden form field used to let a caller target an arbitrary item).
+		let conversation: Pick<Conversation, 'requestedItem'>;
+		try {
+			conversation = await locals.pb
+				.collection('conversations')
+				.getOne(params.conversationId, { fields: 'requestedItem' });
+		} catch (err) {
+			const e = err as Partial<ClientResponseError>;
+			return fail(e.status ?? 500, { fail: true, message: texts.lending.errors.notFound });
+		}
+
+		try {
+			const result = await toggleItemStatus(locals.pb, conversation.requestedItem, locals.user.id);
+			if (result.status === 'not_found') return fail(404, { fail: true, message: texts.errors.itemNotFound });
+			if (result.status === 'not_owner') return fail(403, { fail: true, message: texts.errors.noPermission });
+		} catch (err) {
+			const e = err as Partial<ClientResponseError>;
+			return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });
+		}
 	},
 
-	deleteConversation: async ({ locals, request }) => {
-		const data = await request.formData();
-		const conversationId = data.get('conversationId') as string;
+	deleteConversation: async ({ locals, params }) => {
 		try {
 			const conv = await locals.pb
 				.collection('conversations')
-				.getOne(conversationId, { fields: 'requester,itemOwner' });
-			if (conv.requester !== locals.user?.id && conv.itemOwner !== locals.user?.id) {
+				.getOne(params.conversationId, { fields: 'requester,itemOwner' });
+			if (conv.requester !== locals.user.id && conv.itemOwner !== locals.user.id) {
 				return fail(403, { fail: true, message: texts.errors.noPermission });
 			}
-			await messaging.deleteConversation(locals.pb, conversationId);
+			await deleteConversation(locals.pb, params.conversationId);
 		} catch (err) {
 			const e = err as Partial<ClientResponseError>;
 			return fail(e.status ?? 500, { fail: true, message: e.data?.message ?? texts.errors.failedToDeleteConversation });
@@ -124,56 +164,58 @@ export const actions = {
 	},
 
 	acceptRequest: async ({ locals, params }) => {
-		if (!locals.user) return fail(401, { fail: true, message: texts.lending.errors.noPermission });
 		return lending.acceptRequest(locals.pb, params.conversationId, locals.user.id);
 	},
 
 	rejectRequest: async ({ locals, params }) => {
-		if (!locals.user) return fail(401, { fail: true, message: texts.lending.errors.noPermission });
 		return lending.rejectRequest(locals.pb, params.conversationId, locals.user.id);
 	},
 
 	abortRequest: async ({ locals, params }) => {
-		if (!locals.user) return fail(401, { fail: true, message: texts.lending.errors.noPermission });
 		return lending.abortRequest(locals.pb, params.conversationId, locals.user.id);
 	},
 
 	confirmHandover: async ({ locals, params }) => {
-		if (!locals.user) return fail(401, { fail: true, message: texts.lending.errors.noPermission });
 		return lending.confirmHandover(locals.pb, params.conversationId, locals.user.id);
 	},
 
 	requestReturn: async ({ locals, params }) => {
-		if (!locals.user) return fail(401, { fail: true, message: texts.lending.errors.noPermission });
 		const requesterName = locals.user.username ?? texts.pages.itemDetail.unknownRequester;
 		return lending.requestReturn(locals.pb, params.conversationId, locals.user.id, requesterName);
 	},
 
 	confirmReturn: async ({ locals, params }) => {
-		if (!locals.user) return fail(401, { fail: true, message: texts.lending.errors.noPermission });
 		return lending.confirmReturn(locals.pb, params.conversationId, locals.user.id);
 	},
 
-	submitCounterfactual: async ({ locals, request }) => {
+	submitCounterfactual: async ({ locals, request, params }) => {
 		const form = await request.formData();
-		const conversationId = form.get('conversationId') as string;
 		let answer = form.get('answer') as string;
-		// 'other' is a UI-only sentinel replaced by free text below; all other values must be valid CounterfactualAnswer values (excluding 'pending' which is server-assigned).
-		const valid: (CounterfactualAnswer | 'other')[] = ['would_buy', 'not_important', 'too_expensive', 'borrow_elsewhere', 'unsure', 'other', 'skipped'];
-		if (!valid.includes(answer as CounterfactualAnswer | 'other')) return fail(400, { fail: true, message: texts.errors.somethingWentWrong });
-		if (answer === 'other') {
+		// 'other' is a UI-only sentinel replaced by free text below; all other values must be
+		// one of the valid submittable COUNTERFACTUAL_ANSWERS ('pending' is server-assigned,
+		// never a submittable answer, and therefore correctly excluded from that list).
+		const validSentinelsOrAnswers: readonly string[] = [...COUNTERFACTUAL_ANSWERS, COUNTERFACTUAL_OTHER_SENTINEL];
+		if (!validSentinelsOrAnswers.includes(answer)) return fail(400, { fail: true, message: texts.errors.somethingWentWrong });
+		if (answer === COUNTERFACTUAL_OTHER_SENTINEL) {
 			const text = (form.get('answerText') as string)?.trim();
 			if (!text) return fail(400, { fail: true, message: texts.errors.somethingWentWrong });
+			if (text.length > MAX_COUNTERFACTUAL_TEXT_LENGTH) return fail(400, { fail: true, message: texts.errors.somethingWentWrong });
 			answer = text;
 		}
 		try {
 			const conv = await locals.pb
 				.collection('conversations')
-				.getOne(conversationId, { fields: 'requester,itemOwner' });
-			if (conv.requester !== locals.user?.id && conv.itemOwner !== locals.user?.id) {
+				.getOne(params.conversationId, { fields: 'requester,counterfactual' });
+			// Only the original requester answers the research question (an owner is not who
+			// the question is about), and only once — overwriting an already-submitted answer
+			// is not allowed.
+			if (conv.requester !== locals.user.id) {
 				return fail(403, { fail: true, message: texts.errors.noPermission });
 			}
-			await locals.pb.collection('conversations').update(conversationId, { counterfactual: answer });
+			if (conv.counterfactual !== 'pending') {
+				return fail(400, { fail: true, message: texts.errors.somethingWentWrong });
+			}
+			await locals.pb.collection('conversations').update(params.conversationId, { counterfactual: answer });
 		} catch (err) {
 			const e = err as Partial<ClientResponseError>;
 			return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });

--- a/src/routes/conversations/[conversationId]/+page.svelte
+++ b/src/routes/conversations/[conversationId]/+page.svelte
@@ -2,16 +2,14 @@
 	// Imports for pocketbase real-time subcription
 	import type PocketBase from 'pocketbase';
 	import { onMount } from 'svelte';
-	import { enhance } from '$app/forms';
 	import { invalidateAll } from '$app/navigation';
-	import { PUBLIC_PB_URL } from '$env/static/public';
 	import { getClientPB } from '$lib/client-pb';
 	import { realtimeSynced } from '$lib/stores/realtimeSynced.svelte';
 	import { subscribeConversation } from './conversationRealtime';
+	import { stickToBottom } from './chatScroll';
+	import { startPresenceHeartbeat } from './presenceHeartbeat';
 
 	// Other imports
-	import { Modal, Input } from 'flowbite-svelte';
-	import Button from '$lib/components/ui/Button.svelte';
 	import MessageElement from './MessageElement.svelte';
 	import { displayName } from '$lib/utils/utils';
 	import { ABORTABLE_LENDING_STATES, isLendingStatusIn } from '$lib/lending';
@@ -20,6 +18,7 @@
 	import MessageForm from './MessageForm.svelte';
 	import LendingStatusBar from './LendingStatusBar.svelte';
 	import CounterfactualModal from './CounterfactualModal.svelte';
+	import ConfirmActionModal from './ConfirmActionModal.svelte';
 	import SeoHead from '$lib/components/SeoHead.svelte';
 
 	// Props and state variables
@@ -43,7 +42,6 @@
 			? data.conversation.requester
 			: data.conversation.itemOwner
 	);
-	let messageText: string = $state('');
 
 	// UI state variables
 	let deleteConversationModal = $state(false);
@@ -62,57 +60,12 @@
 	let showCounterfactualModal = $derived(
 		counterfactual.value === 'pending' && !loggedInUserIsItemOwner
 	);
-	let isSubmitting: boolean = $state(false);
-	let chatWindow: HTMLDivElement;
-
-	function scrollToBottom(smooth = true) {
-		if (!chatWindow) return;
-		chatWindow.scrollTo({
-			top: chatWindow.scrollHeight,
-			behavior: smooth ? 'smooth' : 'auto',
-		});
-	}
-
-	// Scroll chat window to bottom when messages change
-	$effect(() => {
-		if (messages.value && messages.value.length > 0 && chatWindow) {
-			setTimeout(() => scrollToBottom(true), 0);
-		}
-	});
 
 	// Grab the shared client once mounted.
 	// Must be $state so the subscription $effect re-runs when pb is set.
 	let pb: PocketBase | undefined = $state();
 	onMount(() => {
 		pb = getClientPB();
-
-		// Keep the newest messages in view when the visual viewport changes height — e.g.
-		// when the mobile keyboard opens and the layout shrinks the chat container. The
-		// container is resized by the layout's own resize handler, which runs in the same
-		// event; scrolling synchronously here would target the pre-resize height (a no-op)
-		// and leave the latest messages hidden below the raised input bar. Defer with rAF
-		// so we scroll after the resize + reflow, then once more after the open/close
-		// animation settles.
-		// Also re-scroll after the layout's cold-load height correction (push/share link,
-		// reload): that correction fires on window `load` / `orientationchange` — not
-		// necessarily via a vv resize — so mirror those triggers here to land at the bottom
-		// once the container has grown to its settled height.
-		const vv = window.visualViewport;
-		let settleTimer: ReturnType<typeof setTimeout>;
-		const keepAtBottom = () => {
-			requestAnimationFrame(() => scrollToBottom(false));
-			clearTimeout(settleTimer);
-			settleTimer = setTimeout(() => scrollToBottom(false), 150);
-		};
-		vv?.addEventListener('resize', keepAtBottom);
-		window.addEventListener('load', keepAtBottom);
-		window.addEventListener('orientationchange', keepAtBottom);
-		return () => {
-			vv?.removeEventListener('resize', keepAtBottom);
-			window.removeEventListener('load', keepAtBottom);
-			window.removeEventListener('orientationchange', keepAtBottom);
-			clearTimeout(settleTimer);
-		};
 	});
 
 	// Set up real-time subscription. The merge/refetch/dedupe logic lives in the
@@ -144,22 +97,13 @@
 	});
 
 	// Presence heartbeat: periodically update the lastSeenAt timestamp so the backend
-	// knows the user is actively viewing this conversation and can suppress email notifications.
+	// knows the user is actively viewing this conversation and can suppress email
+	// notifications. See presenceHeartbeat.ts for the cadence/field-name/SSE-watchdog
+	// contract this must preserve.
 	$effect(() => {
 		if (!pb) return;
 		const field = loggedInUserIsItemOwner ? 'ownerLastSeenAt' : 'requesterLastSeenAt';
-
-		const ping = () => {
-			if (document.visibilityState !== 'visible') return;
-			pb!.collection('conversations').update(conversationId, {
-				[field]: new Date().toISOString(),
-			}).catch(() => {});
-		};
-
-		// Ping immediately on mount, then every 15 seconds
-		ping();
-		const interval = setInterval(ping, 15_000);
-		return () => clearInterval(interval);
+		return startPresenceHeartbeat(pb, conversationId, field);
 	});
 </script>
 
@@ -168,7 +112,6 @@
 <ConversationHeader
 	{chatPartner}
 	conversation={data.conversation}
-	PB_URL={PUBLIC_PB_URL}
 	onDelete={canDelete ? () => (deleteConversationModal = true) : undefined}
 	{loggedInUserIsItemOwner}
 	partnerContact={data.partnerContact}
@@ -183,7 +126,7 @@
 
 <!-- Messages list -->
 <div
-	bind:this={chatWindow}
+	use:stickToBottom={messages.value}
 	class="flex flex-col flex-1 overflow-auto px-4 py-4 gap-0.5 bg-papier dark:bg-tinte-900"
 >
 	{#if lendingStatus.value === 'pending' && messages.value.length === 0 && !loggedInUserIsItemOwner}
@@ -192,12 +135,12 @@
 		>
 			{texts.lending.statusDescription.pending.requesterNudge(
 				displayName(chatPartner),
-				data.conversation.requestedItem.name
+				data.conversation.requestedItem?.name ?? texts.ui.itemUnavailable
 			)}
 		</p>
 	{/if}
 	{#each messages.value as message (message.id)}
-		<MessageElement {message} isFromCurrentUser={data.currentUser?.id} />
+		<MessageElement {message} isSent={message.from === data.currentUser?.id} />
 	{/each}
 </div>
 
@@ -205,42 +148,24 @@
 <div
 	class="border-t border-tinte-100 dark:border-tinte-800 bg-white dark:bg-tinte-900 px-4 py-3"
 >
-	<MessageForm {chatPartner} bind:isSubmitting bind:messageText />
+	<MessageForm />
 </div>
 
-<CounterfactualModal
-	open={showCounterfactualModal}
-	conversationId={data.conversation.id}
+<CounterfactualModal open={showCounterfactualModal} />
+
+<ConfirmActionModal
+	bind:open={deleteConversationModal}
+	title={texts.lending.confirmDelete.title}
+	body={texts.lending.confirmDelete.body}
+	confirmLabel={texts.lending.confirmDelete.confirm}
+	action="?/deleteConversation"
 />
 
-<Modal title="Anfrage löschen" form bind:open={deleteConversationModal}>
-	Willst du diese Anfrage wirklich löschen? Alle Nachrichten dieser Unterhaltung
-	gehen dabei verloren.
-
-	<form
-		class="flex justify-end ml-2"
-		method="POST"
-		action="?/deleteConversation"
-	>
-		<Input name="conversationId" value={data.conversation.id} hidden></Input>
-		<Button variant="danger" type="submit">Anfrage löschen</Button>
-	</form>
-</Modal>
-
-<Modal title={texts.lending.confirmAbort.title} form bind:open={abortRequestModal}>
-	{texts.lending.confirmAbort.body}
-
-	<form
-		class="flex justify-end gap-2 ml-2"
-		method="POST"
-		action="?/abortRequest"
-		use:enhance={() =>
-			async ({ update }) => {
-				abortRequestModal = false;
-				await update();
-			}}
-	>
-		<Input name="conversationId" value={data.conversation.id} hidden></Input>
-		<Button variant="danger" type="submit">{texts.lending.confirmAbort.confirm}</Button>
-	</form>
-</Modal>
+<ConfirmActionModal
+	bind:open={abortRequestModal}
+	title={texts.lending.confirmAbort.title}
+	body={texts.lending.confirmAbort.body}
+	confirmLabel={texts.lending.confirmAbort.confirm}
+	action="?/abortRequest"
+	onConfirm={() => (abortRequestModal = false)}
+/>

--- a/src/routes/conversations/[conversationId]/ConfirmActionModal.svelte
+++ b/src/routes/conversations/[conversationId]/ConfirmActionModal.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import { Modal } from 'flowbite-svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import { enhance } from '$app/forms';
+
+	/**
+	 * Shared confirm-and-POST modal for the two near-identical destructive confirmations
+	 * on this route (delete conversation, abort request): a title + body, and a single
+	 * danger-styled submit button that POSTs to `action`. Both actions read
+	 * `conversationId` from `params.conversationId` (not a hidden form field), so this
+	 * component never needs to know the conversation id itself.
+	 */
+	let {
+		open = $bindable(),
+		title,
+		body,
+		confirmLabel,
+		action,
+		onConfirm,
+	}: {
+		open: boolean;
+		title: string;
+		body: string;
+		confirmLabel: string;
+		action: string;
+		/** Runs right before the form submits — e.g. closing the modal optimistically. */
+		onConfirm?: () => void;
+	} = $props();
+</script>
+
+<Modal {title} form bind:open>
+	{body}
+
+	<form
+		class="flex justify-end gap-2 ml-2"
+		method="POST"
+		{action}
+		use:enhance={() => {
+			onConfirm?.();
+			return async ({ update }) => {
+				await update();
+			};
+		}}
+	>
+		<Button variant="danger" type="submit">{confirmLabel}</Button>
+	</form>
+</Modal>

--- a/src/routes/conversations/[conversationId]/ConversationHeader.svelte
+++ b/src/routes/conversations/[conversationId]/ConversationHeader.svelte
@@ -1,20 +1,22 @@
 <script lang="ts">
 	import { texts } from '$lib/texts';
-	import { formatTimestamp, displayName } from '$lib/utils/utils';
+	import { formatTimestamp, displayName, itemOwnFileUrls, buildItemRedirectHref } from '$lib/utils/utils';
+	import { PUBLIC_PB_URL } from '$env/static/public';
 	import { TrashBinSolid, ChevronLeftOutline } from 'flowbite-svelte-icons';
 	import { Tooltip } from 'flowbite-svelte';
 	import { enhance } from '$app/forms';
 	import { resolve } from '$app/paths';
 	import VerifiedIcon from '$lib/components/VerifiedIcon.svelte';
+	import InitialsAvatar from '$lib/components/InitialsAvatar.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
-	import type { User, Conversation } from '$lib/types/models';
+	import type { ConversationPartner } from '$lib/types/models';
+	import type { ConversationDetail } from './conversationDetail';
 	import telegramLogo from '$lib/images/telegram-logo.svg';
 	import signalLogo from '$lib/images/Signal-Logo-White.svg';
 
-	let { chatPartner, conversation, PB_URL, onDelete, loggedInUserIsItemOwner = false, partnerContact } : {
-		chatPartner: User;
-		conversation: Conversation;
-		PB_URL: string;
+	let { chatPartner, conversation, onDelete, loggedInUserIsItemOwner = false, partnerContact } : {
+		chatPartner: ConversationPartner;
+		conversation: ConversationDetail;
 		onDelete?: () => void;
 		loggedInUserIsItemOwner?: boolean;
 		partnerContact: { telegramUsername: string | null; telegramHidden: boolean; signalLink: string | null; signalHidden: boolean };
@@ -34,30 +36,49 @@
 
 	const chatPartnerName = $derived(displayName(chatPartner));
 
-	// `image` is a multi-file field; the first entry is the cover thumbnail.
-	const requestedItemCoverUrl = $derived(
-		conversation.requestedItem.image?.[0]
-			? `${PB_URL}api/files/${conversation.requestedItem.collectionId}/${conversation.requestedItem.id}/${conversation.requestedItem.image[0]}`
-			: null
-	);
+	// The requested item can go dangling (deleted/inaccessible) while the conversation
+	// persists — every read below falls back to a safe placeholder instead of crashing.
+	const item = $derived(conversation.requestedItem);
+	const itemName = $derived(item?.name ?? texts.ui.itemUnavailable);
+	const itemRedirectItemId = $derived(item?.id ?? '');
+
+	const requestedItemCoverUrl = $derived(item ? (itemOwnFileUrls(PUBLIC_PB_URL, item)[0] ?? null) : null);
 
 	const chatPartnerAvatarUrl = $derived(
-		chatPartner.profileImage
-			? `${PB_URL}api/files/users/${chatPartner.id}/${chatPartner.profileImage}`
-			: `https://ui-avatars.com/api/?name=${encodeURIComponent(chatPartnerName)}&background=random`
+		chatPartner.profileImage ? `${PUBLIC_PB_URL}api/files/users/${chatPartner.id}/${chatPartner.profileImage}` : null
 	);
 </script>
 
-{#snippet messengerBtn(href: string | null, available: boolean, hidden: boolean, logo: string, activeColors: string, label: string, logoSize: string)}
+{#snippet messengerBtn({ href, available, hidden, logo, activeColors, label, logoSize }: {
+	href: string | null;
+	available: boolean;
+	hidden: boolean;
+	logo: string;
+	activeColors: string;
+	label: string;
+	logoSize: string;
+})}
 	{#if available || hidden}
-		<button
-			disabled={!available}
-			onclick={available ? () => window.open(`/api/redirect?to=${encodeURIComponent(href!)}&source=conversation&item=${conversation.requestedItem.id}`, '_blank', 'noopener,noreferrer') : undefined}
-			class="w-7 h-7 rounded-full flex items-center justify-center shrink-0 {available ? `${activeColors} transition-colors cursor-pointer` : 'bg-tinte-100 dark:bg-tinte-800 opacity-40 cursor-not-allowed'}"
-			aria-label={label}
-		>
-			<img src={logo} class="{logoSize} {available ? '' : 'opacity-50'}" alt={label} />
-		</button>
+		{#if available}
+			<!-- eslint-disable svelte/no-navigation-without-resolve -- buildItemRedirectHref() returns an already-resolved URL; the rule cannot see through the call -->
+			<a
+				href={buildItemRedirectHref(href!, itemRedirectItemId, 'conversation')}
+				target="_blank"
+				rel="noopener noreferrer"
+				class="w-7 h-7 rounded-full flex items-center justify-center shrink-0 {activeColors} transition-colors cursor-pointer"
+				aria-label={label}
+			>
+				<img src={logo} class={logoSize} alt={label} />
+			</a>
+			<!-- eslint-enable svelte/no-navigation-without-resolve -->
+		{:else}
+			<span
+				class="w-7 h-7 rounded-full flex items-center justify-center shrink-0 bg-tinte-100 dark:bg-tinte-800 opacity-40 cursor-not-allowed"
+				aria-label={label}
+			>
+				<img src={logo} class="{logoSize} opacity-50" alt={label} />
+			</span>
+		{/if}
 		<Tooltip type="light" placement="bottom">{available ? `Auf ${label} schreiben` : texts.messenger.onlyForTrusted}</Tooltip>
 	{/if}
 {/snippet}
@@ -75,58 +96,80 @@
 	</Button>
 
 	<!-- Item info (left) -->
-	<a
-		href={resolve('/items/[id]', { id: conversation.requestedItem.id })}
-		class="flex items-center gap-3 min-w-0 hover:opacity-80 transition-opacity"
-	>
-		<img
-			src={requestedItemCoverUrl ?? ''}
-			class="w-10 h-10 rounded-full object-cover shrink-0"
-			alt={conversation.requestedItem.name}
-		/>
-		<div class="flex flex-col min-w-0">
-			<span class="text-sm font-semibold truncate">{conversation.requestedItem.name}</span>
+	{#if item}
+		<a
+			href={resolve('/items/[id]', { id: item.id })}
+			class="flex items-center gap-3 min-w-0 hover:opacity-80 transition-opacity"
+		>
+			<img
+				src={requestedItemCoverUrl ?? ''}
+				class="w-10 h-10 rounded-full object-cover shrink-0"
+				alt={itemName}
+			/>
+			<div class="flex flex-col min-w-0">
+				<span class="text-sm font-semibold truncate">{itemName}</span>
 
-			<!-- Status badge: hidden on mobile -->
-			<div class="hidden md:block">
-				{#if loggedInUserIsItemOwner}
-					<form method="POST" action="?/toggleStatus" use:enhance class="w-fit">
-						<input type="hidden" name="itemId" value={conversation.requestedItem.id} />
-						<button
-							type="submit"
-							class="mt-0.5 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold border transition-colors cursor-pointer
-								{conversation.requestedItem.status === 'available'
-									? 'bg-green-100 text-green-800 border-green-300 hover:bg-green-200'
-									: 'bg-accent-100 text-accent-800 border-accent-300 hover:bg-accent-200'}"
+				<!-- Status badge: hidden on mobile -->
+				<div class="hidden md:block">
+					{#if loggedInUserIsItemOwner}
+						<form method="POST" action="?/toggleStatus" use:enhance class="w-fit">
+							<button
+								type="submit"
+								class="mt-0.5 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold border transition-colors cursor-pointer
+									{item.status === 'available'
+										? 'bg-green-100 text-green-800 border-green-300 hover:bg-green-200'
+										: 'bg-accent-100 text-accent-800 border-accent-300 hover:bg-accent-200'}"
+							>
+								{item.status === 'available'
+									? texts.itemStatus.available
+									: texts.itemStatus.unavailable}
+							</button>
+						</form>
+					{:else}
+						<span
+							class="mt-0.5 self-start inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold border
+								{item.status === 'available'
+									? 'bg-green-100 text-green-800 border-green-300'
+									: 'bg-accent-100 text-accent-800 border-accent-300'}"
 						>
-							{conversation.requestedItem.status === 'available'
+							{item.status === 'available'
 								? texts.itemStatus.available
 								: texts.itemStatus.unavailable}
-						</button>
-					</form>
-				{:else}
-					<span
-						class="mt-0.5 self-start inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold border
-							{conversation.requestedItem.status === 'available'
-								? 'bg-green-100 text-green-800 border-green-300'
-								: 'bg-accent-100 text-accent-800 border-accent-300'}"
-					>
-						{conversation.requestedItem.status === 'available'
-							? texts.itemStatus.available
-							: texts.itemStatus.unavailable}
-					</span>
-				{/if}
+						</span>
+					{/if}
+				</div>
 			</div>
+		</a>
+	{:else}
+		<div class="flex items-center gap-3 min-w-0">
+			<div class="w-10 h-10 rounded-full bg-tinte-200 dark:bg-tinte-700 shrink-0"></div>
+			<span class="text-sm font-semibold truncate text-tinte-400 dark:text-tinte-500">{itemName}</span>
 		</div>
-	</a>
+	{/if}
 
 	<!-- Right side: messenger icons + chat partner + delete -->
 	<div class="ml-auto flex items-center gap-2 shrink-0">
 		<!-- Messenger contact icon buttons -->
 		{#if showMessengerSection}
 			<div class="flex items-center gap-1.5">
-				{@render messengerBtn(telegramLink, telegramAvailable, telegramHidden, telegramLogo, 'bg-[#2CA5E0] hover:bg-[#229ED9]', texts.messenger.telegram, 'w-5 h-5')}
-				{@render messengerBtn(signalLink, signalAvailable, signalHidden, signalLogo, 'bg-[#2C6BED] hover:bg-[#2460D4]', texts.messenger.signal, 'w-3.5 h-3.5')}
+				{@render messengerBtn({
+					href: telegramLink,
+					available: telegramAvailable,
+					hidden: telegramHidden,
+					logo: telegramLogo,
+					activeColors: 'bg-[#2CA5E0] hover:bg-[#229ED9]',
+					label: texts.messenger.telegram,
+					logoSize: 'w-5 h-5',
+				})}
+				{@render messengerBtn({
+					href: signalLink,
+					available: signalAvailable,
+					hidden: signalHidden,
+					logo: signalLogo,
+					activeColors: 'bg-[#2C6BED] hover:bg-[#2460D4]',
+					label: texts.messenger.signal,
+					logoSize: 'w-3.5 h-3.5',
+				})}
 			</div>
 		{/if}
 
@@ -142,11 +185,15 @@
 				</span>
 			</div>
 			<div class="relative shrink-0">
-				<img
-					src={chatPartnerAvatarUrl}
-					class="w-9 h-9 rounded-full border object-cover"
-					alt="Avatar"
-				/>
+				{#if chatPartnerAvatarUrl}
+					<img
+						src={chatPartnerAvatarUrl}
+						class="w-9 h-9 rounded-full border object-cover"
+						alt={chatPartnerName}
+					/>
+				{:else}
+					<InitialsAvatar name={chatPartnerName} class="w-9 h-9 rounded-full border" />
+				{/if}
 				{#if chatPartner.verified}
 					<VerifiedIcon class="absolute -top-1 -right-1 h-3.5 w-3.5" />
 				{/if}

--- a/src/routes/conversations/[conversationId]/CounterfactualModal.svelte
+++ b/src/routes/conversations/[conversationId]/CounterfactualModal.svelte
@@ -4,7 +4,9 @@
 	import { enhance } from '$app/forms';
 	import { texts } from '$lib/texts';
 
-	let { open, conversationId }: { open: boolean; conversationId: string } = $props();
+	// submitCounterfactual reads the conversation id from the route's `params.conversationId`
+	// (not a hidden form field), so this component doesn't need to know it either.
+	let { open }: { open: boolean } = $props();
 
 	let selectedAnswer = $state('');
 
@@ -26,12 +28,10 @@
 
 	<!-- Separate skip form so its submit button never competes with the radio value -->
 	<form id="cf-skip" method="POST" action="?/submitCounterfactual" use:enhance>
-		<input type="hidden" name="conversationId" value={conversationId} />
 		<input type="hidden" name="answer" value="skipped" />
 	</form>
 
 	<form method="POST" action="?/submitCounterfactual" use:enhance>
-		<input type="hidden" name="conversationId" value={conversationId} />
 		<div class="flex flex-col gap-3 mb-6">
 			{#each orderedOptions as [value, label] (value)}
 				<label class="flex items-center gap-2 cursor-pointer">

--- a/src/routes/conversations/[conversationId]/LendingStatusBar.svelte
+++ b/src/routes/conversations/[conversationId]/LendingStatusBar.svelte
@@ -2,7 +2,7 @@
 	import { enhance } from '$app/forms';
 	import { texts } from '$lib/texts';
 	import type { Conversation } from '$lib/types/models';
-	import { LENDING_LIFECYCLE, type LendingStatus } from '$lib/lending';
+	import { LENDING_LIFECYCLE, canAbortUi, type LendingStatus } from '$lib/lending';
 	import Button from '$lib/components/ui/Button.svelte';
 
 	interface Props {
@@ -32,11 +32,10 @@
 			: texts.lending.statusDescription.rejected
 	);
 
-	// Who may abort, per the approved role/state rules (#373): in `pending` only the
-	// requester (the owner uses Ablehnen); in `accepted` either party.
-	const showAbort = $derived(
-		!!onAbort && ((status === 'pending' && !isOwner) || status === 'accepted')
-	);
+	// Who may abort, per the approved role/state rules (#373) — see `canAbortUi`'s doc
+	// comment in $lib/lending.ts for why this is intentionally NOT the same rule the
+	// server enforces for the abort transition itself.
+	const showAbort = $derived(!!onAbort && canAbortUi(status, isOwner));
 
 	// The five forward-progress steps. `rejected` is a dead-end handled separately below.
 	const steps: readonly LendingStatus[] = LENDING_LIFECYCLE;
@@ -66,6 +65,12 @@
 	});
 
 </script>
+
+{#snippet actionForm(action: string, label: string, variant: 'primary' | 'secondary')}
+	<form method="POST" {action} use:enhance>
+		<Button type="submit" {variant} size="sm">{label}</Button>
+	</form>
+{/snippet}
 
 {#if status}
 	<div class="border-b border-tinte-100 dark:border-tinte-800 bg-papier dark:bg-tinte-900 px-4 sm:py-3 space-y-3 shrink-0">
@@ -107,42 +112,18 @@
 
 				<div class="flex items-center gap-2 shrink-0">
 					{#if status === 'pending' && isOwner}
-						<form method="POST" action="?/rejectRequest" use:enhance>
-							<Button type="submit" variant="secondary" size="sm">
-								{texts.lending.actions.reject}
-							</Button>
-						</form>
-						<form method="POST" action="?/acceptRequest" use:enhance>
-							<Button type="submit" size="sm">
-								{texts.lending.actions.accept}
-							</Button>
-						</form>
+						{@render actionForm('?/rejectRequest', texts.lending.actions.reject, 'secondary')}
+						{@render actionForm('?/acceptRequest', texts.lending.actions.accept, 'primary')}
 					{:else if status === 'accepted' && isOwner}
-						<form method="POST" action="?/confirmHandover" use:enhance>
-							<Button type="submit" size="sm">
-								{texts.lending.actions.confirmHandover}
-							</Button>
-						</form>
+						{@render actionForm('?/confirmHandover', texts.lending.actions.confirmHandover, 'primary')}
 					{:else if status === 'active'}
 						{#if !isOwner}
-							<form method="POST" action="?/requestReturn" use:enhance>
-								<Button type="submit" size="sm">
-									{texts.lending.actions.requestReturn}
-								</Button>
-							</form>
+							{@render actionForm('?/requestReturn', texts.lending.actions.requestReturn, 'primary')}
 						{:else}
-							<form method="POST" action="?/confirmReturn" use:enhance>
-								<Button type="submit" variant="secondary" size="sm">
-									{texts.lending.actions.confirmReturn}
-								</Button>
-							</form>
+							{@render actionForm('?/confirmReturn', texts.lending.actions.confirmReturn, 'secondary')}
 						{/if}
 					{:else if status === 'return_requested' && isOwner}
-						<form method="POST" action="?/confirmReturn" use:enhance>
-							<Button type="submit" size="sm">
-								{texts.lending.actions.confirmReturn}
-							</Button>
-						</form>
+						{@render actionForm('?/confirmReturn', texts.lending.actions.confirmReturn, 'primary')}
 					{/if}
 					{#if showAbort}
 						<!-- Opens the confirmation modal in the parent; the actual mutation

--- a/src/routes/conversations/[conversationId]/LendingStatusBar.svelte
+++ b/src/routes/conversations/[conversationId]/LendingStatusBar.svelte
@@ -2,7 +2,7 @@
 	import { enhance } from '$app/forms';
 	import { texts } from '$lib/texts';
 	import type { Conversation } from '$lib/types/models';
-	import { LENDING_LIFECYCLE, canAbortUi, type LendingStatus } from '$lib/lending';
+	import { LENDING_LIFECYCLE, canAbortUi, canTransition, type LendingStatus } from '$lib/lending';
 	import Button from '$lib/components/ui/Button.svelte';
 
 	interface Props {
@@ -36,6 +36,21 @@
 	// comment in $lib/lending.ts for why this is intentionally NOT the same rule the
 	// server enforces for the abort transition itself.
 	const showAbort = $derived(!!onAbort && canAbortUi(status, isOwner));
+
+	// A conversation only ever has these two roles, so `isRequester` is just the negation.
+	// Action-button visibility is derived from the same `LENDING_TRANSITIONS` table the
+	// server enforces (via `canTransition`) instead of re-deriving the role/status rule
+	// per button — keeps this list from drifting out of sync with the server guard.
+	const role = $derived({ isOwner, isRequester: !isOwner });
+	const showReject = $derived(canTransition('rejectRequest', role, status));
+	const showAccept = $derived(canTransition('acceptRequest', role, status));
+	const showConfirmHandover = $derived(canTransition('confirmHandover', role, status));
+	const showRequestReturn = $derived(canTransition('requestReturn', role, status));
+	const showConfirmReturn = $derived(canTransition('confirmReturn', role, status));
+	// Visual weight only: `confirmReturn` is the secondary action while still `active`
+	// (the borrower may yet request a return) but becomes the primary CTA once a return
+	// has actually been requested.
+	const confirmReturnVariant = $derived(status === 'return_requested' ? 'primary' : 'secondary');
 
 	// The five forward-progress steps. `rejected` is a dead-end handled separately below.
 	const steps: readonly LendingStatus[] = LENDING_LIFECYCLE;
@@ -111,19 +126,20 @@
 				</div>
 
 				<div class="flex items-center gap-2 shrink-0">
-					{#if status === 'pending' && isOwner}
+					{#if showReject}
 						{@render actionForm('?/rejectRequest', texts.lending.actions.reject, 'secondary')}
+					{/if}
+					{#if showAccept}
 						{@render actionForm('?/acceptRequest', texts.lending.actions.accept, 'primary')}
-					{:else if status === 'accepted' && isOwner}
+					{/if}
+					{#if showConfirmHandover}
 						{@render actionForm('?/confirmHandover', texts.lending.actions.confirmHandover, 'primary')}
-					{:else if status === 'active'}
-						{#if !isOwner}
-							{@render actionForm('?/requestReturn', texts.lending.actions.requestReturn, 'primary')}
-						{:else}
-							{@render actionForm('?/confirmReturn', texts.lending.actions.confirmReturn, 'secondary')}
-						{/if}
-					{:else if status === 'return_requested' && isOwner}
-						{@render actionForm('?/confirmReturn', texts.lending.actions.confirmReturn, 'primary')}
+					{/if}
+					{#if showRequestReturn}
+						{@render actionForm('?/requestReturn', texts.lending.actions.requestReturn, 'primary')}
+					{/if}
+					{#if showConfirmReturn}
+						{@render actionForm('?/confirmReturn', texts.lending.actions.confirmReturn, confirmReturnVariant)}
 					{/if}
 					{#if showAbort}
 						<!-- Opens the confirmation modal in the parent; the actual mutation

--- a/src/routes/conversations/[conversationId]/MessageElement.svelte
+++ b/src/routes/conversations/[conversationId]/MessageElement.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
 	import { formatTimestamp } from '$lib/utils/utils';
-	let { message, isFromCurrentUser } = $props();
+	import type { Message } from '$lib/types/models';
 
-	const isSent = $derived(message.from === isFromCurrentUser);
+	// `isSent` is an explicit boolean the caller derives (`message.from === currentUser.id`)
+	// — previously this component took the current user's id and called it
+	// `isFromCurrentUser`, then compared it internally, which reads like a boolean but was
+	// actually an id.
+	let { message, isSent }: { message: Message; isSent: boolean } = $props();
 </script>
 
 <div

--- a/src/routes/conversations/[conversationId]/MessageForm.svelte
+++ b/src/routes/conversations/[conversationId]/MessageForm.svelte
@@ -5,15 +5,11 @@
 	import Button from '$lib/components/ui/Button.svelte';
 	import { onMount } from 'svelte';
 
-	let {
-		chatPartner,
-		isSubmitting = $bindable(),
-		messageText = $bindable(),
-	}: {
-		chatPartner: { id: string };
-		isSubmitting: boolean;
-		messageText: string;
-	} = $props();
+	// The recipient is derived server-side from the conversation's actual participants
+	// (see ?/sendMessage in +page.server.ts) — this form no longer needs (or sends) a
+	// chatPartnerId, so it also no longer needs a `chatPartner` prop.
+	let messageText = $state('');
+	let isSubmitting = $state(false);
 
 	let inputEl: HTMLInputElement | undefined = $state();
 
@@ -35,13 +31,12 @@
 	use:enhance={() => {
 		isSubmitting = true;
 		return async ({ update }) => {
-			await update({reset: false}); // Have to disable reset, otherwise Svelte clears the form data and the target user is not found
+			await update();
 			isSubmitting = false;
 			messageText = '';
 		};
 	}}
 >
-	<input name="chatPartnerId" value={chatPartner.id} hidden />
 	<input
 		bind:this={inputEl}
 		name="messageContent"

--- a/src/routes/conversations/[conversationId]/chatScroll.ts
+++ b/src/routes/conversations/[conversationId]/chatScroll.ts
@@ -1,0 +1,56 @@
+import type { Action } from 'svelte/action';
+
+function scrollToBottom(node: HTMLElement, smooth: boolean) {
+	node.scrollTo({ top: node.scrollHeight, behavior: smooth ? 'smooth' : 'auto' });
+}
+
+/**
+ * Keeps the messages list (`node`) stuck to the bottom.
+ *
+ * `messages` is the page's current message array — pass it directly (e.g.
+ * `use:stickToBottom={messages.value}`) so the action's `update()` re-runs whenever it's
+ * reassigned (new message arrives, `use:enhance` reload, realtime sync, …), scrolling to
+ * bottom exactly when the original inline `$effect` did.
+ *
+ * On top of that, this also re-anchors to the bottom when the visual viewport resizes/
+ * loads/rotates — e.g. when the mobile keyboard opens and the layout shrinks the chat
+ * container. The container is resized by the layout's own resize handler, which runs in
+ * the same event; scrolling synchronously here would target the pre-resize height (a
+ * no-op) and leave the latest messages hidden below the raised input bar. Defer with rAF
+ * so we scroll after the resize + reflow, then once more after the open/close animation
+ * settles. Also re-scroll after the layout's cold-load height correction (push/share
+ * link, reload): that correction fires on window `load` / `orientationchange` — not
+ * necessarily via a vv resize — so mirror those triggers here to land at the bottom once
+ * the container has grown to its settled height.
+ */
+export const stickToBottom: Action<HTMLElement, unknown[] | undefined> = (node, messages) => {
+	// Scroll chat window to bottom when messages change.
+	if (messages && messages.length > 0) {
+		setTimeout(() => scrollToBottom(node, true), 0);
+	}
+
+	const vv = window.visualViewport;
+	let settleTimer: ReturnType<typeof setTimeout>;
+	const keepAtBottom = () => {
+		requestAnimationFrame(() => scrollToBottom(node, false));
+		clearTimeout(settleTimer);
+		settleTimer = setTimeout(() => scrollToBottom(node, false), 150);
+	};
+	vv?.addEventListener('resize', keepAtBottom);
+	window.addEventListener('load', keepAtBottom);
+	window.addEventListener('orientationchange', keepAtBottom);
+
+	return {
+		update(newMessages) {
+			if (newMessages && newMessages.length > 0) {
+				setTimeout(() => scrollToBottom(node, true), 0);
+			}
+		},
+		destroy() {
+			vv?.removeEventListener('resize', keepAtBottom);
+			window.removeEventListener('load', keepAtBottom);
+			window.removeEventListener('orientationchange', keepAtBottom);
+			clearTimeout(settleTimer);
+		},
+	};
+};

--- a/src/routes/conversations/[conversationId]/conversation.server.test.ts
+++ b/src/routes/conversations/[conversationId]/conversation.server.test.ts
@@ -1,108 +1,32 @@
-import { describe, it, expect, vi } from 'vitest';
-import type PocketBase from 'pocketbase';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeMockPb } from '$lib/test-utils/pocketbase';
 
 // Avoid loading the real notifications module (web-push + VAPID env) at import time.
 vi.mock('$lib/server/notifications.js', () => ({
 	createNotification: vi.fn(),
 	sendPushToUser: vi.fn(),
 	isMessageNotificationThrottled: vi.fn(),
+	notifyAndPush: vi.fn(),
 }));
 
-import { deleteConversation, sendMessage } from './conversation.server';
-
-function mockFilter(raw: string, params?: Record<string, unknown>): string {
-	if (!params) return raw;
-	let result = raw;
-	for (const [key, value] of Object.entries(params)) {
-		const escaped = typeof value === 'string' ? `'${value.replace(/'/g, "\\'")}'` : `${value}`;
-		result = result.replaceAll(`{:${key}}`, escaped);
-	}
-	return result;
-}
-
-function makeMockPb(impls: Record<string, Record<string, ReturnType<typeof vi.fn>>>): PocketBase {
-	return {
-		collection: vi.fn((name: string) => impls[name]),
-		filter: vi.fn(mockFilter),
-	} as unknown as PocketBase;
-}
-
-describe('deleteConversation', () => {
-	it('deletes the conversation and every notification referencing it', async () => {
-		const convDelete = vi.fn().mockResolvedValue(true);
-		const notifDelete = vi.fn().mockResolvedValue(true);
-		const pb = makeMockPb({
-			conversations: { delete: convDelete },
-			notifications: {
-				getFullList: vi.fn().mockResolvedValue([{ id: 'n1' }, { id: 'n2' }]),
-				delete: notifDelete,
-			},
-		});
-
-		await deleteConversation(pb, 'conv1');
-
-		expect(convDelete).toHaveBeenCalledWith('conv1');
-		expect(notifDelete).toHaveBeenCalledTimes(2);
-		expect(notifDelete).toHaveBeenCalledWith('n1');
-		expect(notifDelete).toHaveBeenCalledWith('n2');
-	});
-
-	it('deletes the conversation even when no notifications reference it', async () => {
-		const convDelete = vi.fn().mockResolvedValue(true);
-		const notifDelete = vi.fn();
-		const pb = makeMockPb({
-			conversations: { delete: convDelete },
-			notifications: { getFullList: vi.fn().mockResolvedValue([]), delete: notifDelete },
-		});
-
-		await deleteConversation(pb, 'conv1');
-
-		expect(convDelete).toHaveBeenCalledWith('conv1');
-		expect(notifDelete).not.toHaveBeenCalled();
-	});
-
-	it('swallows a notification-cleanup failure (does not rethrow)', async () => {
-		const pb = makeMockPb({
-			conversations: { delete: vi.fn().mockResolvedValue(true) },
-			notifications: { getFullList: vi.fn().mockRejectedValue(new Error('boom')), delete: vi.fn() },
-		});
-
-		await expect(deleteConversation(pb, 'conv1')).resolves.toBeUndefined();
-	});
-
-	it('propagates a conversation-deletion failure (it is outside the cleanup try/catch)', async () => {
-		const pb = makeMockPb({
-			conversations: { delete: vi.fn().mockRejectedValue(new Error('cannot delete')) },
-			notifications: { getFullList: vi.fn(), delete: vi.fn() },
-		});
-
-		await expect(deleteConversation(pb, 'conv1')).rejects.toThrow('cannot delete');
-	});
-});
+import { sendMessage } from './conversation.server';
+import { notifyAndPush } from '$lib/server/notifications.js';
 
 describe('sendMessage', () => {
-	it('creates the message with conversation relation and updates lastMessageAt (not *LastSeenAt)', async () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('creates the message with conversation relation and atomically appends it via the messages+ modifier', async () => {
 		const msgCreate = vi.fn().mockResolvedValue({ id: 'msg1' });
-		const convGetOne = vi.fn().mockResolvedValue({
-			id: 'conv1',
-			requester: 'userA',
-			itemOwner: 'userB',
-			messages: ['msg0'],
-		});
 		const convUpdate = vi.fn().mockResolvedValue(true);
 		const pb = makeMockPb({
 			messages: { create: msgCreate },
-			conversations: { getOne: convGetOne, update: convUpdate },
-			notifications: {
-				getFullList: vi.fn().mockResolvedValue([]),
-				delete: vi.fn(),
-			},
+			conversations: { update: convUpdate },
 		});
 
 		const { isMessageNotificationThrottled } = await import('$lib/server/notifications.js');
 		vi.mocked(isMessageNotificationThrottled).mockResolvedValue(true);
 
-		await sendMessage(pb, 'conv1', 'Hello!', 'userB', 'userA', 'Owner');
+		await sendMessage(pb, 'conv1', 'Hello!', 'userB', 'userA', 'Owner', /* recipientIsRequester */ true);
 
 		// messages.create is called with conversation relation
 		expect(msgCreate).toHaveBeenCalledWith({
@@ -112,69 +36,89 @@ describe('sendMessage', () => {
 			conversation: 'conv1',
 		});
 
-		// conversations.update sets lastMessageAt but NOT requesterLastSeenAt or ownerLastSeenAt
+		// conversations.update appends the new message id atomically via the 'messages+'
+		// modifier (no read-modify-write, no race under concurrent sends), and sets
+		// lastMessageAt but NOT requesterLastSeenAt or ownerLastSeenAt.
 		expect(convUpdate).toHaveBeenCalledTimes(1);
-		const updatePayload = convUpdate.mock.calls[0][1];
+		const [, updatePayload] = convUpdate.mock.calls[0];
+		expect(updatePayload).toMatchObject({ 'messages+': 'msg1' });
 		expect(updatePayload).toHaveProperty('lastMessageAt');
+		expect(updatePayload).not.toHaveProperty('messages');
 		expect(updatePayload).not.toHaveProperty('requesterLastSeenAt');
 		expect(updatePayload).not.toHaveProperty('ownerLastSeenAt');
 	});
 
-	it('marks readByRequester as false when sending to the requester', async () => {
+	it('marks readByRequester as false when the recipient is the requester', async () => {
 		const msgCreate = vi.fn().mockResolvedValue({ id: 'msg2' });
-		const convGetOne = vi.fn().mockResolvedValue({
-			id: 'conv1',
-			requester: 'userA',
-			itemOwner: 'userB',
-			messages: [],
-		});
 		const convUpdate = vi.fn().mockResolvedValue(true);
 		const pb = makeMockPb({
 			messages: { create: msgCreate },
-			conversations: { getOne: convGetOne, update: convUpdate },
-			notifications: {
-				getFullList: vi.fn().mockResolvedValue([]),
-				delete: vi.fn(),
-			},
+			conversations: { update: convUpdate },
 		});
 
 		const { isMessageNotificationThrottled } = await import('$lib/server/notifications.js');
 		vi.mocked(isMessageNotificationThrottled).mockResolvedValue(true);
 
 		// Send from owner (userB) to requester (userA)
-		await sendMessage(pb, 'conv1', 'Hey', 'userB', 'userA', 'Owner');
+		await sendMessage(pb, 'conv1', 'Hey', 'userB', 'userA', 'Owner', true);
 
 		const updatePayload = convUpdate.mock.calls[0][1];
 		expect(updatePayload).toHaveProperty('readByRequester', false);
 		expect(updatePayload).not.toHaveProperty('readByOwner');
 	});
 
-	it('marks readByOwner as false when sending to the owner', async () => {
+	it('marks readByOwner as false when the recipient is the owner', async () => {
 		const msgCreate = vi.fn().mockResolvedValue({ id: 'msg3' });
-		const convGetOne = vi.fn().mockResolvedValue({
-			id: 'conv1',
-			requester: 'userA',
-			itemOwner: 'userB',
-			messages: ['msg0'],
-		});
 		const convUpdate = vi.fn().mockResolvedValue(true);
 		const pb = makeMockPb({
 			messages: { create: msgCreate },
-			conversations: { getOne: convGetOne, update: convUpdate },
-			notifications: {
-				getFullList: vi.fn().mockResolvedValue([]),
-				delete: vi.fn(),
-			},
+			conversations: { update: convUpdate },
 		});
 
 		const { isMessageNotificationThrottled } = await import('$lib/server/notifications.js');
 		vi.mocked(isMessageNotificationThrottled).mockResolvedValue(true);
 
 		// Send from requester (userA) to owner (userB)
-		await sendMessage(pb, 'conv1', 'Hi', 'userA', 'userB', 'Requester');
+		await sendMessage(pb, 'conv1', 'Hi', 'userA', 'userB', 'Requester', false);
 
 		const updatePayload = convUpdate.mock.calls[0][1];
 		expect(updatePayload).toHaveProperty('readByOwner', false);
 		expect(updatePayload).not.toHaveProperty('readByRequester');
+	});
+
+	it('notifies and pushes to the recipient via notifyAndPush when not throttled', async () => {
+		const msgCreate = vi.fn().mockResolvedValue({ id: 'msg4' });
+		const pb = makeMockPb({
+			messages: { create: msgCreate },
+			conversations: { update: vi.fn().mockResolvedValue(true) },
+		});
+
+		const { isMessageNotificationThrottled } = await import('$lib/server/notifications.js');
+		vi.mocked(isMessageNotificationThrottled).mockResolvedValue(false);
+
+		await sendMessage(pb, 'conv1', 'Hi', 'userA', 'userB', 'Requester', false);
+
+		expect(notifyAndPush).toHaveBeenCalledWith(pb, {
+			recipient: 'userB',
+			sender: 'userA',
+			type: 'new_message',
+			relatedId: 'conv1',
+			body: expect.any(String),
+		});
+	});
+
+	it('does not notify when the message-notification cooldown is active', async () => {
+		const msgCreate = vi.fn().mockResolvedValue({ id: 'msg5' });
+		const pb = makeMockPb({
+			messages: { create: msgCreate },
+			conversations: { update: vi.fn().mockResolvedValue(true) },
+		});
+
+		const { isMessageNotificationThrottled } = await import('$lib/server/notifications.js');
+		vi.mocked(isMessageNotificationThrottled).mockResolvedValue(true);
+
+		await sendMessage(pb, 'conv1', 'Hi', 'userA', 'userB', 'Requester', false);
+
+		expect(notifyAndPush).not.toHaveBeenCalled();
 	});
 });

--- a/src/routes/conversations/[conversationId]/conversation.server.test.ts
+++ b/src/routes/conversations/[conversationId]/conversation.server.test.ts
@@ -26,7 +26,7 @@ describe('sendMessage', () => {
 		const { isMessageNotificationThrottled } = await import('$lib/server/notifications.js');
 		vi.mocked(isMessageNotificationThrottled).mockResolvedValue(true);
 
-		await sendMessage(pb, 'conv1', 'Hello!', 'userB', 'userA', 'Owner', /* recipientIsRequester */ true);
+		await sendMessage(pb, 'conv1', 'Hello!', { fromUserId: 'userB', toUserId: 'userA', senderName: 'Owner', recipientIsRequester: true });
 
 		// messages.create is called with conversation relation
 		expect(msgCreate).toHaveBeenCalledWith({
@@ -60,7 +60,7 @@ describe('sendMessage', () => {
 		vi.mocked(isMessageNotificationThrottled).mockResolvedValue(true);
 
 		// Send from owner (userB) to requester (userA)
-		await sendMessage(pb, 'conv1', 'Hey', 'userB', 'userA', 'Owner', true);
+		await sendMessage(pb, 'conv1', 'Hey', { fromUserId: 'userB', toUserId: 'userA', senderName: 'Owner', recipientIsRequester: true });
 
 		const updatePayload = convUpdate.mock.calls[0][1];
 		expect(updatePayload).toHaveProperty('readByRequester', false);
@@ -79,7 +79,7 @@ describe('sendMessage', () => {
 		vi.mocked(isMessageNotificationThrottled).mockResolvedValue(true);
 
 		// Send from requester (userA) to owner (userB)
-		await sendMessage(pb, 'conv1', 'Hi', 'userA', 'userB', 'Requester', false);
+		await sendMessage(pb, 'conv1', 'Hi', { fromUserId: 'userA', toUserId: 'userB', senderName: 'Requester', recipientIsRequester: false });
 
 		const updatePayload = convUpdate.mock.calls[0][1];
 		expect(updatePayload).toHaveProperty('readByOwner', false);
@@ -96,7 +96,7 @@ describe('sendMessage', () => {
 		const { isMessageNotificationThrottled } = await import('$lib/server/notifications.js');
 		vi.mocked(isMessageNotificationThrottled).mockResolvedValue(false);
 
-		await sendMessage(pb, 'conv1', 'Hi', 'userA', 'userB', 'Requester', false);
+		await sendMessage(pb, 'conv1', 'Hi', { fromUserId: 'userA', toUserId: 'userB', senderName: 'Requester', recipientIsRequester: false });
 
 		expect(notifyAndPush).toHaveBeenCalledWith(pb, {
 			recipient: 'userB',
@@ -117,7 +117,7 @@ describe('sendMessage', () => {
 		const { isMessageNotificationThrottled } = await import('$lib/server/notifications.js');
 		vi.mocked(isMessageNotificationThrottled).mockResolvedValue(true);
 
-		await sendMessage(pb, 'conv1', 'Hi', 'userA', 'userB', 'Requester', false);
+		await sendMessage(pb, 'conv1', 'Hi', { fromUserId: 'userA', toUserId: 'userB', senderName: 'Requester', recipientIsRequester: false });
 
 		expect(notifyAndPush).not.toHaveBeenCalled();
 	});

--- a/src/routes/conversations/[conversationId]/conversation.server.ts
+++ b/src/routes/conversations/[conversationId]/conversation.server.ts
@@ -21,10 +21,17 @@ export async function sendMessage(
 	pb: PocketBase,
 	conversationId: string,
 	messageContent: FormDataEntryValue | null,
-	fromUserId: string,
-	toUserId: string,
-	senderName: string,
-	recipientIsRequester: boolean
+	{
+		fromUserId,
+		toUserId,
+		senderName,
+		recipientIsRequester,
+	}: {
+		fromUserId: string;
+		toUserId: string;
+		senderName: string;
+		recipientIsRequester: boolean;
+	}
 ): Promise<FailResult | void> {
 	let createdMessage: Message;
 	try {

--- a/src/routes/conversations/[conversationId]/conversation.server.ts
+++ b/src/routes/conversations/[conversationId]/conversation.server.ts
@@ -3,18 +3,28 @@ import type { ClientResponseError } from 'pocketbase';
 import { fail } from '@sveltejs/kit';
 import type { Message } from '$lib/types/models.js';
 import { texts } from '$lib/texts';
-import { createNotification, sendPushToUser, isMessageNotificationThrottled } from '$lib/server/notifications.js';
+import { notifyAndPush, isMessageNotificationThrottled } from '$lib/server/notifications.js';
 
 /** Convenience alias for the return type of SvelteKit's `fail()`. */
 type FailResult = ReturnType<typeof fail>;
 
+/**
+ * Creates a message and atomically appends it to the conversation's `messages` relation via
+ * PocketBase's `'messages+'` append modifier — no read-modify-write, so concurrent sends can
+ * no longer race and drop a message (the previous implementation fetched the conversation,
+ * spread `.messages`, appended, then wrote the whole array back).
+ *
+ * `recipientIsRequester` is derived by the caller (which already loaded the conversation to
+ * verify the sender is a participant) — never trust a client-supplied recipient identity here.
+ */
 export async function sendMessage(
 	pb: PocketBase,
 	conversationId: string,
 	messageContent: FormDataEntryValue | null,
 	fromUserId: string,
 	toUserId: string,
-	senderName: string
+	senderName: string,
+	recipientIsRequester: boolean
 ): Promise<FailResult | void> {
 	let createdMessage: Message;
 	try {
@@ -24,20 +34,9 @@ export async function sendMessage(
 		return fail(e.status ?? 500, { fail: true, message: e.data?.message ?? texts.errors.failedToSendMessage });
 	}
 
-	// Re-fetch the conversation to read the current messages array before appending.
-	// PocketBase's create() response doesn't include parent collection data.
-	const conversationRecord = await pb
-		.collection('conversations')
-		.getOne(conversationId, { expand: 'requester,itemOwner,requestedItem' });
-
-	const updatedMessages = conversationRecord.messages
-		? [...conversationRecord.messages, createdMessage.id]
-		: [createdMessage.id];
-
-	const recipientIsRequester = conversationRecord.requester === toUserId;
 	try {
 		await pb.collection('conversations').update(conversationId, {
-			messages: updatedMessages,
+			'messages+': createdMessage.id,
 			lastMessageAt: new Date().toISOString(),
 			...(recipientIsRequester ? { readByRequester: false } : { readByOwner: false }),
 		});
@@ -47,50 +46,14 @@ export async function sendMessage(
 	}
 
 	const notificationBody = texts.notifications.newMessage(senderName);
-	const conversationUrl = `/conversations/${conversationId}`;
 	const throttled = await isMessageNotificationThrottled(pb, toUserId, conversationId);
 	if (!throttled) {
-		await createNotification(pb, toUserId, fromUserId, 'new_message', conversationId, notificationBody);
-		await sendPushToUser(pb, toUserId, texts.notifications.pushTitle, notificationBody, conversationUrl);
-	}
-}
-
-export async function toggleItemStatus(
-	pb: PocketBase,
-	itemId: string,
-	userId: string
-): Promise<FailResult | void> {
-	if (!itemId) return fail(400, { fail: true, message: 'Fehlende Item-ID.' });
-
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	let item: any;
-	try {
-		item = await pb.collection('items').getOne(itemId);
-	} catch {
-		return fail(404, { fail: true, message: texts.errors.itemNotFound });
-	}
-
-	if (item.owner !== userId) return fail(403, { fail: true, message: texts.errors.noPermission });
-
-	const newStatus = item.status === 'available' ? 'unavailable' : 'available';
-	try {
-		await pb.collection('items').update(itemId, { status: newStatus });
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	} catch (err: Error | any) {
-		console.error(err?.message ?? err);
-	}
-}
-
-// Throws on failure — caller is responsible for catching and returning fail().
-export async function deleteConversation(pb: PocketBase, conversationId: string): Promise<void> {
-	await pb.collection('conversations').delete(conversationId);
-
-	try {
-		const orphaned = await pb.collection('notifications').getFullList({
-			filter: pb.filter('relatedId={:conversationId}', { conversationId }),
+		await notifyAndPush(pb, {
+			recipient: toUserId,
+			sender: fromUserId,
+			type: 'new_message',
+			relatedId: conversationId,
+			body: notificationBody,
 		});
-		await Promise.all(orphaned.map((n) => pb.collection('notifications').delete(n.id)));
-	} catch (err) {
-		console.error('Failed to clean up orphaned notifications for conversation', err);
 	}
 }

--- a/src/routes/conversations/[conversationId]/conversationDetail.test.ts
+++ b/src/routes/conversations/[conversationId]/conversationDetail.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import type { Conversation, Item, User } from '$lib/types/models';
+import { toConversationDetail } from './conversationDetail';
+
+function user(overrides: Partial<User> = {}): User {
+	return {
+		id: 'u1',
+		username: 'alice',
+		email: 'alice@example.com',
+		created: '2025-01-01T00:00:00Z',
+		updated: '2025-01-01T00:00:00Z',
+		...overrides,
+	} as User;
+}
+
+function item(overrides: Partial<Item> = {}): Item {
+	return {
+		id: 'item1',
+		name: 'Bohrmaschine',
+		created: '2025-01-01T00:00:00Z',
+		updated: '2025-01-01T00:00:00Z',
+		...overrides,
+	} as Item;
+}
+
+function conversationRecord(overrides: Partial<Conversation> = {}): Conversation {
+	const requester = user({ id: 'userA', username: 'alice' });
+	const itemOwner = user({ id: 'userB', username: 'bob' });
+	return {
+		id: 'conv1',
+		requester: requester.id,
+		itemOwner: itemOwner.id,
+		requestedItem: 'item1',
+		messages: [],
+		readByRequester: true,
+		readByOwner: false,
+		created: '2025-01-01T00:00:00Z',
+		updated: '2025-01-02T00:00:00Z',
+		expand: {
+			requester,
+			itemOwner,
+			requestedItem: item(),
+			messages: [],
+		},
+		...overrides,
+	};
+}
+
+describe('toConversationDetail', () => {
+	it('flattens a fully-expanded conversation record', () => {
+		const detail = toConversationDetail(conversationRecord());
+
+		expect(detail).toMatchObject({
+			id: 'conv1',
+			requester: { id: 'userA', username: 'alice' },
+			itemOwner: { id: 'userB', username: 'bob' },
+			requestedItem: { id: 'item1', name: 'Bohrmaschine' },
+			messages: [],
+			readByRequester: true,
+			readByOwner: false,
+		});
+	});
+
+	it('maps a dangling/missing requestedItem to null instead of crashing', () => {
+		const record = conversationRecord({
+			expand: {
+				requester: user({ id: 'userA' }),
+				itemOwner: user({ id: 'userB' }),
+				// requestedItem intentionally omitted — simulates a deleted/inaccessible item.
+				messages: [],
+			},
+		});
+
+		const detail = toConversationDetail(record);
+
+		expect(detail.requestedItem).toBeNull();
+	});
+
+	it('throws if requester/itemOwner were not expanded', () => {
+		const record = conversationRecord({ expand: { requester: undefined, itemOwner: undefined } });
+
+		expect(() => toConversationDetail(record)).toThrow();
+	});
+
+	it('defaults messages to an empty array when the expand is missing', () => {
+		const record = conversationRecord({
+			expand: { requester: user({ id: 'userA' }), itemOwner: user({ id: 'userB' }) },
+		});
+
+		expect(toConversationDetail(record).messages).toEqual([]);
+	});
+});

--- a/src/routes/conversations/[conversationId]/conversationDetail.ts
+++ b/src/routes/conversations/[conversationId]/conversationDetail.ts
@@ -1,0 +1,57 @@
+import type { Conversation, ConversationPartner, Item, Message } from '$lib/types/models';
+
+/**
+ * Flattened view-model the detail page (and its header) render from — the honest wire
+ * `Conversation` record (ids + optional `expand`) mapped into the fully-resolved shape the
+ * UI actually needs, with `requestedItem` explicitly typed as nullable: an item can go
+ * dangling (deleted/inaccessible) while its conversation persists, and every consumer of
+ * this shape must handle that case instead of crashing on `.name`/`.image`/`.status`
+ * (the list view already guards this via `expand?.requestedItem ?? null`; this mapper
+ * brings the detail page and `ConversationHeader` up to the same standard).
+ */
+export interface ConversationDetail {
+	id: string;
+	/** Restricted to a safe field subset (never the full `User`, in particular never `email`) — see `$lib/server/conversations.ts`'s `conversationFieldsWithSafePartners()`. */
+	requester: ConversationPartner;
+	/** Same restriction as `requester` above. */
+	itemOwner: ConversationPartner;
+	/** `null` when the item is missing/dangling — render an "item unavailable" fallback. */
+	requestedItem: Item | null;
+	messages: Message[];
+	readByRequester: boolean;
+	readByOwner: boolean;
+	lendingStatus: Conversation['lendingStatus'];
+	counterfactual: Conversation['counterfactual'];
+	created: string;
+	updated: string;
+}
+
+/**
+ * Maps a `conversations` record (fetched with
+ * `expand: 'requester,itemOwner,requestedItem,messages'`) to the flattened
+ * {@link ConversationDetail} view-model.
+ *
+ * `requester`/`itemOwner` are required relations that are never expected to go dangling
+ * (accounts are anonymized in place on deletion, never removed) — if the expand is somehow
+ * missing, this throws rather than silently rendering `undefined` as a user.
+ */
+export function toConversationDetail(record: Conversation): ConversationDetail {
+	const expand = record.expand ?? {};
+	if (!expand.requester || !expand.itemOwner) {
+		throw new Error('toConversationDetail: conversation record is missing requester/itemOwner expand');
+	}
+
+	return {
+		id: record.id,
+		requester: expand.requester,
+		itemOwner: expand.itemOwner,
+		requestedItem: expand.requestedItem ?? null,
+		messages: expand.messages ?? [],
+		readByRequester: record.readByRequester,
+		readByOwner: record.readByOwner,
+		lendingStatus: record.lendingStatus,
+		counterfactual: record.counterfactual,
+		created: record.created,
+		updated: record.updated,
+	};
+}

--- a/src/routes/conversations/[conversationId]/conversationRealtime.test.ts
+++ b/src/routes/conversations/[conversationId]/conversationRealtime.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { RecordSubscription } from 'pocketbase';
 import type { Conversation, Message } from '$lib/types/models';
+import { makeMockPb } from '$lib/test-utils/pocketbase';
 
 // Capture the options passed to subscribeRealtime so tests can fire synthetic
 // events at the registered handler. The real client-pb pulls in $env/static/public
@@ -57,12 +58,7 @@ function makeState(initialMessages: Message[] = []) {
 
 /** A fake PocketBase whose `messages` collection getOne is scriptable. */
 function makePb(getOne: ReturnType<typeof vi.fn>) {
-	return {
-		collection: vi.fn((name: string) => {
-			if (name === 'messages') return { getOne };
-			return {};
-		}),
-	} as never;
+	return makeMockPb({ messages: { getOne } });
 }
 
 beforeEach(() => {
@@ -94,6 +90,21 @@ describe('subscribeConversation', () => {
 		expect(getOne).toHaveBeenCalledWith('m2');
 		expect(state.setMessages).toHaveBeenCalledTimes(1);
 		expect(state.messages).toEqual([msg('m1'), msg('m2')]);
+	});
+
+	it('fetches and appends ALL new ids from a coalesced/batched event, not just the last one', async () => {
+		const state = makeState([msg('m1')]);
+		const getOne = vi.fn().mockImplementation(async (id: string) => msg(id));
+		subscribeConversation(makePb(getOne), 'conv1', state.accessors);
+
+		await registeredHandler()(updateEvent({ messages: ['m1', 'm2', 'm3'] }));
+
+		expect(getOne).toHaveBeenCalledWith('m2');
+		expect(getOne).toHaveBeenCalledWith('m3');
+		expect(getOne).toHaveBeenCalledTimes(2);
+		expect(state.setMessages).toHaveBeenCalledTimes(1);
+		// Order preserved: earlier message in the batch is not dropped or reordered.
+		expect(state.messages).toEqual([msg('m1'), msg('m2'), msg('m3')]);
 	});
 
 	it('skips the fetch when the last message id is already present (case 2)', async () => {

--- a/src/routes/conversations/[conversationId]/conversationRealtime.ts
+++ b/src/routes/conversations/[conversationId]/conversationRealtime.ts
@@ -56,23 +56,31 @@ export function subscribeConversation(
 				setCounterfactual(event.record.counterfactual || undefined);
 			}
 
-			// Extract the last message id from the updated conversation record.
+			// A coalesced/batched SSE event can carry more than one new message at once
+			// (e.g. two messages sent in quick succession before the client processes the
+			// first event) — fetch every id not already held locally, not just the last one,
+			// or earlier messages in the same batch are silently dropped until the next full
+			// reload.
 			const messageIds = event.record.messages as unknown as string[] | undefined;
-			const lastMessageId = messageIds?.[messageIds.length - 1];
+			if (!messageIds || messageIds.length === 0) return;
 
-			// Skip fetch if there's no new message or we already have it.
-			if (!lastMessageId || getMessages().some((m) => m.id === lastMessageId)) return;
+			const existingIds = new Set(getMessages().map((m) => m.id));
+			const newIds = messageIds.filter((id) => !existingIds.has(id));
 
-			// Get the last message's contents from PocketBase.
+			// Skip fetch if there's nothing new.
+			if (newIds.length === 0) return;
+
+			// Get the new messages' contents from PocketBase, in their conversation order.
 			try {
-				const latestMessage = await pb.collection('messages').getOne<Message>(lastMessageId);
-				// Deduplicate: a server reload via use:enhance may have already added this
-				// message while the fetch was in flight.
-				if (!getMessages().some((m) => m.id === latestMessage.id)) {
-					setMessages([...getMessages(), latestMessage]);
+				const newMessages = await Promise.all(newIds.map((id) => pb.collection('messages').getOne<Message>(id)));
+				// Deduplicate: a server reload via use:enhance may have already added some of
+				// these messages while the fetch was in flight.
+				const stillMissing = newMessages.filter((m) => !getMessages().some((existing) => existing.id === m.id));
+				if (stillMissing.length > 0) {
+					setMessages([...getMessages(), ...stillMissing]);
 				}
 			} catch (error) {
-				console.error('Failed to fetch last message record:', error);
+				console.error('Failed to fetch new message records:', error);
 			}
 		},
 		onReconnect,

--- a/src/routes/conversations/[conversationId]/lending.server.test.ts
+++ b/src/routes/conversations/[conversationId]/lending.server.test.ts
@@ -1,109 +1,292 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type PocketBase from 'pocketbase';
 import { texts } from '$lib/texts';
+import type { LendingAction, LendingStatus } from '$lib/lending';
+import type { NotificationType } from '$lib/types/models';
+import { makeMockPb } from '$lib/test-utils/pocketbase';
 
 // Avoid loading the real notifications module (web-push + VAPID env) at import time.
+// notifyAndPush is mocked to still call through to createNotification/sendPushToUser (defined
+// via vi.hoisted so the factory below can reference them directly, without a fragile
+// self-importing dynamic import()) so assertions can keep checking those two directly.
+// PUSH_TITLE is a fixed placeholder — decouples these tests from texts.ts content.
+const { createNotification, sendPushToUser, isMessageNotificationThrottled, notifyAndPush, PUSH_TITLE } = vi.hoisted(() => {
+	const PUSH_TITLE = 'push-title';
+	const createNotification = vi.fn();
+	const sendPushToUser = vi.fn();
+	const isMessageNotificationThrottled = vi.fn();
+	const notifyAndPush = vi.fn(
+		async (
+			pb: PocketBase,
+			params: { recipient: string; sender?: string; type: NotificationType; relatedId: string; body: string }
+		) => {
+			await createNotification(pb, params.recipient, params.sender, params.type, params.relatedId, params.body);
+			await sendPushToUser(pb, params.recipient, PUSH_TITLE, params.body, `/conversations/${params.relatedId}`);
+		}
+	);
+	return { createNotification, sendPushToUser, isMessageNotificationThrottled, notifyAndPush, PUSH_TITLE };
+});
+
 vi.mock('$lib/server/notifications.js', () => ({
-	createNotification: vi.fn(),
-	sendPushToUser: vi.fn(),
-	isMessageNotificationThrottled: vi.fn(),
+	createNotification,
+	sendPushToUser,
+	isMessageNotificationThrottled,
+	notifyAndPush,
 }));
 
-import { abortRequest } from './lending.server';
-import { createNotification, sendPushToUser } from '$lib/server/notifications.js';
+import {
+	acceptRequest,
+	rejectRequest,
+	abortRequest,
+	confirmHandover,
+	requestReturn,
+	confirmReturn,
+} from './lending.server';
 
-function mockFilter(raw: string, params?: Record<string, unknown>): string {
-	if (!params) return raw;
-	let result = raw;
-	for (const [key, value] of Object.entries(params)) {
-		const escaped = typeof value === 'string' ? `'${value.replace(/'/g, "\\'")}'` : `${value}`;
-		result = result.replaceAll(`{:${key}}`, escaped);
-	}
-	return result;
-}
+const OWNER = 'userB';
+const REQUESTER = 'userA';
+const STRANGER = 'stranger';
+const ITEM_NAME = 'Bohrmaschine';
 
-function makeMockPb(impls: Record<string, Record<string, ReturnType<typeof vi.fn>>>): PocketBase {
-	return {
-		collection: vi.fn((name: string) => impls[name]),
-		filter: vi.fn(mockFilter),
-	} as unknown as PocketBase;
-}
-
-// A conversation between userA (requester) and userB (owner) for item1.
+// A conversation between the requester and the item owner for item1.
 function conversation(overrides: Record<string, unknown> = {}) {
 	return {
 		id: 'conv1',
-		requester: 'userA',
-		itemOwner: 'userB',
+		requester: REQUESTER,
+		itemOwner: OWNER,
 		requestedItem: 'item1',
 		lendingStatus: 'pending',
 		...overrides,
 	};
 }
 
-/** pb wired for a successful abort; `itemUpdate` lets tests assert the item is untouched. */
-function pbForAbort(conv: Record<string, unknown>) {
+/** pb wired for a transition; `getFullList` defaults to `[]` (acceptRequest's auto-reject query). */
+function pbForTransition(conv: Record<string, unknown>) {
 	const convUpdate = vi.fn().mockResolvedValue(true);
 	const itemUpdate = vi.fn().mockResolvedValue(true);
 	const pb = makeMockPb({
-		conversations: { getOne: vi.fn().mockResolvedValue(conv), update: convUpdate },
-		items: { getOne: vi.fn().mockResolvedValue({ id: 'item1', name: 'Bohrmaschine' }), update: itemUpdate },
+		conversations: { getOne: vi.fn().mockResolvedValue(conv), update: convUpdate, getFullList: vi.fn().mockResolvedValue([]) },
+		items: { getOne: vi.fn().mockResolvedValue({ id: 'item1', name: ITEM_NAME }), update: itemUpdate },
 	});
 	return { pb, convUpdate, itemUpdate };
 }
 
-describe('abortRequest', () => {
+interface Case {
+	action: LendingAction;
+	/** Calls the transition with the given pb + conversationId + caller. */
+	call: (pb: PocketBase, conversationId: string, callerId: string) => ReturnType<typeof acceptRequest>;
+	callerId: string;
+	wrongRoleCallerId: string;
+	validState: LendingStatus;
+	invalidState: LendingStatus;
+	toStatus: LendingStatus;
+	notifyRecipient: string;
+	notifyType: NotificationType;
+	bodyFor: (itemName: string) => string;
+	itemPatch?: { status: 'available' | 'unavailable' };
+}
+
+// One row per `?/actionName` form action — role/from/to mirrors $lib/lending.ts's
+// LENDING_TRANSITIONS; happy/wrong-role/wrong-state are exercised generically below for
+// each row (6 actions × 3 cases = 18 minimum), plus a few action-specific extras.
+const CASES: Case[] = [
+	{
+		action: 'acceptRequest',
+		call: (pb, id, callerId) => acceptRequest(pb, id, callerId),
+		callerId: OWNER,
+		wrongRoleCallerId: REQUESTER,
+		validState: 'pending',
+		invalidState: 'accepted',
+		toStatus: 'accepted',
+		notifyRecipient: REQUESTER,
+		notifyType: 'request_accepted',
+		bodyFor: texts.notifications.requestAccepted,
+		itemPatch: { status: 'unavailable' },
+	},
+	{
+		action: 'rejectRequest',
+		call: (pb, id, callerId) => rejectRequest(pb, id, callerId),
+		callerId: OWNER,
+		wrongRoleCallerId: REQUESTER,
+		validState: 'pending',
+		invalidState: 'active',
+		toStatus: 'rejected',
+		notifyRecipient: REQUESTER,
+		notifyType: 'request_rejected',
+		bodyFor: texts.notifications.requestRejected,
+	},
+	{
+		action: 'confirmHandover',
+		call: (pb, id, callerId) => confirmHandover(pb, id, callerId),
+		callerId: OWNER,
+		wrongRoleCallerId: REQUESTER,
+		validState: 'accepted',
+		invalidState: 'pending',
+		toStatus: 'active',
+		notifyRecipient: REQUESTER,
+		notifyType: 'handover_confirmed',
+		bodyFor: texts.notifications.handoverConfirmed,
+	},
+	{
+		action: 'requestReturn',
+		call: (pb, id, callerId) => requestReturn(pb, id, callerId, 'Requester Name'),
+		callerId: REQUESTER,
+		wrongRoleCallerId: OWNER,
+		validState: 'active',
+		invalidState: 'accepted',
+		toStatus: 'return_requested',
+		notifyRecipient: OWNER,
+		notifyType: 'return_requested',
+		bodyFor: (itemName) => texts.notifications.returnRequested('Requester Name', itemName),
+	},
+	{
+		action: 'confirmReturn',
+		call: (pb, id, callerId) => confirmReturn(pb, id, callerId),
+		callerId: OWNER,
+		wrongRoleCallerId: REQUESTER,
+		validState: 'active',
+		invalidState: 'pending',
+		toStatus: 'completed',
+		notifyRecipient: REQUESTER,
+		notifyType: 'return_confirmed',
+		bodyFor: texts.notifications.returnConfirmed,
+		itemPatch: { status: 'available' },
+	},
+	{
+		action: 'abortRequest',
+		call: (pb, id, callerId) => abortRequest(pb, id, callerId),
+		callerId: REQUESTER,
+		wrongRoleCallerId: STRANGER,
+		validState: 'pending',
+		invalidState: 'active',
+		toStatus: 'aborted',
+		notifyRecipient: OWNER,
+		notifyType: 'request_aborted',
+		bodyFor: texts.notifications.requestAborted,
+	},
+];
+
+describe.each(CASES)('$action', (testCase) => {
 	beforeEach(() => vi.clearAllMocks());
 
-	it('requester aborts a pending request: status → aborted, notifies the owner, no item update', async () => {
-		const { pb, convUpdate, itemUpdate } = pbForAbort(conversation({ lendingStatus: 'pending' }));
+	it(`transitions ${testCase.validState} → ${testCase.toStatus} and notifies ${testCase.notifyRecipient === OWNER ? 'the owner' : 'the requester'}`, async () => {
+		const { pb, convUpdate, itemUpdate } = pbForTransition(conversation({ lendingStatus: testCase.validState }));
 
-		const result = await abortRequest(pb, 'conv1', 'userA');
+		const result = await testCase.call(pb, 'conv1', testCase.callerId);
 
 		expect(result).toBeUndefined(); // void on success
-		expect(convUpdate).toHaveBeenCalledWith('conv1', { lendingStatus: 'aborted' });
-		// The frontend must NOT touch the item — the backend hook frees it.
-		expect(itemUpdate).not.toHaveBeenCalled();
+		expect(convUpdate).toHaveBeenCalledTimes(1);
+		expect(convUpdate.mock.calls[0][0]).toBe('conv1');
+		expect(convUpdate.mock.calls[0][1]).toMatchObject({ lendingStatus: testCase.toStatus });
 
-		const body = texts.notifications.requestAborted('Bohrmaschine');
-		// Counterparty of the requester (userA) is the owner (userB).
-		expect(createNotification).toHaveBeenCalledWith(pb, 'userB', 'userA', 'request_aborted', 'conv1', body);
-		expect(sendPushToUser).toHaveBeenCalledWith(pb, 'userB', texts.notifications.pushTitle, body, '/conversations/conv1');
+		if (testCase.itemPatch) {
+			expect(itemUpdate).toHaveBeenCalledWith('item1', testCase.itemPatch);
+		} else {
+			expect(itemUpdate).not.toHaveBeenCalled();
+		}
+
+		const body = testCase.bodyFor(ITEM_NAME);
+		expect(createNotification).toHaveBeenCalledWith(pb, testCase.notifyRecipient, testCase.callerId, testCase.notifyType, 'conv1', body);
+		expect(sendPushToUser).toHaveBeenCalledWith(pb, testCase.notifyRecipient, PUSH_TITLE, body, '/conversations/conv1');
 	});
 
-	it('owner aborts an accepted request: status → aborted, notifies the requester', async () => {
-		const { pb, convUpdate, itemUpdate } = pbForAbort(conversation({ lendingStatus: 'accepted' }));
+	it('rejects a caller in the wrong role with fail(403) and no writes', async () => {
+		const { pb, convUpdate, itemUpdate } = pbForTransition(conversation({ lendingStatus: testCase.validState }));
 
-		const result = await abortRequest(pb, 'conv1', 'userB');
+		const result = await testCase.call(pb, 'conv1', testCase.wrongRoleCallerId);
 
-		expect(result).toBeUndefined();
-		expect(convUpdate).toHaveBeenCalledWith('conv1', { lendingStatus: 'aborted' });
-		expect(itemUpdate).not.toHaveBeenCalled();
-
-		const body = texts.notifications.requestAborted('Bohrmaschine');
-		// Counterparty of the owner (userB) is the requester (userA).
-		expect(createNotification).toHaveBeenCalledWith(pb, 'userA', 'userB', 'request_aborted', 'conv1', body);
-		expect(sendPushToUser).toHaveBeenCalledWith(pb, 'userA', texts.notifications.pushTitle, body, '/conversations/conv1');
-	});
-
-	it('rejects an abort from a non-abortable state with fail(400) and no writes', async () => {
-		const { pb, convUpdate } = pbForAbort(conversation({ lendingStatus: 'active' }));
-
-		const result = await abortRequest(pb, 'conv1', 'userA');
-
-		expect(result).toMatchObject({ status: 400 });
+		expect(result).toMatchObject({ status: 403 });
 		expect(convUpdate).not.toHaveBeenCalled();
+		expect(itemUpdate).not.toHaveBeenCalled();
 		expect(createNotification).not.toHaveBeenCalled();
 		expect(sendPushToUser).not.toHaveBeenCalled();
 	});
 
-	it('rejects an abort from a non-participant with fail(403) and no writes', async () => {
-		const { pb, convUpdate } = pbForAbort(conversation({ lendingStatus: 'pending' }));
+	it('rejects a call from an invalid lending state with fail(400) and no writes', async () => {
+		const { pb, convUpdate, itemUpdate } = pbForTransition(conversation({ lendingStatus: testCase.invalidState }));
 
-		const result = await abortRequest(pb, 'conv1', 'stranger');
+		const result = await testCase.call(pb, 'conv1', testCase.callerId);
 
-		expect(result).toMatchObject({ status: 403 });
+		expect(result).toMatchObject({ status: 400 });
 		expect(convUpdate).not.toHaveBeenCalled();
+		expect(itemUpdate).not.toHaveBeenCalled();
 		expect(createNotification).not.toHaveBeenCalled();
+		expect(sendPushToUser).not.toHaveBeenCalled();
+	});
+});
+
+// Action-specific behavior not covered by the generic table above.
+
+describe('abortRequest (symmetric role)', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('lets the OWNER abort an accepted request too, notifying the requester', async () => {
+		const { pb, convUpdate, itemUpdate } = pbForTransition(conversation({ lendingStatus: 'accepted' }));
+
+		const result = await abortRequest(pb, 'conv1', OWNER);
+
+		expect(result).toBeUndefined();
+		expect(convUpdate).toHaveBeenCalledWith('conv1', { lendingStatus: 'aborted' });
+		// The frontend must NOT touch the item — the backend hook frees it.
+		expect(itemUpdate).not.toHaveBeenCalled();
+		const body = texts.notifications.requestAborted(ITEM_NAME);
+		expect(createNotification).toHaveBeenCalledWith(pb, REQUESTER, OWNER, 'request_aborted', 'conv1', body);
+	});
+});
+
+describe('acceptRequest (auto-reject fan-out)', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('auto-rejects other pending conversations for the same item and notifies each requester', async () => {
+		const convUpdate = vi.fn().mockResolvedValue(true);
+		const itemUpdate = vi.fn().mockResolvedValue(true);
+		const getFullList = vi.fn().mockResolvedValue([{ id: 'conv2', requester: 'userC' }, { id: 'conv3', requester: 'userD' }]);
+		const pb = makeMockPb({
+			conversations: { getOne: vi.fn().mockResolvedValue(conversation({ lendingStatus: 'pending' })), update: convUpdate, getFullList },
+			items: { getOne: vi.fn().mockResolvedValue({ id: 'item1', name: ITEM_NAME }), update: itemUpdate },
+		});
+
+		await acceptRequest(pb, 'conv1', OWNER);
+
+		expect(getFullList).toHaveBeenCalled();
+		expect(convUpdate).toHaveBeenCalledWith('conv2', { lendingStatus: 'rejected' });
+		expect(convUpdate).toHaveBeenCalledWith('conv3', { lendingStatus: 'rejected' });
+		const rejectedBody = texts.notifications.requestRejected(ITEM_NAME);
+		expect(createNotification).toHaveBeenCalledWith(pb, 'userC', OWNER, 'request_rejected', 'conv2', rejectedBody);
+		expect(createNotification).toHaveBeenCalledWith(pb, 'userD', OWNER, 'request_rejected', 'conv3', rejectedBody);
+	});
+
+	it('does not fail the accept when the auto-reject fan-out itself fails', async () => {
+		const convUpdate = vi.fn().mockResolvedValue(true);
+		const itemUpdate = vi.fn().mockResolvedValue(true);
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const pb = makeMockPb({
+			conversations: {
+				getOne: vi.fn().mockResolvedValue(conversation({ lendingStatus: 'pending' })),
+				update: convUpdate,
+				getFullList: vi.fn().mockRejectedValue(new Error('boom')),
+			},
+			items: { getOne: vi.fn().mockResolvedValue({ id: 'item1', name: ITEM_NAME }), update: itemUpdate },
+		});
+
+		const result = await acceptRequest(pb, 'conv1', OWNER);
+
+		expect(result).toBeUndefined();
+		expect(convUpdate).toHaveBeenCalledWith('conv1', { lendingStatus: 'accepted' });
+		expect(consoleError).toHaveBeenCalled();
+		consoleError.mockRestore();
+	});
+});
+
+describe('confirmReturn (counterfactual)', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('also accepts confirming from return_requested (not just active)', async () => {
+		const { pb, convUpdate } = pbForTransition(conversation({ lendingStatus: 'return_requested' }));
+
+		const result = await confirmReturn(pb, 'conv1', OWNER);
+
+		expect(result).toBeUndefined();
+		expect(convUpdate.mock.calls[0][1]).toMatchObject({ lendingStatus: 'completed' });
 	});
 });

--- a/src/routes/conversations/[conversationId]/lending.server.ts
+++ b/src/routes/conversations/[conversationId]/lending.server.ts
@@ -2,9 +2,14 @@ import type PocketBase from 'pocketbase';
 import type { ClientResponseError } from 'pocketbase';
 import { fail } from '@sveltejs/kit';
 import type { NotificationType } from '$lib/types/models.js';
-import { ABORTABLE_LENDING_STATES, isLendingStatusIn, type LendingStatus } from '$lib/lending';
+import {
+	isLendingStatusIn,
+	LENDING_TRANSITIONS,
+	type LendingAction,
+	type LendingStatus,
+} from '$lib/lending';
 import { texts } from '$lib/texts';
-import { createNotification, sendPushToUser } from '$lib/server/notifications.js';
+import { notifyAndPush } from '$lib/server/notifications.js';
 
 const PERCENTAGE_OF_USERS_ASKED = 0.33;
 
@@ -60,9 +65,7 @@ async function notifyUser(
 	conversationId: string,
 	body: string
 ): Promise<void> {
-	const url = `/conversations/${conversationId}`;
-	await createNotification(pb, recipientId, senderId, type, conversationId, body);
-	await sendPushToUser(pb, recipientId, texts.notifications.pushTitle, body, url);
+	await notifyAndPush(pb, { recipient: recipientId, sender: senderId, type, relatedId: conversationId, body });
 }
 
 /** Fetches an item's display name, falling back gracefully if the item can't be loaded. */
@@ -75,117 +78,180 @@ async function getItemName(pb: PocketBase, itemId: string): Promise<string> {
 	}
 }
 
+/** Everything a `TRANSITION_EFFECTS` entry needs to compute its side effects. */
+interface EffectContext {
+	pb: PocketBase;
+	conversationId: string;
+	conv: Record<string, unknown>;
+	userId: string;
+	itemName: string;
+	/** `requestReturn`'s `requesterName` — the only transition that needs extra caller data. */
+	extra?: string;
+}
+
+interface TransitionEffect {
+	/** Extra fields merged into the `conversations.update()` patch alongside `{ lendingStatus }`. */
+	conversationPatch?: (ctx: EffectContext) => Record<string, unknown>;
+	/** Item-side patch to apply after the conversation write succeeds, if any. */
+	itemPatch?: (ctx: EffectContext) => Record<string, unknown> | null;
+	/** Who gets notified, with what type/body. */
+	notify: (ctx: EffectContext) => { recipientId: string; type: NotificationType; body: string };
+	/** Runs after the core transition + notification succeed (failures here are logged, not fatal). */
+	after?: (ctx: EffectContext) => Promise<void>;
+}
+
+/**
+ * Per-action side effects, keyed the same as `$lib/lending.ts`'s `LENDING_TRANSITIONS` (which
+ * supplies the role/state guard). `executeLendingTransition()` below is the single function
+ * that drives conversation update + item update + notification + after-effect for all 6
+ * actions from this table, replacing 6 near-identical try/catch/update blocks.
+ */
+const TRANSITION_EFFECTS: Record<LendingAction, TransitionEffect> = {
+	acceptRequest: {
+		itemPatch: () => ({ status: 'unavailable' }),
+		notify: (ctx) => ({
+			recipientId: ctx.conv.requester as string,
+			type: 'request_accepted',
+			body: texts.notifications.requestAccepted(ctx.itemName),
+		}),
+		// Only one borrower can proceed — auto-reject every other still-pending request
+		// for the same item. Best-effort: a failure here is logged, not surfaced as a
+		// failed accept (the accept itself already succeeded).
+		after: async (ctx) => {
+			try {
+				const otherPending = await ctx.pb.collection('conversations').getFullList({
+					filter: ctx.pb.filter(
+						'requestedItem={:requestedItem} && lendingStatus="pending" && id!={:conversationId}',
+						{ requestedItem: ctx.conv.requestedItem, conversationId: ctx.conversationId }
+					),
+				});
+				await Promise.all(
+					otherPending.map(async (other) => {
+						await ctx.pb.collection('conversations').update(other.id, { lendingStatus: 'rejected' });
+						await notifyUser(ctx.pb, other.requester, ctx.userId, 'request_rejected', other.id, texts.notifications.requestRejected(ctx.itemName));
+					})
+				);
+			} catch (err) {
+				console.error('Failed to auto-reject other pending conversations:', err);
+			}
+		},
+	},
+
+	rejectRequest: {
+		notify: (ctx) => ({
+			recipientId: ctx.conv.requester as string,
+			type: 'request_rejected',
+			body: texts.notifications.requestRejected(ctx.itemName),
+		}),
+	},
+
+	// The requested item is NOT touched here: on `accepted → aborted` the backend
+	// `lending.pb.js` hook resets it to `available` in an elevated transaction (the
+	// aborting party may be the non-owner requester). The counterparty is notified
+	// neutrally — the notification does not name who aborted.
+	abortRequest: {
+		notify: (ctx) => {
+			const counterpartyId = (ctx.conv.requester === ctx.userId ? ctx.conv.itemOwner : ctx.conv.requester) as string;
+			return { recipientId: counterpartyId, type: 'request_aborted', body: texts.notifications.requestAborted(ctx.itemName) };
+		},
+	},
+
+	confirmHandover: {
+		notify: (ctx) => ({
+			recipientId: ctx.conv.requester as string,
+			type: 'handover_confirmed',
+			body: texts.notifications.handoverConfirmed(ctx.itemName),
+		}),
+	},
+
+	requestReturn: {
+		notify: (ctx) => ({
+			recipientId: ctx.conv.itemOwner as string,
+			type: 'return_requested',
+			body: texts.notifications.returnRequested(ctx.extra ?? '', ctx.itemName),
+		}),
+	},
+
+	confirmReturn: {
+		conversationPatch: () => (shouldAskCounterfactual() ? { counterfactual: 'pending' } : {}),
+		itemPatch: () => ({ status: 'available' }),
+		notify: (ctx) => ({
+			recipientId: ctx.conv.requester as string,
+			type: 'return_confirmed',
+			body: texts.notifications.returnConfirmed(ctx.itemName),
+		}),
+	},
+};
+
+/**
+ * Runs a lending state transition end-to-end: role/state guard (via
+ * `loadAndValidateConversation`, using `LENDING_TRANSITIONS[action]`), the conversation +
+ * optional item update (via `TRANSITION_EFFECTS[action]`), the notification, and any
+ * after-effect. Every one of the 6 exported transition functions below is a thin wrapper
+ * around this.
+ */
+async function executeLendingTransition(
+	pb: PocketBase,
+	action: LendingAction,
+	conversationId: string,
+	userId: string,
+	extra?: string
+): Promise<FailResult | void> {
+	const transition = LENDING_TRANSITIONS[action];
+	const result = await loadAndValidateConversation(pb, conversationId, userId, transition.role, transition.from);
+	if ('error' in result) return result.error;
+	const { conv } = result;
+
+	const itemName = await getItemName(pb, conv.requestedItem as string);
+	const effect = TRANSITION_EFFECTS[action];
+	const ctx: EffectContext = { pb, conversationId, conv, userId, itemName, extra };
+
+	try {
+		const extraPatch = effect.conversationPatch?.(ctx) ?? {};
+		await pb.collection('conversations').update(conversationId, { lendingStatus: transition.to, ...extraPatch });
+		// NOT atomic: for acceptRequest/confirmReturn this is a conversation write followed by
+		// a separate item write — if the item update fails after the conversation update
+		// already succeeded, the two can end up out of sync (e.g. status 'accepted' but the
+		// item still 'available'). Fixing this needs a backend transaction (PocketBase hook
+		// running both writes in `$app.runInTransaction`); out of scope for this refactor.
+		const itemPatch = effect.itemPatch?.(ctx);
+		if (itemPatch) await pb.collection('items').update(conv.requestedItem as string, itemPatch);
+	} catch (err) {
+		const e = err as Partial<ClientResponseError>;
+		return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });
+	}
+
+	const { recipientId, type, body } = effect.notify(ctx);
+	await notifyUser(pb, recipientId, userId, type, conversationId, body);
+
+	if (effect.after) await effect.after(ctx);
+}
+
 /**
  * State transition: `pending` → `accepted` (called by item owner).
  * Marks the item unavailable and auto-rejects all other pending conversations
  * for the same item so only one borrower can proceed.
  */
-export async function acceptRequest(
-	pb: PocketBase,
-	conversationId: string,
-	userId: string
-): Promise<FailResult | void> {
-	const result = await loadAndValidateConversation(pb, conversationId, userId, 'owner', 'pending');
-	if ('error' in result) return result.error;
-	const { conv } = result;
-
-	const itemName = await getItemName(pb, conv.requestedItem as string);
-
-	try {
-		await pb.collection('conversations').update(conversationId, { lendingStatus: 'accepted' });
-		await pb.collection('items').update(conv.requestedItem as string, { status: 'unavailable' });
-	} catch (err) {
-		const e = err as Partial<ClientResponseError>;
-		return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });
-	}
-
-	await notifyUser(pb, conv.requester as string, userId, 'request_accepted', conversationId, texts.notifications.requestAccepted(itemName));
-
-	// Auto-reject all other pending conversations for the same item
-	try {
-		const otherPending = await pb.collection('conversations').getFullList({
-			filter: pb.filter('requestedItem={:requestedItem} && lendingStatus="pending" && id!={:conversationId}', {
-				requestedItem: conv.requestedItem,
-				conversationId,
-			}),
-		});
-		await Promise.all(otherPending.map(async (other) => {
-			await pb.collection('conversations').update(other.id, { lendingStatus: 'rejected' });
-			await notifyUser(pb, other.requester, userId, 'request_rejected', other.id, texts.notifications.requestRejected(itemName));
-		}));
-	} catch (err) {
-		console.error('Failed to auto-reject other pending conversations:', err);
-	}
+export async function acceptRequest(pb: PocketBase, conversationId: string, userId: string): Promise<FailResult | void> {
+	return executeLendingTransition(pb, 'acceptRequest', conversationId, userId);
 }
 
 /** State transition: `pending` → `rejected` (called by item owner). */
-export async function rejectRequest(
-	pb: PocketBase,
-	conversationId: string,
-	userId: string
-): Promise<FailResult | void> {
-	const result = await loadAndValidateConversation(pb, conversationId, userId, 'owner', 'pending');
-	if ('error' in result) return result.error;
-	const { conv } = result;
-
-	try {
-		await pb.collection('conversations').update(conversationId, { lendingStatus: 'rejected' });
-	} catch (err) {
-		const e = err as Partial<ClientResponseError>;
-		return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });
-	}
-
-	const itemName = await getItemName(pb, conv.requestedItem as string);
-	await notifyUser(pb, conv.requester as string, userId, 'request_rejected', conversationId, texts.notifications.requestRejected(itemName));
-}
-
-/** State transition: `accepted` → `active` (called by item owner after physical handover). */
-export async function confirmHandover(
-	pb: PocketBase,
-	conversationId: string,
-	userId: string
-): Promise<FailResult | void> {
-	const result = await loadAndValidateConversation(pb, conversationId, userId, 'owner', 'accepted');
-	if ('error' in result) return result.error;
-	const { conv } = result;
-
-	try {
-		await pb.collection('conversations').update(conversationId, { lendingStatus: 'active' });
-	} catch (err) {
-		const e = err as Partial<ClientResponseError>;
-		return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });
-	}
-
-	const itemName = await getItemName(pb, conv.requestedItem as string);
-	await notifyUser(pb, conv.requester as string, userId, 'handover_confirmed', conversationId, texts.notifications.handoverConfirmed(itemName));
+export async function rejectRequest(pb: PocketBase, conversationId: string, userId: string): Promise<FailResult | void> {
+	return executeLendingTransition(pb, 'rejectRequest', conversationId, userId);
 }
 
 /**
  * State transition: `pending` | `accepted` → `aborted` (called by EITHER party).
- * The counterparty is notified (neutrally — the notification does not name who
- * aborted). The requested item is NOT touched here: on `accepted → aborted` the
- * backend `lending.pb.js` hook resets it to `available` in an elevated
- * transaction (the aborting party may be the non-owner requester).
+ * See `TRANSITION_EFFECTS.abortRequest` for why the item is intentionally left untouched.
  */
-export async function abortRequest(
-	pb: PocketBase,
-	conversationId: string,
-	userId: string
-): Promise<FailResult | void> {
-	const result = await loadAndValidateConversation(pb, conversationId, userId, 'participant', ABORTABLE_LENDING_STATES);
-	if ('error' in result) return result.error;
-	const { conv } = result;
+export async function abortRequest(pb: PocketBase, conversationId: string, userId: string): Promise<FailResult | void> {
+	return executeLendingTransition(pb, 'abortRequest', conversationId, userId);
+}
 
-	try {
-		await pb.collection('conversations').update(conversationId, { lendingStatus: 'aborted' });
-	} catch (err) {
-		const e = err as Partial<ClientResponseError>;
-		return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });
-	}
-
-	const itemName = await getItemName(pb, conv.requestedItem as string);
-	const counterpartyId = (conv.requester === userId ? conv.itemOwner : conv.requester) as string;
-	await notifyUser(pb, counterpartyId, userId, 'request_aborted', conversationId, texts.notifications.requestAborted(itemName));
+/** State transition: `accepted` → `active` (called by item owner after physical handover). */
+export async function confirmHandover(pb: PocketBase, conversationId: string, userId: string): Promise<FailResult | void> {
+	return executeLendingTransition(pb, 'confirmHandover', conversationId, userId);
 }
 
 /** State transition: `active` → `return_requested` (called by the borrower). */
@@ -195,44 +261,13 @@ export async function requestReturn(
 	userId: string,
 	requesterName: string
 ): Promise<FailResult | void> {
-	const result = await loadAndValidateConversation(pb, conversationId, userId, 'requester', 'active');
-	if ('error' in result) return result.error;
-	const { conv } = result;
-
-	try {
-		await pb.collection('conversations').update(conversationId, { lendingStatus: 'return_requested' });
-	} catch (err) {
-		const e = err as Partial<ClientResponseError>;
-		return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });
-	}
-
-	const itemName = await getItemName(pb, conv.requestedItem as string);
-	await notifyUser(pb, conv.itemOwner as string, userId, 'return_requested', conversationId, texts.notifications.returnRequested(requesterName, itemName));
+	return executeLendingTransition(pb, 'requestReturn', conversationId, userId, requesterName);
 }
 
 /**
  * State transition: `active` | `return_requested` → `completed` (called by item owner).
  * Marks the item available again so it can receive new requests.
  */
-export async function confirmReturn(
-	pb: PocketBase,
-	conversationId: string,
-	userId: string
-): Promise<FailResult | void> {
-	const result = await loadAndValidateConversation(pb, conversationId, userId, 'owner', ['active', 'return_requested']);
-	if ('error' in result) return result.error;
-	const { conv } = result;
-
-	const itemName = await getItemName(pb, conv.requestedItem as string);
-
-	try {
-		const counterfactualPatch = shouldAskCounterfactual() ? { counterfactual: 'pending' } : {};
-		await pb.collection('conversations').update(conversationId, { lendingStatus: 'completed', ...counterfactualPatch });
-		await pb.collection('items').update(conv.requestedItem as string, { status: 'available' });
-	} catch (err) {
-		const e = err as Partial<ClientResponseError>;
-		return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });
-	}
-
-	await notifyUser(pb, conv.requester as string, userId, 'return_confirmed', conversationId, texts.notifications.returnConfirmed(itemName));
+export async function confirmReturn(pb: PocketBase, conversationId: string, userId: string): Promise<FailResult | void> {
+	return executeLendingTransition(pb, 'confirmReturn', conversationId, userId);
 }

--- a/src/routes/conversations/[conversationId]/lending.server.ts
+++ b/src/routes/conversations/[conversationId]/lending.server.ts
@@ -56,18 +56,6 @@ async function loadAndValidateConversation(
 	return { conv: conversation };
 }
 
-/** Sends both an in-app notification and a push to all of a user's registered devices. */
-async function notifyUser(
-	pb: PocketBase,
-	recipientId: string,
-	senderId: string,
-	type: NotificationType,
-	conversationId: string,
-	body: string
-): Promise<void> {
-	await notifyAndPush(pb, { recipient: recipientId, sender: senderId, type, relatedId: conversationId, body });
-}
-
 /** Fetches an item's display name, falling back gracefully if the item can't be loaded. */
 async function getItemName(pb: PocketBase, itemId: string): Promise<string> {
 	try {
@@ -128,7 +116,13 @@ const TRANSITION_EFFECTS: Record<LendingAction, TransitionEffect> = {
 				await Promise.all(
 					otherPending.map(async (other) => {
 						await ctx.pb.collection('conversations').update(other.id, { lendingStatus: 'rejected' });
-						await notifyUser(ctx.pb, other.requester, ctx.userId, 'request_rejected', other.id, texts.notifications.requestRejected(ctx.itemName));
+						await notifyAndPush(ctx.pb, {
+							recipient: other.requester,
+							sender: ctx.userId,
+							type: 'request_rejected',
+							relatedId: other.id,
+							body: texts.notifications.requestRejected(ctx.itemName),
+						});
 					})
 				);
 			} catch (err) {
@@ -222,7 +216,7 @@ async function executeLendingTransition(
 	}
 
 	const { recipientId, type, body } = effect.notify(ctx);
-	await notifyUser(pb, recipientId, userId, type, conversationId, body);
+	await notifyAndPush(pb, { recipient: recipientId, sender: userId, type, relatedId: conversationId, body });
 
 	if (effect.after) await effect.after(ctx);
 }

--- a/src/routes/conversations/[conversationId]/lending.server.ts
+++ b/src/routes/conversations/[conversationId]/lending.server.ts
@@ -73,8 +73,8 @@ interface EffectContext {
 	conv: Record<string, unknown>;
 	userId: string;
 	itemName: string;
-	/** `requestReturn`'s `requesterName` — the only transition that needs extra caller data. */
-	extra?: string;
+	/** Set only for `requestReturn`, the sole transition that needs extra caller data. */
+	requesterName?: string;
 }
 
 interface TransitionEffect {
@@ -162,7 +162,7 @@ const TRANSITION_EFFECTS: Record<LendingAction, TransitionEffect> = {
 		notify: (ctx) => ({
 			recipientId: ctx.conv.itemOwner as string,
 			type: 'return_requested',
-			body: texts.notifications.returnRequested(ctx.extra ?? '', ctx.itemName),
+			body: texts.notifications.returnRequested(ctx.requesterName ?? '', ctx.itemName),
 		}),
 	},
 
@@ -189,7 +189,7 @@ async function executeLendingTransition(
 	action: LendingAction,
 	conversationId: string,
 	userId: string,
-	extra?: string
+	requesterName?: string
 ): Promise<FailResult | void> {
 	const transition = LENDING_TRANSITIONS[action];
 	const result = await loadAndValidateConversation(pb, conversationId, userId, transition.role, transition.from);
@@ -198,7 +198,7 @@ async function executeLendingTransition(
 
 	const itemName = await getItemName(pb, conv.requestedItem as string);
 	const effect = TRANSITION_EFFECTS[action];
-	const ctx: EffectContext = { pb, conversationId, conv, userId, itemName, extra };
+	const ctx: EffectContext = { pb, conversationId, conv, userId, itemName, requesterName };
 
 	try {
 		const extraPatch = effect.conversationPatch?.(ctx) ?? {};

--- a/src/routes/conversations/[conversationId]/page.server.test.ts
+++ b/src/routes/conversations/[conversationId]/page.server.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { conversationFieldsWithSafePartners } from '$lib/conversationPartnerFields';
+import { makeMockPb } from '$lib/test-utils/pocketbase';
+
+// Avoid loading the real notifications module (web-push + VAPID env) at import time —
+// pulled in transitively via ./lending.server.js and ./conversation.server.js.
+vi.mock('$lib/server/notifications.js', () => ({
+	createNotification: vi.fn(),
+	sendPushToUser: vi.fn(),
+	isMessageNotificationThrottled: vi.fn(),
+	notifyAndPush: vi.fn(),
+}));
+
+// Contact resolution is exercised by its own suite; stub it here so `load()` doesn't need a
+// real `user_contacts` collection wired into the mock pb.
+vi.mock('$lib/server/contacts', () => ({
+	fetchPartnerContact: vi.fn().mockResolvedValue(null),
+}));
+
+import { load } from './+page.server';
+
+const REQUESTER = 'userA';
+const OWNER = 'userB';
+
+function conversationRecord(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'conv1',
+		requester: REQUESTER,
+		itemOwner: OWNER,
+		requestedItem: 'item1',
+		lendingStatus: 'pending',
+		readByRequester: true,
+		readByOwner: true,
+		created: '2026-01-01',
+		updated: '2026-01-01',
+		expand: {
+			requester: { id: REQUESTER, username: 'requesterName', deleted: false },
+			itemOwner: { id: OWNER, username: 'ownerName', deleted: false },
+			requestedItem: { id: 'item1', name: 'Bohrmaschine' },
+			messages: [],
+		},
+		...overrides,
+	};
+}
+
+describe('conversations/[conversationId] load()', () => {
+	it("requests the requester/itemOwner expand restricted to conversationFieldsWithSafePartners' safe subset (never email)", async () => {
+		const getOne = vi.fn().mockResolvedValue(conversationRecord());
+		const pb = makeMockPb({
+			conversations: { getOne, update: vi.fn() },
+			notifications: { getFullList: vi.fn().mockResolvedValue([]) },
+		});
+
+		await load({
+			params: { conversationId: 'conv1' },
+			locals: { pb, user: { id: REQUESTER } },
+		} as unknown as Parameters<typeof load>[0]);
+
+		expect(getOne).toHaveBeenCalledWith(
+			'conv1',
+			expect.objectContaining({
+				fields: conversationFieldsWithSafePartners('*,expand.requestedItem.*,expand.messages.*'),
+			})
+		);
+		// Belt-and-suspenders: whatever the fields builder produces, this call site must
+		// never end up requesting the partners' `email` field.
+		const requestedFields = getOne.mock.calls[0][1].fields as string;
+		expect(requestedFields).not.toMatch(/email/i);
+	});
+});

--- a/src/routes/conversations/[conversationId]/presenceHeartbeat.test.ts
+++ b/src/routes/conversations/[conversationId]/presenceHeartbeat.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { startPresenceHeartbeat } from './presenceHeartbeat';
+
+function makePb(update: ReturnType<typeof vi.fn>) {
+	return { collection: vi.fn(() => ({ update })) } as never;
+}
+
+describe('startPresenceHeartbeat', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.stubGlobal('document', { visibilityState: 'visible' });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+	});
+
+	it('pings immediately on start, with the exact given field', () => {
+		const update = vi.fn().mockResolvedValue(undefined);
+		const pb = makePb(update);
+
+		const stop = startPresenceHeartbeat(pb, 'conv1', 'ownerLastSeenAt');
+
+		expect(update).toHaveBeenCalledTimes(1);
+		expect(update).toHaveBeenCalledWith('conv1', { ownerLastSeenAt: expect.any(String) });
+		stop();
+	});
+
+	it('uses requesterLastSeenAt (not ownerLastSeenAt) when that field is requested', () => {
+		const update = vi.fn().mockResolvedValue(undefined);
+		const pb = makePb(update);
+
+		const stop = startPresenceHeartbeat(pb, 'conv1', 'requesterLastSeenAt');
+
+		expect(update).toHaveBeenCalledWith('conv1', { requesterLastSeenAt: expect.any(String) });
+		const [, payload] = update.mock.calls[0];
+		expect(payload).not.toHaveProperty('ownerLastSeenAt');
+		stop();
+	});
+
+	it('pings again every 15 seconds — not more, not less often', () => {
+		const update = vi.fn().mockResolvedValue(undefined);
+		const pb = makePb(update);
+		const stop = startPresenceHeartbeat(pb, 'conv1', 'ownerLastSeenAt');
+		update.mockClear();
+
+		vi.advanceTimersByTime(14_999);
+		expect(update).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(1);
+		expect(update).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(15_000);
+		expect(update).toHaveBeenCalledTimes(2);
+
+		stop();
+	});
+
+	it('skips the ping while the document is not visible', () => {
+		vi.stubGlobal('document', { visibilityState: 'hidden' });
+		const update = vi.fn();
+		const pb = makePb(update);
+
+		const stop = startPresenceHeartbeat(pb, 'conv1', 'ownerLastSeenAt');
+		vi.advanceTimersByTime(30_000);
+
+		expect(update).not.toHaveBeenCalled();
+		stop();
+	});
+
+	it('stops pinging once the returned cleanup function is called', () => {
+		const update = vi.fn().mockResolvedValue(undefined);
+		const pb = makePb(update);
+		const stop = startPresenceHeartbeat(pb, 'conv1', 'ownerLastSeenAt');
+		update.mockClear();
+
+		stop();
+		vi.advanceTimersByTime(60_000);
+
+		expect(update).not.toHaveBeenCalled();
+	});
+});

--- a/src/routes/conversations/[conversationId]/presenceHeartbeat.ts
+++ b/src/routes/conversations/[conversationId]/presenceHeartbeat.ts
@@ -1,0 +1,48 @@
+import type PocketBase from 'pocketbase';
+
+/** Ping cadence — see the SSE-watchdog coupling note below before changing this. */
+const HEARTBEAT_INTERVAL_MS = 15_000;
+
+/**
+ * Periodically updates `field` on the conversation to "now", so the backend knows the
+ * current user is actively viewing it and can suppress email notifications for it while
+ * they are.
+ *
+ * `field` MUST be exactly `ownerLastSeenAt` for the item owner or `requesterLastSeenAt`
+ * for the requester — the backend's `conversations` updateRule silently rejects a PATCH
+ * naming the wrong side's field, which would quietly break email suppression for that
+ * user with no visible error. Get this from the caller's own role check, never guess it
+ * here.
+ *
+ * This heartbeat also feeds an already-merged SSE watchdog: the detail page passes
+ * `expectsHeartbeat: true` to `conversationRealtime.ts`'s `subscribeConversation()` for
+ * exactly this reason — because each ping here echoes back over realtime as a
+ * `conversations` update, a healthy stream delivers an event at least every
+ * {@link HEARTBEAT_INTERVAL_MS}, letting `subscribeRealtime()`'s watchdog treat a longer
+ * silence as a frozen connection and reconnect (#528). Do not change the cadence without
+ * checking that coupling still holds.
+ *
+ * @param pb              Shared client PocketBase instance.
+ * @param conversationId  Conversation to ping.
+ * @param field           Which side's lastSeenAt field to update.
+ * @returns A cleanup function that stops the heartbeat — call it from `$effect`'s teardown.
+ */
+export function startPresenceHeartbeat(
+	pb: PocketBase,
+	conversationId: string,
+	field: 'ownerLastSeenAt' | 'requesterLastSeenAt'
+): () => void {
+	const ping = () => {
+		// Only ping while the tab is actually visible — a backgrounded/closed tab
+		// shouldn't be reported as "actively viewing" for email-suppression purposes.
+		if (document.visibilityState !== 'visible') return;
+		pb.collection('conversations')
+			.update(conversationId, { [field]: new Date().toISOString() })
+			.catch(() => {});
+	};
+
+	// Ping immediately on mount, then on the fixed cadence.
+	ping();
+	const interval = setInterval(ping, HEARTBEAT_INTERVAL_MS);
+	return () => clearInterval(interval);
+}

--- a/src/routes/conversations/chatViewport.ts
+++ b/src/routes/conversations/chatViewport.ts
@@ -1,0 +1,74 @@
+import type { Action } from 'svelte/action';
+
+/**
+ * Locks the document while a conversation route is mounted so the page itself can
+ * never scroll: the chat is a fixed-height app shell, and a scrollable document is
+ * what let the mobile keyboard scroll the whole page down (revealing the footer)
+ * instead of just reflowing the chat. The footer and the root <main> padding still
+ * exist in flow but are simply clipped below the fold. Scoped here (rather than in
+ * the root layout) via mount/destroy, the same pattern modals use for scroll-locking.
+ */
+export const scrollLock: Action<HTMLElement> = () => {
+	const html = document.documentElement;
+	const body = document.body;
+	const prevHtml = html.style.overflow;
+	const prevBody = body.style.overflow;
+	// Reset to the top before locking: on a cold load the document can already be
+	// scrolled down (e.g. the input focus dragging the too-tall page into view), and
+	// locking `overflow: hidden` would otherwise freeze it there — footer showing,
+	// view trapped (#529). The input now focuses with preventScroll, this is the belt.
+	window.scrollTo(0, 0);
+	html.style.overflow = 'hidden';
+	body.style.overflow = 'hidden';
+	return {
+		destroy() {
+			html.style.overflow = prevHtml;
+			body.style.overflow = prevBody;
+		},
+	};
+};
+
+/**
+ * Size the chat container to fill the *visual* viewport below the navbar.
+ * Using visualViewport.height (rather than 100dvh) means the on-screen mobile
+ * keyboard shrinks the container: the message list (flex-1) absorbs the shrink
+ * and the input bar rides up just above the keyboard, matching native chat apps.
+ * The scroll-lock above keeps the page itself from scrolling, so the keyboard only
+ * reflows this container.
+ * On a cold load (push/share link, reload) the mobile visual viewport isn't settled
+ * yet — the browser toolbar is still expanded, so a single mount-time measurement
+ * fixes too small a height and the scroll-lock stops a correcting event from firing.
+ * So we re-measure across the settle window: after first paint (rAF), after the
+ * toolbar collapses (timeout), and on window `load` / `orientationchange`, on top of
+ * the live resize/scroll listeners. On internal navigation the viewport is already
+ * settled → the extra passes are harmless no-ops.
+ */
+export const viewportHeight: Action<HTMLElement> = (node) => {
+	const vv = window.visualViewport;
+
+	const update = () => {
+		const top = node.getBoundingClientRect().top + window.scrollY;
+		const height = vv ? vv.height : window.innerHeight;
+		node.style.height = `${height - top}px`;
+	};
+
+	update();
+	const rafId = requestAnimationFrame(update);
+	const timeoutId = setTimeout(update, 250);
+	window.addEventListener('load', update);
+	window.addEventListener('orientationchange', update);
+	window.addEventListener('resize', update);
+	vv?.addEventListener('resize', update);
+	vv?.addEventListener('scroll', update);
+	return {
+		destroy() {
+			cancelAnimationFrame(rafId);
+			clearTimeout(timeoutId);
+			window.removeEventListener('load', update);
+			window.removeEventListener('orientationchange', update);
+			window.removeEventListener('resize', update);
+			vv?.removeEventListener('resize', update);
+			vv?.removeEventListener('scroll', update);
+		},
+	};
+};

--- a/src/routes/conversations/conversationFilters.test.ts
+++ b/src/routes/conversations/conversationFilters.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import type { Conversation } from '$lib/types/models';
+import { isLending, isConversationActive, matchesRole, matchesActive, emptyReason } from './conversationFilters';
+
+const OWNER = 'userB';
+const REQUESTER = 'userA';
+
+function conv(overrides: Partial<Conversation> = {}): Pick<Conversation, 'itemOwner' | 'lendingStatus'> {
+	return { itemOwner: OWNER, lendingStatus: undefined, ...overrides };
+}
+
+describe('isLending', () => {
+	it('is true when the current user is the item owner', () => {
+		expect(isLending(conv({ itemOwner: OWNER }), OWNER)).toBe(true);
+	});
+
+	it('is false when the current user is the requester', () => {
+		expect(isLending(conv({ itemOwner: OWNER }), REQUESTER)).toBe(false);
+	});
+});
+
+describe('isConversationActive', () => {
+	it('is true for a plain chat with no lending status', () => {
+		expect(isConversationActive(conv({ lendingStatus: undefined }))).toBe(true);
+	});
+
+	it('is true for every OPEN_LENDING_STATES status', () => {
+		for (const status of ['pending', 'accepted', 'active', 'return_requested'] as const) {
+			expect(isConversationActive(conv({ lendingStatus: status }))).toBe(true);
+		}
+	});
+
+	it('is false for a terminal status', () => {
+		for (const status of ['completed', 'rejected', 'aborted'] as const) {
+			expect(isConversationActive(conv({ lendingStatus: status }))).toBe(false);
+		}
+	});
+});
+
+describe('matchesRole', () => {
+	const lendingConv = conv({ itemOwner: OWNER });
+
+	it('passes everything when no filter is selected', () => {
+		expect(matchesRole(lendingConv, OWNER, null)).toBe(true);
+		expect(matchesRole(lendingConv, REQUESTER, null)).toBe(true);
+	});
+
+	it("matches the 'lending' filter only for the item owner", () => {
+		expect(matchesRole(lendingConv, OWNER, 'lending')).toBe(true);
+		expect(matchesRole(lendingConv, REQUESTER, 'lending')).toBe(false);
+	});
+
+	it("matches the 'borrowing' filter only for the non-owner", () => {
+		expect(matchesRole(lendingConv, OWNER, 'borrowing')).toBe(false);
+		expect(matchesRole(lendingConv, REQUESTER, 'borrowing')).toBe(true);
+	});
+});
+
+describe('matchesActive', () => {
+	it('passes everything when showOnlyActive is false', () => {
+		expect(matchesActive(conv({ lendingStatus: 'completed' }), false)).toBe(true);
+	});
+
+	it('filters out terminal states when showOnlyActive is true', () => {
+		expect(matchesActive(conv({ lendingStatus: 'completed' }), true)).toBe(false);
+		expect(matchesActive(conv({ lendingStatus: 'pending' }), true)).toBe(true);
+		expect(matchesActive(conv({ lendingStatus: undefined }), true)).toBe(true);
+	});
+});
+
+describe('emptyReason', () => {
+	it("returns 'active' whenever the role filter has any match (even if the active-only checkbox hides them all)", () => {
+		expect(emptyReason(true, null)).toBe('active');
+		expect(emptyReason(true, 'lending')).toBe('active');
+	});
+
+	it("returns the selected role filter's name when it has zero matches", () => {
+		expect(emptyReason(false, 'lending')).toBe('lending');
+		expect(emptyReason(false, 'borrowing')).toBe('borrowing');
+	});
+
+	it("returns 'none' when no filter is selected and there are no conversations at all", () => {
+		expect(emptyReason(false, null)).toBe('none');
+	});
+});

--- a/src/routes/conversations/conversationFilters.ts
+++ b/src/routes/conversations/conversationFilters.ts
@@ -1,0 +1,48 @@
+import type { Conversation } from '$lib/types/models';
+import { OPEN_LENDING_STATES, isLendingStatusIn } from '$lib/lending';
+
+/** `null` = no role filter selected, show both lending and borrowing conversations. */
+export type ConversationRoleFilter = 'lending' | 'borrowing' | null;
+
+/** Is the current user the item owner (lending) side of this conversation? */
+export function isLending(c: Pick<Conversation, 'itemOwner'>, currentUserId: string): boolean {
+	return c.itemOwner === currentUserId;
+}
+
+/**
+ * Plain chats without a lending status count as active; terminal states
+ * (rejected/aborted/completed) do not.
+ */
+export function isConversationActive(c: Pick<Conversation, 'lendingStatus'>): boolean {
+	return !c.lendingStatus || isLendingStatusIn(OPEN_LENDING_STATES, c.lendingStatus);
+}
+
+/** Does `c` match the selected lending/borrowing tab (or pass through when none is selected)? */
+export function matchesRole(
+	c: Pick<Conversation, 'itemOwner'>,
+	currentUserId: string,
+	filter: ConversationRoleFilter
+): boolean {
+	return filter === null || (filter === 'lending') === isLending(c, currentUserId);
+}
+
+/** Does `c` pass the "only active conversations" checkbox? */
+export function matchesActive(c: Pick<Conversation, 'lendingStatus'>, showOnlyActive: boolean): boolean {
+	return !showOnlyActive || isConversationActive(c);
+}
+
+export type EmptyReason = 'active' | 'lending' | 'borrowing' | 'none';
+
+/**
+ * Which empty-state message the sidebar should show. `hasAnyMatchingRoleFilter` is whether
+ * any conversation matches the selected lending/borrowing tab BEFORE the "only active"
+ * checkbox is applied — so a tab that has conversations, all hidden by that checkbox, still
+ * reports 'active' (matching the checkbox's own empty-state copy) rather than falsely
+ * claiming there are no conversations of that type at all.
+ */
+export function emptyReason(hasAnyMatchingRoleFilter: boolean, activeFilter: ConversationRoleFilter): EmptyReason {
+	if (hasAnyMatchingRoleFilter) return 'active';
+	if (activeFilter === 'lending') return 'lending';
+	if (activeFilter === 'borrowing') return 'borrowing';
+	return 'none';
+}

--- a/src/routes/conversations/conversationListRealtime.test.ts
+++ b/src/routes/conversations/conversationListRealtime.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { RecordSubscription } from 'pocketbase';
+import type { Conversation } from '$lib/types/models';
+import { makeMockPb } from '$lib/test-utils/pocketbase';
+import { conversationFieldsWithSafePartners } from '$lib/conversationPartnerFields';
+
+const { subscribeRealtime, unsubscribe } = vi.hoisted(() => ({
+	subscribeRealtime: vi.fn(),
+	unsubscribe: vi.fn(),
+}));
+
+vi.mock('$lib/client-pb', () => ({ subscribeRealtime }));
+
+import { subscribeConversationList } from './conversationListRealtime';
+
+type Handler = (event: RecordSubscription<Conversation>) => void | Promise<void>;
+
+function registeredHandler(): Handler {
+	expect(subscribeRealtime).toHaveBeenCalledTimes(1);
+	return subscribeRealtime.mock.calls[0][0].handler as Handler;
+}
+
+function conv(overrides: Partial<Conversation> = {}): Conversation {
+	return {
+		id: 'c1',
+		requester: 'userA',
+		itemOwner: 'userB',
+		requestedItem: 'item1',
+		messages: [],
+		readByRequester: true,
+		readByOwner: true,
+		lastMessageAt: '',
+		created: '2025-01-01T00:00:00Z',
+		updated: '2025-01-01T00:00:00Z',
+		...overrides,
+	} as Conversation;
+}
+
+/** Backing state + accessors mirroring how the layout wires this helper's list. */
+function makeState(initial: Conversation[] = []) {
+	let list = initial;
+	const setList = vi.fn((next: Conversation[]) => {
+		list = next;
+	});
+	return {
+		getList: () => list,
+		setList,
+		get list() {
+			return list;
+		},
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	subscribeRealtime.mockReturnValue(unsubscribe);
+});
+
+describe('subscribeConversationList', () => {
+	it('wires the subscription to the "*" topic and returns the unsubscribe fn', () => {
+		const state = makeState();
+		const onReconnect = vi.fn();
+		const cleanup = subscribeConversationList(makeMockPb({}), state.getList, state.setList, onReconnect);
+
+		expect(subscribeRealtime).toHaveBeenCalledTimes(1);
+		const opts = subscribeRealtime.mock.calls[0][0];
+		expect(opts.collection).toBe('conversations');
+		expect(opts.topic).toBe('*');
+		expect(opts.onReconnect).toBe(onReconnect);
+		expect(cleanup).toBe(unsubscribe);
+	});
+
+	describe('update events', () => {
+		it('syncs readByOwner/readByRequester, lastMessageAt and lendingStatus', async () => {
+			const state = makeState([conv({ id: 'c1', readByOwner: false, lastMessageAt: '2025-01-01T00:00:00Z' })]);
+			subscribeConversationList(makeMockPb({}), state.getList, state.setList);
+
+			await registeredHandler()({
+				action: 'update',
+				record: {
+					id: 'c1',
+					readByOwner: true,
+					readByRequester: false,
+					lastMessageAt: '2025-01-02T00:00:00Z',
+					lendingStatus: 'accepted',
+				},
+			} as unknown as RecordSubscription<Conversation>);
+
+			expect(state.list).toEqual([
+				expect.objectContaining({
+					id: 'c1',
+					readByOwner: true,
+					readByRequester: false,
+					lastMessageAt: '2025-01-02T00:00:00Z',
+					lendingStatus: 'accepted',
+				}),
+			]);
+		});
+
+		it('re-sorts the list by the new lastMessageAt (descending)', async () => {
+			const older = conv({ id: 'older', lastMessageAt: '2025-01-01T00:00:00Z' });
+			const newer = conv({ id: 'newer', lastMessageAt: '2025-01-05T00:00:00Z' });
+			const state = makeState([newer, older]);
+			subscribeConversationList(makeMockPb({}), state.getList, state.setList);
+
+			// 'older' just received a brand-new message, making it the most recent.
+			await registeredHandler()({
+				action: 'update',
+				record: { id: 'older', readByOwner: true, readByRequester: true, lastMessageAt: '2025-01-10T00:00:00Z' },
+			} as unknown as RecordSubscription<Conversation>);
+
+			expect(state.list.map((c) => c.id)).toEqual(['older', 'newer']);
+		});
+
+		it('leaves the list untouched when the updated conversation is not present', async () => {
+			const state = makeState([conv({ id: 'c1' })]);
+			subscribeConversationList(makeMockPb({}), state.getList, state.setList);
+
+			await registeredHandler()({
+				action: 'update',
+				record: { id: 'unknown', readByOwner: true, readByRequester: true, lastMessageAt: '' },
+			} as unknown as RecordSubscription<Conversation>);
+
+			expect(state.list.map((c) => c.id)).toEqual(['c1']);
+		});
+	});
+
+	describe('create events', () => {
+		it('inserts a fetched record respecting the sort order (not just appending)', async () => {
+			const older = conv({ id: 'older', lastMessageAt: '2025-01-01T00:00:00Z' });
+			const newest = conv({ id: 'newest', lastMessageAt: '2025-01-20T00:00:00Z' });
+			const state = makeState([older]);
+			const getOne = vi.fn().mockResolvedValue(newest);
+			const pb = makeMockPb({ conversations: { getOne } });
+			subscribeConversationList(pb, state.getList, state.setList);
+
+			await registeredHandler()({ action: 'create', record: { id: 'newest' } } as unknown as RecordSubscription<Conversation>);
+
+			expect(getOne).toHaveBeenCalledWith('newest', {
+				expand: 'requester,itemOwner,requestedItem',
+				fields: conversationFieldsWithSafePartners('*,expand.requestedItem.*'),
+			});
+			expect(state.list.map((c) => c.id)).toEqual(['newest', 'older']);
+		});
+
+		it('skips the fetch and does not duplicate when the id is already present', async () => {
+			const state = makeState([conv({ id: 'c1' })]);
+			const getOne = vi.fn();
+			subscribeConversationList(makeMockPb({ conversations: { getOne } }), state.getList, state.setList);
+
+			await registeredHandler()({ action: 'create', record: { id: 'c1' } } as unknown as RecordSubscription<Conversation>);
+
+			expect(getOne).not.toHaveBeenCalled();
+			expect(state.setList).not.toHaveBeenCalled();
+		});
+
+		it('silently ignores a fetch failure (record deleted before it could be fetched)', async () => {
+			const state = makeState([]);
+			const getOne = vi.fn().mockRejectedValue(new Error('not found'));
+			subscribeConversationList(makeMockPb({ conversations: { getOne } }), state.getList, state.setList);
+
+			await expect(
+				registeredHandler()({ action: 'create', record: { id: 'gone' } } as unknown as RecordSubscription<Conversation>)
+			).resolves.toBeUndefined();
+			expect(state.setList).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('delete events', () => {
+		it('removes the deleted conversation from the list', async () => {
+			const state = makeState([conv({ id: 'c1' }), conv({ id: 'c2' })]);
+			subscribeConversationList(makeMockPb({}), state.getList, state.setList);
+
+			await registeredHandler()({ action: 'delete', record: { id: 'c1' } } as unknown as RecordSubscription<Conversation>);
+
+			expect(state.list.map((c) => c.id)).toEqual(['c2']);
+		});
+
+		it('is a no-op when the deleted id is not in the list', async () => {
+			const state = makeState([conv({ id: 'c1' })]);
+			subscribeConversationList(makeMockPb({}), state.getList, state.setList);
+
+			await registeredHandler()({ action: 'delete', record: { id: 'unknown' } } as unknown as RecordSubscription<Conversation>);
+
+			expect(state.list.map((c) => c.id)).toEqual(['c1']);
+		});
+	});
+});

--- a/src/routes/conversations/conversationListRealtime.ts
+++ b/src/routes/conversations/conversationListRealtime.ts
@@ -1,6 +1,29 @@
 import type PocketBase from 'pocketbase';
 import { subscribeRealtime } from '$lib/client-pb';
+import { conversationFieldsWithSafePartners } from '$lib/conversationPartnerFields';
 import type { Conversation } from '$lib/types/models';
+
+/**
+ * Mirrors the server-side list sort (`sort: '-lastMessageAt,-updated'` in
+ * `+layout.server.ts`'s `load()`): primary key `lastMessageAt` descending, ties broken by
+ * `updated` descending. Both are ISO datetime strings, so plain string comparison sorts them
+ * correctly; a conversation with no messages yet has `lastMessageAt === ''`, which sorts
+ * after every real timestamp (empty string is lexicographically smallest).
+ */
+function compareConversations(a: Conversation, b: Conversation): number {
+	const aLast = a.lastMessageAt ?? '';
+	const bLast = b.lastMessageAt ?? '';
+	if (aLast !== bLast) return aLast > bLast ? -1 : 1;
+	if (a.updated !== b.updated) return a.updated > b.updated ? -1 : 1;
+	return 0;
+}
+
+/** Inserts `item` into `list` at the position `compareConversations` says it belongs. */
+function insertSorted(list: Conversation[], item: Conversation): Conversation[] {
+	const idx = list.findIndex((c) => compareConversations(item, c) < 0);
+	if (idx === -1) return [...list, item];
+	return [...list.slice(0, idx), item, ...list.slice(idx)];
+}
 
 /**
  * Keep a local conversation list in sync with realtime `conversations` events.
@@ -35,29 +58,40 @@ export function subscribeConversationList(
 		handler: async (e) => {
 			if (e.action === 'update') {
 				setList(
-					getList().map((c) =>
-						c.id === e.record.id
-							? {
-									...c,
-									readByOwner: e.record.readByOwner,
-									readByRequester: e.record.readByRequester,
-								}
-							: c
-					)
+					getList()
+						.map((c) =>
+							c.id === e.record.id
+								? {
+										...c,
+										readByOwner: e.record.readByOwner,
+										readByRequester: e.record.readByRequester,
+										lastMessageAt: e.record.lastMessageAt,
+										lendingStatus: e.record.lendingStatus,
+									}
+								: c
+						)
+						.sort(compareConversations)
 				);
 			} else if (e.action === 'create') {
 				if (getList().some((c) => c.id === e.record.id)) return;
 				try {
 					// Subscription events don't include expanded relations — fetch the full record.
+					// This runs client-side, so the `requester`/`itemOwner` expands must be restricted
+					// to the safe partner fields (never the full `User`, in particular never `email`) —
+					// same protection as the server-side `load()`s in this route.
 					const full = await pb
 						.collection('conversations')
 						.getOne<Conversation>(e.record.id, {
 							expand: 'requester,itemOwner,requestedItem',
+							fields: conversationFieldsWithSafePartners('*,expand.requestedItem.*'),
 						});
-					setList([...getList(), full]);
+					setList(insertSorted(getList(), full));
 				} catch {
 					// Record may have been deleted before we could fetch it — ignore silently.
 				}
+			} else if (e.action === 'delete') {
+				// Otherwise a deleted conversation stays in the sidebar and 404s on click.
+				setList(getList().filter((c) => c.id !== e.record.id));
 			}
 		},
 		onReconnect,


### PR DESCRIPTION
## What & why

The `/conversations` route had grown to ~2,300 lines across 20 files, mixing DOM plumbing, realtime wiring, domain logic, and markup — server logic was split inconsistently across `+page.server.ts` and two co-located `*.server.ts` modules, and the `Conversation` type declared a fully-expanded shape that didn't match what most code paths actually received. This PR is a structural refactor plus several behavior fixes surfaced during review.

### Security / correctness fixes
- **Message-recipient spoofing**: `?/sendMessage` trusted a hidden `chatPartnerId` form field as the recipient — any conversation participant could spoof messages/push notifications to an arbitrary user. Recipient is now derived server-side from the loaded conversation + authenticated participant.
- **Racy message append**: replaced a read-modify-write on `conversation.messages` with PocketBase's atomic `'messages+'` update modifier.
- **Counterfactual overwrite**: `?/submitCounterfactual` allowed any participant to overwrite the research answer at any time; now requires the original requester and a `pending` current state.
- **PII leak via unrestricted `expand`**: full `User` records (including `email`) were being expanded at three call sites (two server `load()`s, one client-side realtime fetch) and shipped to the browser. All three now route through a new shared `$lib/conversationPartnerFields.ts` allowlist (`conversationFieldsWithSafePartners()`), backed by a `ConversationPartner` type that's compile-time checked against the field list.
- **Realtime sync gaps**: the conversation list ignored `lastMessageAt`/`lendingStatus` on realtime `update` events (never re-sorting), appended `create` events at the wrong position, and silently ignored `delete` events (stale, 404-ing sidebar entries). Detail-view realtime only fetched the *last* message id from a coalesced SSE event, dropping earlier messages in the same batch.

### Structure
- Lending transitions are now table-driven: `$lib/lending.ts` gained `LENDING_TRANSITIONS`/`canTransition`/`canAbortUi` (the latter intentionally kept separate from the server-side rule per #373's UI/server divergence), and `lending.server.ts` is built around one `executeLendingTransition()` + a `TRANSITION_EFFECTS` table instead of six near-duplicate transition functions.
- New focused modules extracted from `+layout.svelte`/`+page.svelte`: `chatViewport.ts`, `chatScroll.ts`, `presenceHeartbeat.ts`, `conversationFilters.ts`, `conversationDetail.ts` (an honest wire-format mapper replacing the previously-dishonest `Conversation` type).
- `$lib/test-utils/pocketbase.ts` extracts a shared `mockFilter`/`makeMockPb` that was independently duplicated across ~15 test files (this PR migrates the 3 conversations test files to it).
- Various hygiene: inline German moved to `texts.ts`, `ui-avatars.com` third-party avatar fallback replaced with a local `InitialsAvatar`, dead `PB_URL` prop threading removed, `$lib/server/items.ts`'s inverted import of route code fixed.

## Test notes

**Automated (all green):**
- `npm run lint` / `npm run check` (0 errors) / `npx vitest run` (**812/812**, 77 files) / `npm run build` — all pass.
- Full Playwright e2e suite: **47/48 passing**. The one failure (`search-focus.spec.ts`) is a pre-existing flaky test in the unrelated `public` project, not touched by this diff. `e2e/tests/lending.spec.ts` (full request→accept→handover→return→complete lifecycle) and `e2e/tests/messages.spec.ts` both pass outright.
- This branch went through 4 parallel reviewer roles (security, code quality, a11y, conventions) and 3 fix-loop rounds; closed with zero findings above Nice-to-have.

**⚠️ Manual QA still needed** — interactive browser smoke testing (Playwright/Chrome DevTools MCP) could not run in the environment this was built in. Please verify before/while reviewing:
- [ ] Two-tab realtime check: send a message from each side, confirm it appears for the other without a manual refresh; confirm the conversation list re-sorts/updates live.
- [ ] Abort a request from both roles (requester-while-pending, either-party-while-accepted) — confirm the UI's abort button visibility (`canAbortUi`) never offers an abort the server (`LENDING_TRANSITIONS`) would then reject.
- [ ] Delete a conversation in a terminal state via the new shared `ConfirmActionModal` — confirm the confirm/cancel flow and redirect behave correctly.
- [ ] Visual check: `InitialsAvatar` renders sensibly where `ui-avatars.com` used to be; the segmented filter tabs' new `aria-pressed` state is visually/behaviorally correct; `presenceHeartbeat`'s periodic PATCH still fires in the network tab.

## Out of scope (flagged, not implemented)
- Backend hardening (`allerleih-backend/pb_hooks/lending.pb.js`) to validate *all* lending transitions server-side, not just the abort one — currently the frontend's checks are the only gate for non-abort transitions.
- `acceptRequest`'s non-atomic conversation/item writes (needs a backend transaction) — commented in place.
- Migrating the ~12 other test files still hand-rolling `mockFilter`/`makeMockPb`.
- Replacing `ui-avatars.com` in `/social` (same privacy pattern, different route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
