### PR TITLE
refactor(quality): fix behavior bugs hidden in duplicated server flows (review phase 1)

### DIFF
--- a/src/lib/components/FooterComponent.svelte
+++ b/src/lib/components/FooterComponent.svelte
@@ -112,7 +112,7 @@
 							href="/api/redirect?to=https%3A%2F%2Fnorden.social%2F%40AllerLeih&source=footer"
 							target="_blank"
 							rel="noopener noreferrer"
-							aria-label="{texts.footer.mastodon}}"
+							aria-label={texts.footer.mastodon}
 						>
 							<span class="flex items-center gap-2">
 							<svg

--- a/src/lib/server/contacts.ts
+++ b/src/lib/server/contacts.ts
@@ -1,4 +1,5 @@
 import type PocketBase from 'pocketbase';
+import { upsertSingletonRow } from '$lib/server/singletonRow';
 
 export type UserContact = {
 	telegramUsername: string;
@@ -31,20 +32,26 @@ export async function getOwnContact(pb: PocketBase, userId: string): Promise<Par
 	}
 }
 
+/** The current user's contact row id, or null if none exists yet. */
+async function findOwnContactRow(pb: PocketBase, userId: string): Promise<{ id: string } | null> {
+	try {
+		return await pb
+			.collection('user_contacts')
+			.getFirstListItem(pb.filter('user = {:u}', { u: userId }), { fields: 'id' });
+	} catch {
+		return null;
+	}
+}
+
 /** Upserts the current user's own contact row. */
 export async function upsertOwnContact(pb: PocketBase, userId: string, contact: UserContact): Promise<void> {
-	let existingId: string | null = null;
-	try {
-		const rec = await pb
-			.collection('user_contacts')
-			.getFirstListItem(pb.filter('user = {:u}', { u: userId }));
-		existingId = rec.id;
-	} catch {
-		// no existing row
-	}
-	const data = { user: userId, ...contact };
-	if (existingId) await pb.collection('user_contacts').update(existingId, data);
-	else await pb.collection('user_contacts').create(data);
+	await upsertSingletonRow({
+		pb,
+		collection: 'user_contacts',
+		find: () => findOwnContactRow(pb, userId),
+		createData: { user: userId, ...contact },
+		patch: contact,
+	});
 }
 
 /** Resolves another user's visible contact handles via the privileged `/api/contact` hook. */

--- a/src/lib/server/conversations.test.ts
+++ b/src/lib/server/conversations.test.ts
@@ -1,6 +1,138 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { makeMockPb } from '$lib/test-utils/pocketbase';
-import { deleteConversation } from './conversations';
+import { texts } from '$lib/texts';
+import { requirementRegistry } from '$lib/server/lendingRequirements';
+import {
+	deleteConversation,
+	findResumableConversation,
+	startConversationAndNotify,
+} from './conversations';
+
+vi.mock('$lib/server/notifications', () => ({
+	createNotification: vi.fn().mockResolvedValue(undefined),
+	sendPushToUser: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { createNotification, sendPushToUser } from '$lib/server/notifications';
+
+describe('findResumableConversation', () => {
+	it('returns the newest matching open conversation id', async () => {
+		const getFullList = vi.fn().mockResolvedValue([{ id: 'conv-new' }, { id: 'conv-old' }]);
+		const pb = makeMockPb({ conversations: { getFullList } });
+
+		expect(await findResumableConversation(pb, 'u1', 'item1')).toBe('conv-new');
+		expect(getFullList).toHaveBeenCalledWith(
+			expect.objectContaining({ sort: '-created', fields: 'id' })
+		);
+		// Filter excludes rejected/completed/empty — it must scope to the open states.
+		expect(getFullList.mock.calls[0][0].filter).toContain('lendingStatus');
+	});
+
+	it('returns null when no conversation matches', async () => {
+		const pb = makeMockPb({ conversations: { getFullList: vi.fn().mockResolvedValue([]) } });
+		expect(await findResumableConversation(pb, 'u1', 'item1')).toBeNull();
+	});
+
+	it('returns null when the lookup fails (resume is best-effort)', async () => {
+		const pb = makeMockPb({
+			conversations: { getFullList: vi.fn().mockRejectedValue(new Error('boom')) },
+		});
+		expect(await findResumableConversation(pb, 'u1', 'item1')).toBeNull();
+	});
+});
+
+describe('startConversationAndNotify', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	const requester = { id: 'u1', username: 'Anna' };
+	const item = { id: 'item1', ownerId: 'owner1', name: 'Bohrmaschine' };
+
+	it('creates a pending conversation and notifies the owner (in-app + push)', async () => {
+		const create = vi.fn().mockResolvedValue({ id: 'conv1' });
+		const pb = makeMockPb({ conversations: { create } });
+
+		const result = await startConversationAndNotify(pb, requester, item);
+
+		expect(result).toEqual({ status: 'ok', conversationId: 'conv1' });
+		expect(create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				requester: 'u1',
+				itemOwner: 'owner1',
+				requestedItem: 'item1',
+				lendingStatus: 'pending',
+				readByRequester: true,
+				readByOwner: false,
+			})
+		);
+		expect(createNotification).toHaveBeenCalledWith(
+			pb,
+			'owner1',
+			'u1',
+			'new_request',
+			'conv1',
+			expect.stringContaining('Anna')
+		);
+		expect(sendPushToUser).toHaveBeenCalledWith(
+			pb,
+			'owner1',
+			texts.notifications.pushTitle,
+			expect.stringContaining('Anna'),
+			'/conversations/conv1'
+		);
+	});
+
+	it('reads the real item name from base items when the public row was masked', async () => {
+		const create = vi.fn().mockResolvedValue({ id: 'conv1' });
+		const getOne = vi.fn().mockResolvedValue({ name: 'Geheime Säge' });
+		const pb = makeMockPb({ conversations: { create }, items: { getOne } });
+
+		await startConversationAndNotify(pb, requester, { ...item, name: null });
+
+		expect(getOne).toHaveBeenCalledWith('item1', { fields: 'name' });
+		expect(createNotification).toHaveBeenCalledWith(
+			pb,
+			'owner1',
+			'u1',
+			'new_request',
+			'conv1',
+			expect.stringContaining('Geheime Säge')
+		);
+	});
+
+	it("maps the backend hook's lending_requirement_unmet rejection to a friendly 403", async () => {
+		const def = requirementRegistry[0];
+		const create = vi
+			.fn()
+			.mockRejectedValue(
+				Object.assign(new Error(`lending_requirement_unmet: ${def.key}`), { status: 400 })
+			);
+		const pb = makeMockPb({ conversations: { create } });
+
+		const result = await startConversationAndNotify(pb, requester, item);
+
+		expect(result.status).toBe('error');
+		if (result.status !== 'error') throw new Error('unreachable');
+		expect(result.httpStatus).toBe(403);
+		expect(result.message).toContain(texts.lendingRequirements.blockedIntro);
+		expect(result.message).toContain(def.label);
+		expect(createNotification).not.toHaveBeenCalled();
+	});
+
+	it('maps any other create failure to an error result instead of throwing (terms-route regression)', async () => {
+		const create = vi.fn().mockRejectedValue(Object.assign(new Error('nope'), { status: 400 }));
+		const pb = makeMockPb({ conversations: { create } });
+
+		const result = await startConversationAndNotify(pb, requester, item);
+
+		expect(result).toEqual({
+			status: 'error',
+			httpStatus: 400,
+			message: texts.errors.failedToCreateConversation,
+		});
+		expect(createNotification).not.toHaveBeenCalled();
+		expect(sendPushToUser).not.toHaveBeenCalled();
+	});
+});
 
 describe('deleteConversation', () => {
 	it('deletes the conversation and every notification referencing it', async () => {

--- a/src/lib/server/conversations.ts
+++ b/src/lib/server/conversations.ts
@@ -113,8 +113,14 @@ export async function startConversationAndNotify(
 	);
 	const conversationUrl = `/conversations/${conversation.id}`;
 
-	await createNotification(pb, item.ownerId, requester.id, 'new_request', conversation.id, notificationBody);
-	await sendPushToUser(pb, item.ownerId, texts.notifications.pushTitle, notificationBody, conversationUrl);
+	try {
+		await createNotification(pb, item.ownerId, requester.id, 'new_request', conversation.id, notificationBody);
+		await sendPushToUser(pb, item.ownerId, texts.notifications.pushTitle, notificationBody, conversationUrl);
+	} catch (err) {
+		// Best-effort: the conversation already exists, so a failure to notify the
+		// owner must not fail the action (mirrors addTrustAndNotify in trust.ts).
+		console.error('startConversationAndNotify: owner notification failed', err);
+	}
 
 	return { status: 'ok', conversationId: conversation.id };
 }

--- a/src/lib/server/conversations.ts
+++ b/src/lib/server/conversations.ts
@@ -1,4 +1,9 @@
 import type PocketBase from 'pocketbase';
+import type { ClientResponseError } from 'pocketbase';
+import { texts } from '$lib/texts';
+import { OPEN_LENDING_STATES, lendingStatusFilter } from '$lib/lending';
+import { createNotification, sendPushToUser } from '$lib/server/notifications';
+import { requirementRegistry } from '$lib/server/lendingRequirements';
 
 /**
  * Re-exported for the two server `load()`s in this route (`+layout.server.ts`,
@@ -8,6 +13,111 @@ import type PocketBase from 'pocketbase';
  * SvelteKit forbids importing `$lib/server/*` from client code.
  */
 export { conversationFieldsWithSafePartners } from '$lib/conversationPartnerFields';
+
+/**
+ * Finds an in-progress conversation for this requester+item so callers can resume it
+ * instead of creating a duplicate. Rejected/completed/empty lendingStatus are excluded
+ * (a borrower may legitimately re-request; conversations created before the lending
+ * feature have no status value). Returns the newest matching conversation id, or null.
+ */
+export async function findResumableConversation(
+	pb: PocketBase,
+	requesterId: string,
+	itemId: string
+): Promise<string | null> {
+	try {
+		const conversations = await pb.collection('conversations').getFullList({
+			filter: pb.filter(
+				'requester = {:requesterId} && requestedItem = {:itemId} && ' +
+					lendingStatusFilter(OPEN_LENDING_STATES),
+				{ requesterId, itemId }
+			),
+			sort: '-created',
+			fields: 'id',
+		});
+		return conversations[0]?.id ?? null;
+	} catch {
+		return null;
+	}
+}
+
+export type StartConversationResult =
+	| { status: 'ok'; conversationId: string }
+	| { status: 'error'; httpStatus: number; message: string };
+
+/**
+ * Creates a new pending conversation for requester+item and notifies the owner
+ * (in-app notification + push). Callers run their own gates first (auth, off-platform
+ * contact, terms acceptance) and check {@link findResumableConversation} where resuming
+ * should win over creating.
+ *
+ * The backend hook on conversation create is the authoritative gate for the lender's
+ * borrower requirements (#423/#389) — we don't re-check here (single source of truth).
+ * If the hook rejects with 'lending_requirement_unmet: <keys>', the keys are mapped to
+ * friendly labels in the returned error message.
+ */
+export async function startConversationAndNotify(
+	pb: PocketBase,
+	requester: { id: string; username?: string; name?: string },
+	item: { id: string; ownerId: string; name?: string | null }
+): Promise<StartConversationResult> {
+	let conversation;
+	try {
+		conversation = await pb.collection('conversations').create({
+			requester: requester.id,
+			itemOwner: item.ownerId,
+			requestedItem: item.id,
+			lendingStatus: 'pending',
+			readByRequester: true,
+			readByOwner: false,
+			lastMessageAt: new Date().toISOString(),
+		});
+	} catch (err) {
+		const e = err as Partial<ClientResponseError> & { response?: { message?: string } };
+		const raw = [e.response?.message, e.message].filter(Boolean).join(' ');
+		const m = raw.match(/lending_requirement_unmet:\s*([a-z_,]+)/i);
+		if (m) {
+			const labels = m[1]
+				.split(',')
+				.map((k) => requirementRegistry.find((d) => d.key === k.trim())?.label)
+				.filter(Boolean);
+			return {
+				status: 'error',
+				httpStatus: 403,
+				message: labels.length
+					? `${texts.lendingRequirements.blockedIntro} ${labels.join(', ')}`
+					: texts.lendingRequirements.blockedIntro,
+			};
+		}
+		return {
+			status: 'error',
+			httpStatus: e.status ?? 500,
+			message: e.data?.message ?? texts.errors.failedToCreateConversation,
+		};
+	}
+
+	const requesterName = requester.username ?? requester.name ?? texts.pages.itemDetail.unknownRequester;
+	// items_public masks trustees-only item names; the requester is authorized (the
+	// conversation was just created), so read the real name from base items if masked.
+	let itemName = item.name;
+	if (!itemName) {
+		try {
+			itemName = (await pb.collection('items').getOne(item.id, { fields: 'name' })).name;
+		} catch {
+			// fall back to the generic label below
+		}
+	}
+	const notificationBody = texts.notifications.newRequest(
+		requesterName,
+		itemName ?? texts.pages.itemDetail.unknownItem
+	);
+	const conversationUrl = `/conversations/${conversation.id}`;
+
+	await createNotification(pb, item.ownerId, requester.id, 'new_request', conversation.id, notificationBody);
+	await sendPushToUser(pb, item.ownerId, texts.notifications.pushTitle, notificationBody, conversationUrl);
+
+	return { status: 'ok', conversationId: conversation.id };
+}
 
 /**
  * Deletes a conversation and every notification referencing it.

--- a/src/lib/server/geolocation.ts
+++ b/src/lib/server/geolocation.ts
@@ -1,6 +1,18 @@
 import type PocketBase from 'pocketbase';
+import { upsertSingletonRow } from '$lib/server/singletonRow';
 
 export type GeoPoint = { lon: number; lat: number };
+
+/** The user's geolocation row id, or null if none exists yet. */
+async function findGeolocationRow(pb: PocketBase, userId: string): Promise<{ id: string } | null> {
+	try {
+		return await pb
+			.collection('user_geolocations')
+			.getFirstListItem(pb.filter('user = {:u}', { u: userId }), { fields: 'id' });
+	} catch {
+		return null;
+	}
+}
 
 /** Reads the current user's own stored geolocation, or null if none/null-island. */
 export async function getUserGeolocation(pb: PocketBase, userId: string): Promise<GeoPoint | null> {
@@ -21,20 +33,16 @@ export async function upsertUserGeolocation(
 	userId: string,
 	geo: GeoPoint | null
 ): Promise<void> {
-	let existingId: string | null = null;
-	try {
-		const rec = await pb
-			.collection('user_geolocations')
-			.getFirstListItem(pb.filter('user = {:u}', { u: userId }));
-		existingId = rec.id;
-	} catch {
-		// no existing entry
+	if (!geo) {
+		const existing = await findGeolocationRow(pb, userId);
+		if (existing) await pb.collection('user_geolocations').delete(existing.id);
+		return;
 	}
-
-	if (geo) {
-		if (existingId) await pb.collection('user_geolocations').update(existingId, { geolocation: geo });
-		else await pb.collection('user_geolocations').create({ user: userId, geolocation: geo });
-	} else if (existingId) {
-		await pb.collection('user_geolocations').delete(existingId);
-	}
+	await upsertSingletonRow({
+		pb,
+		collection: 'user_geolocations',
+		find: () => findGeolocationRow(pb, userId),
+		createData: { user: userId, geolocation: geo },
+		patch: { geolocation: geo },
+	});
 }

--- a/src/lib/server/lendingRequirements.ts
+++ b/src/lib/server/lendingRequirements.ts
@@ -1,6 +1,7 @@
 import type PocketBase from 'pocketbase';
 import type { LendingRequirements, UnmetRequirement, RequirementSetting } from '$lib/types/models';
 import { texts } from '$lib/texts';
+import { upsertSingletonRow } from '$lib/server/singletonRow';
 
 /**
  * Lender-defined borrower requirements (issues #423 / #389).
@@ -110,29 +111,21 @@ export async function getOwnerRequirements(
 
 /**
  * Upserts the owner's own requirements row. Creates it on first save, updates it
- * thereafter (one row per owner, enforced by a unique index on `owner`). If two
- * saves race and both try to create, the loser's unique-index error is caught and
- * retried as an update, so the user never sees a spurious failure.
+ * thereafter (one row per owner, enforced by a unique index on `owner`); a lost
+ * create race is retried as an update by the shared helper.
  */
 export async function upsertOwnerRequirements(
 	pb: PocketBase,
 	ownerId: string,
 	data: Partial<Record<RequirementField, boolean>>
 ): Promise<void> {
-	const existing = await getOwnerRequirements(pb, ownerId);
-	if (existing) {
-		await pb.collection('lending_requirements').update(existing.id, data);
-		return;
-	}
-	try {
-		await pb.collection('lending_requirements').create({ owner: ownerId, ...data });
-	} catch (err) {
-		// Lost a create race (unique index on owner) — fall back to updating the row
-		// that the other writer just created.
-		const row = await getOwnerRequirements(pb, ownerId);
-		if (row) await pb.collection('lending_requirements').update(row.id, data);
-		else throw err;
-	}
+	await upsertSingletonRow({
+		pb,
+		collection: 'lending_requirements',
+		find: () => getOwnerRequirements(pb, ownerId),
+		createData: { owner: ownerId, ...data },
+		patch: data,
+	});
 }
 
 /**

--- a/src/lib/server/singletonRow.test.ts
+++ b/src/lib/server/singletonRow.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { makeMockPb } from '$lib/test-utils/pocketbase';
+import { upsertSingletonRow } from './singletonRow';
+
+const COLLECTION = 'user_things';
+
+function run(opts: {
+	find: ReturnType<typeof vi.fn>;
+	create?: ReturnType<typeof vi.fn>;
+	update?: ReturnType<typeof vi.fn>;
+}) {
+	const create = opts.create ?? vi.fn().mockResolvedValue({ id: 'new' });
+	const update = opts.update ?? vi.fn().mockResolvedValue({ id: 'row1' });
+	const pb = makeMockPb({ [COLLECTION]: { create, update } });
+	const promise = upsertSingletonRow({
+		pb,
+		collection: COLLECTION,
+		find: opts.find,
+		createData: { user: 'u1', value: 42 },
+		patch: { value: 42 },
+	});
+	return { promise, create, update };
+}
+
+describe('upsertSingletonRow', () => {
+	it('updates the existing row with the patch (not the full create data)', async () => {
+		const find = vi.fn().mockResolvedValue({ id: 'row1' });
+		const { promise, create, update } = run({ find });
+		await promise;
+		expect(update).toHaveBeenCalledWith('row1', { value: 42 });
+		expect(create).not.toHaveBeenCalled();
+	});
+
+	it('creates the row when none exists', async () => {
+		const find = vi.fn().mockResolvedValue(null);
+		const { promise, create, update } = run({ find });
+		await promise;
+		expect(create).toHaveBeenCalledWith({ user: 'u1', value: 42 });
+		expect(update).not.toHaveBeenCalled();
+	});
+
+	it('retries a lost create race as an update (unique-index loser)', async () => {
+		// find: null up front, then the row the concurrent writer just created.
+		const find = vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({ id: 'row1' });
+		const create = vi.fn().mockRejectedValue(new Error('unique constraint'));
+		const { promise, update } = run({ find, create });
+		await expect(promise).resolves.toBeUndefined();
+		expect(update).toHaveBeenCalledWith('row1', { value: 42 });
+	});
+
+	it('rethrows a genuine create error when no row exists afterwards', async () => {
+		const find = vi.fn().mockResolvedValue(null);
+		const create = vi.fn().mockRejectedValue(new Error('boom'));
+		const { promise, update } = run({ find, create });
+		await expect(promise).rejects.toThrow('boom');
+		expect(update).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/server/singletonRow.test.ts
+++ b/src/lib/server/singletonRow.test.ts
@@ -15,7 +15,7 @@ function run(opts: {
 	const promise = upsertSingletonRow({
 		pb,
 		collection: COLLECTION,
-		find: opts.find,
+		find: opts.find as () => Promise<{ id: string } | null>,
 		createData: { user: 'u1', value: 42 },
 		patch: { value: 42 },
 	});

--- a/src/lib/server/singletonRow.ts
+++ b/src/lib/server/singletonRow.ts
@@ -1,0 +1,40 @@
+import type PocketBase from 'pocketbase';
+
+/**
+ * Upsert for "one row per user/owner" sidecar collections (user_preferences,
+ * user_contacts, user_geolocations, lending_requirements): update the existing row
+ * if one matches, otherwise create it.
+ *
+ * Includes the create-race guard all callers need: if two saves race and both try
+ * to create, the loser's unique-index error is caught and retried as an update, so
+ * the user never sees a spurious failure from a double-submit. (Historically two of
+ * the four call sites carried this fix and two didn't — keeping the idiom here means
+ * the next sidecar collection gets it for free.)
+ */
+export async function upsertSingletonRow(opts: {
+	pb: PocketBase;
+	collection: string;
+	/** Resolves the user's existing row (or null). Called again after a lost create race. */
+	find: () => Promise<{ id: string } | null>;
+	/** Full record data for first-time creation (must include the owning relation). */
+	createData: Record<string, unknown>;
+	/** Fields to patch when the row already exists. */
+	patch: Record<string, unknown>;
+}): Promise<void> {
+	const { pb, collection, find, createData, patch } = opts;
+
+	const existing = await find();
+	if (existing) {
+		await pb.collection(collection).update(existing.id, patch);
+		return;
+	}
+	try {
+		await pb.collection(collection).create(createData);
+	} catch (err) {
+		// Lost a create race (unique index on the owning relation) — fall back to
+		// updating the row the other writer just created.
+		const row = await find();
+		if (row) await pb.collection(collection).update(row.id, patch);
+		else throw err;
+	}
+}

--- a/src/lib/server/trust.test.ts
+++ b/src/lib/server/trust.test.ts
@@ -1,6 +1,21 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type PocketBase from 'pocketbase';
-import { isTrusting, addTrust, removeTrust, getTrustees, getTrusters } from './trust';
+import { texts } from '$lib/texts';
+import {
+	isTrusting,
+	addTrust,
+	addTrustAndNotify,
+	removeTrust,
+	getTrustees,
+	getTrusters,
+} from './trust';
+
+vi.mock('$lib/server/notifications', () => ({
+	createNotification: vi.fn().mockResolvedValue(undefined),
+	sendPushToUser: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { createNotification, sendPushToUser } from '$lib/server/notifications';
 
 function mockFilter(raw: string, params?: Record<string, unknown>): string {
 	if (!params) return raw;
@@ -78,6 +93,101 @@ describe('addTrust', () => {
 		const create = vi.fn().mockRejectedValue(new Error('boom'));
 		const pb = makePb({ getFirstListItem, create });
 		await expect(addTrust(pb, 'a', 'b')).rejects.toThrow('boom');
+	});
+});
+
+describe('addTrustAndNotify', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	const truster = { id: 'a', username: 'Anna' };
+
+	/** pb with a users_public target lookup plus trusts-collection mocks. */
+	function makeTrustNotifyPb(
+		target: { deleted?: boolean } | null,
+		trusts: Record<string, ReturnType<typeof vi.fn>>
+	): PocketBase {
+		const usersPublic = {
+			getOne:
+				target === null
+					? vi.fn().mockRejectedValue(new Error('not found'))
+					: vi.fn().mockResolvedValue({ id: 'b', ...target }),
+		};
+		return {
+			collection: vi.fn((name: string) =>
+				name === 'trusts' ? trusts : name === 'users_public' ? usersPublic : {}
+			),
+			filter: vi.fn(mockFilter),
+		} as unknown as PocketBase;
+	}
+
+	it('creates the edge and notifies the trustee (in-app + push)', async () => {
+		const create = vi.fn().mockResolvedValue({ id: 't1' });
+		const pb = makeTrustNotifyPb({}, {
+			getFirstListItem: vi.fn().mockRejectedValue(new Error('none')),
+			create,
+		});
+
+		const result = await addTrustAndNotify(pb, truster, 'b');
+
+		expect(result).toEqual({ ok: true });
+		expect(create).toHaveBeenCalledWith({ truster: 'a', trustee: 'b' });
+		expect(createNotification).toHaveBeenCalledWith(
+			pb,
+			'b',
+			'a',
+			'trust_added',
+			'a',
+			expect.stringContaining('Anna')
+		);
+		expect(sendPushToUser).toHaveBeenCalledWith(
+			pb,
+			'b',
+			texts.notifications.pushTitle,
+			expect.stringContaining('Anna'),
+			'/users/a'
+		);
+	});
+
+	it('refuses a deleted (anonymized) target with a 400 and does not touch the edge', async () => {
+		const create = vi.fn();
+		const pb = makeTrustNotifyPb({ deleted: true }, { create });
+
+		const result = await addTrustAndNotify(pb, truster, 'b');
+
+		expect(result).toEqual({ ok: false, status: 400, message: texts.account.cannotTrustDeleted });
+		expect(create).not.toHaveBeenCalled();
+		expect(createNotification).not.toHaveBeenCalled();
+	});
+
+	it('returns a 404 when the target cannot be resolved', async () => {
+		const pb = makeTrustNotifyPb(null, {});
+		const result = await addTrustAndNotify(pb, truster, 'b');
+		expect(result).toEqual({ ok: false, status: 404, message: texts.errors.somethingWentWrong });
+	});
+
+	it('surfaces an edge-creation failure as a 500 instead of pretending success (regression)', async () => {
+		// Pre-check and post-failure re-check both say "no edge" → addTrust rethrows.
+		const pb = makeTrustNotifyPb({}, {
+			getFirstListItem: vi.fn().mockRejectedValue(new Error('none')),
+			create: vi.fn().mockRejectedValue(new Error('boom')),
+		});
+
+		const result = await addTrustAndNotify(pb, truster, 'b');
+
+		expect(result).toEqual({ ok: false, status: 500, message: texts.errors.somethingWentWrong });
+		expect(createNotification).not.toHaveBeenCalled();
+	});
+
+	it('treats a notification failure as non-fatal — the edge exists, so the flow succeeded', async () => {
+		vi.mocked(createNotification).mockRejectedValueOnce(new Error('push down'));
+		const pb = makeTrustNotifyPb({}, {
+			getFirstListItem: vi.fn().mockRejectedValue(new Error('none')),
+			create: vi.fn().mockResolvedValue({ id: 't1' }),
+		});
+
+		const result = await addTrustAndNotify(pb, truster, 'b');
+
+		expect(result).toEqual({ ok: true });
 	});
 });
 

--- a/src/lib/server/trust.ts
+++ b/src/lib/server/trust.ts
@@ -1,5 +1,7 @@
 import type PocketBase from 'pocketbase';
 import type { Trust, UserId } from '$lib/types/models';
+import { texts } from '$lib/texts';
+import { createNotification, sendPushToUser } from '$lib/server/notifications';
 
 // Central access point for the `trusts` join collection (replacing the old
 // users.trusts[] array). A row {truster, trustee} means "truster trusts trustee":
@@ -35,6 +37,51 @@ export async function addTrust(pb: PocketBase, trusterId: UserId, trusteeId: Use
 		// edge exists now, the intent is satisfied — treat it as a no-op; otherwise rethrow.
 		if (!(await isTrusting(pb, trusterId, trusteeId))) throw err;
 	}
+}
+
+export type AddTrustResult = { ok: true } | { ok: false; status: number; message: string };
+
+/**
+ * The full "trust someone" flow shared by /social, /users/[id] and onboarding:
+ * refuses deleted (anonymized) targets, creates the trust edge, then notifies the
+ * new trustee (in-app + push).
+ *
+ * An edge-creation failure is returned as an error so callers surface a fail()
+ * instead of pretending success; a notification failure is non-fatal (the edge
+ * exists — which is what the caller's UI reflects) and only logged.
+ */
+export async function addTrustAndNotify(
+	pb: PocketBase,
+	truster: { id: UserId; username?: string; name?: string },
+	trusteeId: UserId
+): Promise<AddTrustResult> {
+	// Cannot trust a deleted (anonymized) account.
+	try {
+		const target = await pb.collection('users_public').getOne(trusteeId, { fields: 'id,deleted' });
+		if (target.deleted) {
+			return { ok: false, status: 400, message: texts.account.cannotTrustDeleted };
+		}
+	} catch {
+		return { ok: false, status: 404, message: texts.errors.somethingWentWrong };
+	}
+
+	try {
+		await addTrust(pb, truster.id, trusteeId);
+	} catch (err) {
+		console.error('Failed to add trust', err instanceof Error ? err.message : err);
+		return { ok: false, status: 500, message: texts.errors.somethingWentWrong };
+	}
+
+	const adderName = truster.username ?? truster.name ?? texts.pages.itemDetail.unknownRequester;
+	const notificationBody = texts.notifications.trustAdded(adderName);
+	try {
+		await createNotification(pb, trusteeId, truster.id, 'trust_added', truster.id, notificationBody);
+		await sendPushToUser(pb, trusteeId, texts.notifications.pushTitle, notificationBody, `/users/${truster.id}`);
+	} catch (err) {
+		console.error('Trust notification failed', err instanceof Error ? err.message : err);
+	}
+
+	return { ok: true };
 }
 
 /** Remove the trust edge {truster, trustee} if it exists. */

--- a/src/lib/server/userPreferences.ts
+++ b/src/lib/server/userPreferences.ts
@@ -1,5 +1,6 @@
 import type PocketBase from 'pocketbase';
 import type { UserPreferences, UserId } from '$lib/types/models';
+import { upsertSingletonRow } from '$lib/server/singletonRow';
 
 // Central access point for the `user_preferences` sidecar collection (issue #426).
 // One owner-only row per user (unique index on `user`) holds settings pulled off the
@@ -41,26 +42,18 @@ export async function getUserPreferences(
 /**
  * Upserts the user's own preferences row, patching only the given fields. Creates it
  * on first save, updates it thereafter (one row per user, enforced by a unique index
- * on `user`). If two saves race and both try to create, the loser's unique-index error
- * is caught and retried as an update, so the user never sees a spurious failure.
+ * on `user`); a lost create race is retried as an update by the shared helper.
  */
 export async function upsertUserPreferences(
 	pb: PocketBase,
 	userId: UserId,
 	patch: UserPreferencesPatch
 ): Promise<void> {
-	const existing = await getUserPreferences(pb, userId);
-	if (existing) {
-		await pb.collection('user_preferences').update(existing.id, patch);
-		return;
-	}
-	try {
-		await pb.collection('user_preferences').create({ user: userId, ...patch });
-	} catch (err) {
-		// Lost a create race (unique index on user) — fall back to updating the row
-		// that the other writer just created.
-		const row = await getUserPreferences(pb, userId);
-		if (row) await pb.collection('user_preferences').update(row.id, patch);
-		else throw err;
-	}
+	await upsertSingletonRow({
+		pb,
+		collection: 'user_preferences',
+		find: () => getUserPreferences(pb, userId),
+		createData: { user: userId, ...patch },
+		patch,
+	});
 }

--- a/src/lib/utils/pushSubscription.ts
+++ b/src/lib/utils/pushSubscription.ts
@@ -35,13 +35,43 @@ export function nextPushRegistration(
 	return { register: false, lastRegisteredUserId };
 }
 
+/** `serviceWorker.ready` can hang indefinitely if the SW never activates, so every
+ *  caller races it against a 10 s failsafe to avoid a silent hang. */
+function swReady(): Promise<ServiceWorkerRegistration> {
+	const timeout = new Promise<never>((_, reject) =>
+		setTimeout(() => reject(new Error('serviceWorker.ready timeout')), 10000)
+	);
+	return Promise.race([navigator.serviceWorker.ready, timeout]);
+}
+
+/** DELETE against /api/push-subscribe, bounded to 4 s. Callers (e.g. logout, the
+ *  notification-settings toggles) await the teardown, and a slow or hanging
+ *  connection must not stall them. The local unsubscribe has already detached this
+ *  device before this runs, so aborting doesn't weaken the guarantee — the server
+ *  record is also cleaned up lazily on the next push (410 Gone) if the request
+ *  never lands. */
+async function boundedUnsubscribeRequest(body: Record<string, unknown>): Promise<void> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), 4000);
+	try {
+		await fetch('/api/push-subscribe', {
+			method: 'DELETE',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(body),
+			signal: controller.signal,
+		});
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
 /** Sets up the Web Push subscription and registers it with the server.
  *  Called either silently (permission already granted) or after the user
  *  taps "Aktivieren" (satisfying the user-gesture requirement). */
 export async function setupPushSubscription(): Promise<void> {
 	if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
 	try {
-		const registration = await navigator.serviceWorker.ready;
+		const registration = await swReady();
 		const existing = await registration.pushManager.getSubscription();
 		const subscription =
 			existing ??
@@ -71,16 +101,12 @@ export async function setupPushSubscription(): Promise<void> {
 export async function teardownAllPushSubscriptions(): Promise<void> {
 	if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
 	try {
-		const registration = await navigator.serviceWorker.ready;
+		const registration = await swReady();
 		const subscription = await registration.pushManager.getSubscription();
 		if (subscription) {
 			await subscription.unsubscribe();
 		}
-		await fetch('/api/push-subscribe', {
-			method: 'DELETE',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ all: true }),
-		});
+		await boundedUnsubscribeRequest({ all: true });
 	} catch (err) {
 		console.error('Push unsubscription (all devices) failed:', err);
 	}
@@ -91,29 +117,12 @@ export async function teardownAllPushSubscriptions(): Promise<void> {
 export async function teardownPushSubscription(): Promise<void> {
 	if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
 	try {
-		const registration = await navigator.serviceWorker.ready;
+		const registration = await swReady();
 		const subscription = await registration.pushManager.getSubscription();
 		if (!subscription) return;
 
 		await subscription.unsubscribe();
-
-		// Bound the server round-trip: callers (e.g. logout) await this, and a slow
-		// or hanging connection must not stall them. The local unsubscribe above has
-		// already detached this device, so aborting the DELETE doesn't weaken the
-		// guarantee — the server record is also cleaned up lazily on the next push
-		// (410 Gone) if this request never lands.
-		const controller = new AbortController();
-		const timeout = setTimeout(() => controller.abort(), 4000);
-		try {
-			await fetch('/api/push-subscribe', {
-				method: 'DELETE',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ endpoint: subscription.endpoint }),
-				signal: controller.signal,
-			});
-		} finally {
-			clearTimeout(timeout);
-		}
+		await boundedUnsubscribeRequest({ endpoint: subscription.endpoint });
 	} catch (err) {
 		console.error('Push unsubscription failed:', err);
 	}

--- a/src/routes/items/[id]/+page.server.ts
+++ b/src/routes/items/[id]/+page.server.ts
@@ -3,10 +3,14 @@ import { error, fail, redirect } from '@sveltejs/kit';
 import type { ItemPublic } from '$lib/types/models';
 import type { ClientResponseError } from 'pocketbase';
 import { texts } from '$lib/texts';
-import { createNotification, sendPushToUser } from '$lib/server/notifications.js';
 import { getActiveTerms, hasAcceptedActiveTerms } from '$lib/server/lendingTerms';
-import { evaluateUnmetRequirements, requirementRegistry } from '$lib/server/lendingRequirements';
+import { evaluateUnmetRequirements } from '$lib/server/lendingRequirements';
 import { isTrusting } from '$lib/server/trust';
+import { toggleItemStatus } from '$lib/server/items';
+import {
+	findResumableConversation,
+	startConversationAndNotify,
+} from '$lib/server/conversations';
 import { getUserPreferences } from '$lib/server/userPreferences';
 import { OPEN_LENDING_STATES, lendingStatusFilter } from '$lib/lending';
 
@@ -196,23 +200,13 @@ export const actions = {
 			redirect(303, `/auth/login?redirectTo=/items/${params.id}`);
 		}
 
-		let item: ItemPublic;
 		try {
-			item = await locals.pb.collection('items_public').getOne(params.id);
-		} catch {
-			return fail(404, { fail: true, message: texts.errors.itemNotFound });
-		}
-
-		if (item.userId !== locals.user.id) {
-			return fail(403, { fail: true, message: texts.errors.noPermission });
-		}
-
-		const newStatus = item.status === 'available' ? 'unavailable' : 'available';
-		try {
-			await locals.pb.collection('items').update(params.id, { status: newStatus });
+			const result = await toggleItemStatus(locals.pb, params.id, locals.user.id);
+			if (result.status === 'not_found') return fail(404, { fail: true, message: texts.errors.itemNotFound });
+			if (result.status === 'not_owner') return fail(403, { fail: true, message: texts.errors.noPermission });
 		} catch (err) {
 			const e = err as Partial<ClientResponseError>;
-			console.error(e?.message ?? err);
+			return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });
 		}
 	},
 
@@ -235,23 +229,9 @@ export const actions = {
 		// Resume an already in-progress conversation for this requester+item BEFORE any
 		// other gate, so a borrower with a live loan is taken back into it — even if the
 		// owner has since enabled email contact (#438) or published lending terms.
-		// (rejected/completed/empty are excluded so a fresh re-request still creates one.)
-		let existingConversations: { id: string }[] = [];
-		try {
-			existingConversations = await locals.pb.collection('conversations').getFullList({
-				filter: locals.pb.filter(
-					'requester = {:requesterId} && requestedItem = {:itemId} && ' +
-						lendingStatusFilter(OPEN_LENDING_STATES),
-					{ requesterId, itemId: params.id }
-				),
-				sort: '-created',
-				fields: 'id',
-			});
-		} catch {
-			existingConversations = [];
-		}
-		if (existingConversations.length > 0) {
-			redirect(303, `/conversations/${existingConversations[0].id}`);
+		const resumableId = await findResumableConversation(locals.pb, requesterId, params.id);
+		if (resumableId) {
+			redirect(303, `/conversations/${resumableId}`);
 		}
 
 		// Off-platform-contact owners (#438) handle NEW requests outside the app — the CTA
@@ -283,70 +263,17 @@ export const actions = {
 			redirect(303, `/items/${params.id}/terms`);
 		}
 
-		// The lender's borrower requirements (#423/#389) are enforced authoritatively
-		// by the backend hook on conversation create — we don't re-check here (single
-		// source of truth). If the hook rejects, the catch below maps its
-		// 'lending_requirement_unmet' error into a friendly message.
-
 		// No existing conversation (we'd have redirected above) → create a new one.
 		await request.formData(); // consume the POST body; item resolved from params, ownerId ignored
-		let targetConversationId = '';
-		{
-			let conversation;
-			try {
-				conversation = await locals.pb.collection('conversations').create({
-					requester: requesterId,
-					itemOwner: itemOwnerId,
-					requestedItem: params.id,
-					lendingStatus: 'pending',
-					readByRequester: true,
-					readByOwner: false,
-					lastMessageAt: new Date().toISOString(),
-				});
-			} catch (err) {
-				const e = err as Partial<ClientResponseError> & { response?: { message?: string } };
-				// The backend hook rejects unmet lending requirements with a message
-				// "lending_requirement_unmet: <keys>" — map the keys to friendly labels.
-				const raw = [e.response?.message, e.message].filter(Boolean).join(' ');
-				const m = raw.match(/lending_requirement_unmet:\s*([a-z_,]+)/i);
-				if (m) {
-					const labels = m[1]
-						.split(',')
-						.map((k) => requirementRegistry.find((d) => d.key === k.trim())?.label)
-						.filter(Boolean);
-					return fail(403, {
-						fail: true,
-						message: labels.length
-							? `${texts.lendingRequirements.blockedIntro} ${labels.join(', ')}`
-							: texts.lendingRequirements.blockedIntro,
-					});
-				}
-				return fail(e.status ?? 500, {
-					fail: true,
-					message: e.data?.message ?? texts.errors.failedToCreateConversation,
-				});
-			}
-
-			targetConversationId = conversation.id;
-
-			const requesterName = locals.user.username ?? locals.user.name ?? texts.pages.itemDetail.unknownRequester;
-			// items_public masks trustees-only item names; the requester is authorized
-			// (the conversation was just created), so read the real name from base items.
-			let itemName = itemRecord.name;
-			if (!itemName) {
-				try {
-					itemName = (await locals.pb.collection('items').getOne(params.id, { fields: 'name' })).name;
-				} catch {
-					// fall back to the generic label below
-				}
-			}
-			const notificationBody = texts.notifications.newRequest(requesterName, itemName ?? texts.pages.itemDetail.unknownItem);
-			const conversationUrl = `/conversations/${targetConversationId}`;
-
-			await createNotification(locals.pb, itemOwnerId, locals.user.id, 'new_request', targetConversationId, notificationBody);
-			await sendPushToUser(locals.pb, itemOwnerId, texts.notifications.pushTitle, notificationBody, conversationUrl);
+		const result = await startConversationAndNotify(locals.pb, locals.user, {
+			id: params.id,
+			ownerId: itemOwnerId,
+			name: itemRecord.name,
+		});
+		if (result.status === 'error') {
+			return fail(result.httpStatus, { fail: true, message: result.message });
 		}
 
-		redirect(303, `/conversations/${targetConversationId}`);
+		redirect(303, `/conversations/${result.conversationId}`);
 	},
 };

--- a/src/routes/items/[id]/terms/+page.server.ts
+++ b/src/routes/items/[id]/terms/+page.server.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { error, fail, redirect } from '@sveltejs/kit';
 import type { Item, LendingTerms } from '$lib/types/models';
 import type { ClientResponseError } from 'pocketbase';
@@ -8,8 +7,10 @@ import {
 	getAcceptance,
 	cleanTermsHtml,
 } from '$lib/server/lendingTerms';
-import { createNotification, sendPushToUser } from '$lib/server/notifications';
-import { OPEN_LENDING_STATES, lendingStatusFilter } from '$lib/lending';
+import {
+	findResumableConversation,
+	startConversationAndNotify,
+} from '$lib/server/conversations';
 
 export async function load({ params, locals, url }) {
 	// Auth is required to accept terms. Bounce through login if needed.
@@ -126,78 +127,23 @@ export const actions = {
 			}
 		}
 
-		// After acceptance, kick off the actual lending request flow.
-		await startConversationForItem(locals, itemRecord);
+		// After acceptance, transparently kick off the actual lending request flow —
+		// resume an open conversation if one exists, otherwise create + notify.
+		// Shared with /items/[id]'s ?/startConversation via $lib/server/conversations.
+		const resumableId = await findResumableConversation(locals.pb, locals.user.id, itemRecord.id);
+		if (resumableId) {
+			redirect(303, `/conversations/${resumableId}`);
+		}
 
-		// If we got here, startConversation didn't redirect — fall back.
-		redirect(303, `/items/${params.id}`);
+		const result = await startConversationAndNotify(locals.pb, locals.user, {
+			id: itemRecord.id,
+			ownerId: itemRecord.owner,
+			name: itemRecord.name,
+		});
+		if (result.status === 'error') {
+			return fail(result.httpStatus, { error: true, message: result.message });
+		}
+
+		redirect(303, `/conversations/${result.conversationId}`);
 	},
 };
-
-/**
- * Mirrors the startConversation logic in /items/[id]/+page.server.ts so that
- * accepting the terms transparently kicks off the request. Centralising this
- * is out of scope for the first cut; if the request flow grows further we
- * should extract a shared helper.
- */
-async function startConversationForItem(
-	locals: any,
-	itemRecord: Item
-): Promise<never> {
-	const requesterId = locals.user.id;
-	const itemOwnerId = itemRecord.owner;
-
-	let targetConversationId = '';
-	let existingConversations;
-	try {
-		existingConversations = await locals.pb.collection('conversations').getFullList({
-			filter: locals.pb.filter(
-				'requester = {:requesterId} && requestedItem = {:itemId} && ' +
-					lendingStatusFilter(OPEN_LENDING_STATES),
-				{ requesterId, itemId: itemRecord.id }
-			),
-			sort: '-created',
-		});
-	} catch {
-		existingConversations = [];
-	}
-
-	if (existingConversations.length > 0) {
-		targetConversationId = existingConversations[0].id;
-	} else {
-		const conversation = await locals.pb.collection('conversations').create({
-			requester: requesterId,
-			itemOwner: itemOwnerId,
-			requestedItem: itemRecord.id,
-			lendingStatus: 'pending',
-			readByRequester: true,
-			readByOwner: false,
-			lastMessageAt: new Date().toISOString(),
-		});
-		targetConversationId = conversation.id;
-
-		const requesterName =
-			locals.user.username ?? locals.user.name ?? texts.pages.itemDetail.unknownRequester;
-		const itemName = itemRecord.name ?? texts.pages.itemDetail.unknownItem;
-		const notificationBody = texts.notifications.newRequest(requesterName, itemName);
-		const conversationUrl = `/conversations/${targetConversationId}`;
-
-		await createNotification(
-			locals.pb,
-			itemOwnerId,
-			locals.user.id,
-			'new_request',
-			targetConversationId,
-			notificationBody
-		);
-		await sendPushToUser(
-			locals.pb,
-			itemOwnerId,
-			texts.notifications.pushTitle,
-			notificationBody,
-			conversationUrl
-		);
-	}
-
-	redirect(303, `/conversations/${targetConversationId}`);
-}

--- a/src/routes/onboarding/+page.server.ts
+++ b/src/routes/onboarding/+page.server.ts
@@ -3,8 +3,7 @@ import { fail } from '@sveltejs/kit';
 import { texts } from '$lib/texts';
 import { PUBLIC_PB_URL } from '../../hooks.server';
 import type { User } from '$lib/types/models';
-import { createNotification, sendPushToUser } from '$lib/server/notifications';
-import { addTrust, removeTrust, getTrustees } from '$lib/server/trust';
+import { addTrustAndNotify, removeTrust, getTrustees } from '$lib/server/trust';
 import { generateInviteSlug } from '$lib/inviteSlug';
 import { getUserGeolocation, upsertUserGeolocation } from '$lib/server/geolocation';
 import { getOwnContact, upsertOwnContact } from '$lib/server/contacts';
@@ -76,16 +75,8 @@ export const actions = {
 		const formData = await request.formData();
 		const newTrusteeId = formData.get('trusteeId') as string;
 
-		try {
-			await addTrust(locals.pb, locals.user.id, newTrusteeId);
-		} catch (error: Error | any) {
-			console.error(error?.message ?? error);
-		}
-
-		const adderName = locals.user.username ?? 'Jemand';
-		const notificationBody = texts.notifications.trustAdded(adderName);
-		await createNotification(locals.pb, newTrusteeId as string, locals.user.id, 'trust_added', locals.user.id, notificationBody);
-		await sendPushToUser(locals.pb, newTrusteeId as string, texts.notifications.pushTitle, notificationBody, `/users/${locals.user.id}`);
+		const result = await addTrustAndNotify(locals.pb, locals.user, newTrusteeId);
+		if (!result.ok) return fail(result.status, { error: true, message: result.message });
 	},
 
 	saveProfile: async ({ locals, request }) => {
@@ -128,6 +119,7 @@ export const actions = {
 			await removeTrust(locals.pb, locals.user.id, toRemoveTrusteeId);
 		} catch (error: Error | any) {
 			console.error(error?.message ?? error);
+			return fail(500, { error: true, message: texts.errors.somethingWentWrong });
 		}
 	},
 

--- a/src/routes/onboarding/StepPushNotifications.svelte
+++ b/src/routes/onboarding/StepPushNotifications.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onDestroy } from 'svelte';
 	import { texts } from '$lib/texts';
-	import { PUBLIC_VAPID_PUBLIC_KEY } from '$env/static/public';
+	import { setupPushSubscription } from '$lib/utils/pushSubscription';
 	import Button from '$lib/components/ui/Button.svelte';
 
 	interface Props {
@@ -21,47 +21,6 @@
 		cancelled = true;
 		if (advanceTimer) clearTimeout(advanceTimer);
 	});
-
-	function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
-		const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
-		const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
-		const rawData = atob(base64);
-		const output = new Uint8Array(rawData.length);
-		for (let i = 0; i < rawData.length; i++) {
-			output[i] = rawData.charCodeAt(i);
-		}
-		return output;
-	}
-
-	async function setupPushSubscription() {
-		if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
-		try {
-			// `serviceWorker.ready` can hang indefinitely if the SW never activates,
-			// so we race it against a 10 s failsafe to avoid a silent hang here.
-			const swReadyTimeout = new Promise<never>((_, reject) =>
-				setTimeout(() => reject(new Error('serviceWorker.ready timeout')), 10000)
-			);
-			const registration = await Promise.race([navigator.serviceWorker.ready, swReadyTimeout]);
-			const existing = await registration.pushManager.getSubscription();
-			const subscription =
-				existing ??
-				(await registration.pushManager.subscribe({
-					userVisibleOnly: true,
-					applicationServerKey: urlBase64ToUint8Array(PUBLIC_VAPID_PUBLIC_KEY),
-				}));
-			const { endpoint, keys } = subscription.toJSON() as {
-				endpoint: string;
-				keys: { p256dh: string; auth: string };
-			};
-			await fetch('/api/push-subscribe', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ endpoint, keys }),
-			});
-		} catch (err) {
-			console.error('Push subscription failed:', err);
-		}
-	}
 
 	async function request() {
 		if (!('Notification' in window)) {

--- a/src/routes/social/+page.server.ts
+++ b/src/routes/social/+page.server.ts
@@ -2,8 +2,7 @@
 import { fail } from '@sveltejs/kit';
 import type { User } from '$lib/types/models.js';
 import { texts } from '$lib/texts';
-import { createNotification, sendPushToUser } from '$lib/server/notifications.js';
-import { addTrust, removeTrust, getTrustees, getTrusters } from '$lib/server/trust.js';
+import { addTrustAndNotify, removeTrust, getTrustees, getTrusters } from '$lib/server/trust.js';
 import { generateInviteSlug } from '$lib/inviteSlug.js';
 
 export async function load({ locals, url }) {
@@ -79,33 +78,15 @@ export const actions = {
 		const newTrusteeId = formData.get('trusteeId') as string;
 		const newTrusteeUsername = formData.get('trusteeUsername') as string | null;
 
-		// Cannot trust a deleted (anonymized) account.
-		try {
-			const target = await locals.pb.collection('users_public').getOne(newTrusteeId);
-			if (target.deleted) return fail(400, { fail: true, message: texts.account.cannotTrustDeleted });
-		} catch {
-			return fail(404, { fail: true, message: texts.errors.somethingWentWrong });
-		}
-
-		try {
-			await addTrust(locals.pb, locals.user.id, newTrusteeId);
-		} catch (error: Error | any) {
-			console.error(error ? error.message : error);
-			return fail(500, { fail: true, message: texts.errors.somethingWentWrong });
-		}
-
-		const adderName = locals.user.username ?? locals.user.name ?? 'Jemand';
-		const notificationBody = texts.notifications.trustAdded(adderName);
-
-		await createNotification(locals.pb, newTrusteeId, locals.user.id, 'trust_added', locals.user.id, notificationBody);
-		await sendPushToUser(locals.pb, newTrusteeId, texts.notifications.pushTitle, notificationBody, `/users/${locals.user.id}`);
+		const result = await addTrustAndNotify(locals.pb, locals.user, newTrusteeId);
+		if (!result.ok) return fail(result.status, { fail: true, message: result.message });
 
 		return {
 			success: true,
 			message: texts.success.trusteeAdded(newTrusteeUsername ?? newTrusteeId),
 		};
 	},
-	removeTrustee: async ({ request, locals }): Promise<void> => {
+	removeTrustee: async ({ request, locals }) => {
 		const formData = await request.formData();
 		const toRemoveTrusteeId = formData.get('trusteeId') as string;
 
@@ -113,6 +94,7 @@ export const actions = {
 			await removeTrust(locals.pb, locals.user.id, toRemoveTrusteeId);
 		} catch (error: Error | any) {
 			console.error(error ? error.message : error);
+			return fail(500, { fail: true, message: texts.errors.somethingWentWrong });
 		}
 	},
 };

--- a/src/routes/user/items/+page.server.ts
+++ b/src/routes/user/items/+page.server.ts
@@ -4,7 +4,7 @@ import { PUBLIC_PB_URL } from '../../../hooks.server';
 import { texts } from '$lib/texts';
 import type { Item } from '$lib/types/models';
 import { getAttachableGroups } from '$lib/server/groups';
-import { deleteItem, deleteMultipleItems, setItemStatus } from '$lib/server/items';
+import { deleteItem, deleteMultipleItems, setItemStatus, toggleItemStatus } from '$lib/server/items';
 import {
 	extractItemForm,
 	sanitizeCategories,
@@ -211,18 +211,10 @@ export const actions = {
 		const itemId = formData.get('itemId')?.toString();
 		if (!itemId) return fail(400, { fail: true, message: texts.errors.missingId });
 
-		let item: Item;
 		try {
-			item = await locals.pb.collection('items').getOne<Item>(itemId);
-		} catch {
-			return fail(404, { fail: true, message: texts.errors.itemNotFound });
-		}
-
-		if (item.owner !== locals.user.id) return fail(403, { fail: true, message: texts.errors.noPermission });
-
-		const newStatus = item.status === 'available' ? 'unavailable' : 'available';
-		try {
-			await setItemStatus(locals.pb, itemId, locals.user.id, newStatus);
+			const result = await toggleItemStatus(locals.pb, itemId, locals.user.id);
+			if (result.status === 'not_found') return fail(404, { fail: true, message: texts.errors.itemNotFound });
+			if (result.status === 'not_owner') return fail(403, { fail: true, message: texts.errors.noPermission });
 		} catch (err) {
 			const e = err as Partial<ClientResponseError>;
 			return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });

--- a/src/routes/users/[id]/+page.server.ts
+++ b/src/routes/users/[id]/+page.server.ts
@@ -3,8 +3,7 @@ import { PUBLIC_PB_URL } from '$env/static/public';
 import type { Item, User } from '$lib/types/models.js';
 import type { ClientResponseError } from 'pocketbase';
 import { texts } from '$lib/texts';
-import { createNotification, sendPushToUser } from '$lib/server/notifications';
-import { addTrust as addTrustEdge, removeTrust as removeTrustEdge, isTrusting } from '$lib/server/trust';
+import { addTrustAndNotify, removeTrust as removeTrustEdge, isTrusting } from '$lib/server/trust';
 
 export async function load({ params, locals }) {
 
@@ -123,40 +122,18 @@ export const actions = {
 		if (!locals.user) return fail(401, { message: texts.errors.noPermission });
 		if (params.id === locals.user.id) return fail(400, { message: texts.errors.noPermission });
 
-		// Cannot trust a deleted (anonymized) account.
-		try {
-			const target = await locals.pb.collection('users_public').getOne(params.id);
-			if (target.deleted) return fail(400, { message: texts.account.cannotTrustDeleted });
-		} catch {
-			return fail(404, { message: texts.errors.noPermission });
-		}
-
-		const profileUserId = params.id;
-		try {
-			await addTrustEdge(locals.pb, locals.user.id, profileUserId);
-		} catch (err) {
-			console.error('Failed to add trust', err);
-		}
-
-		// Notify the newly trusted user — fire and forget.
-		const adderName = locals.user.username ?? locals.user.name ?? texts.pages.itemDetail.unknownRequester;
-		const notificationBody = texts.notifications.trustAdded(adderName);
-		try {
-			await createNotification(locals.pb, profileUserId, locals.user.id, 'trust_added', locals.user.id, notificationBody);
-			await sendPushToUser(locals.pb, profileUserId, texts.notifications.pushTitle, notificationBody, `/users/${locals.user.id}`);
-		} catch (err) {
-			console.error('Trust notification failed', err);
-		}
+		const result = await addTrustAndNotify(locals.pb, locals.user, params.id);
+		if (!result.ok) return fail(result.status, { message: result.message });
 	},
 
 	removeTrust: async ({ params, locals }) => {
 		if (!locals.user) return fail(401, { message: texts.errors.noPermission });
 
-		const profileUserId = params.id;
 		try {
-			await removeTrustEdge(locals.pb, locals.user.id, profileUserId);
+			await removeTrustEdge(locals.pb, locals.user.id, params.id);
 		} catch (err) {
 			console.error('Failed to remove trust', err);
+			return fail(500, { message: texts.errors.somethingWentWrong });
 		}
 	},
 };


### PR DESCRIPTION
## What & why

Phase 1 of the full-codebase quality review (code-quality-reviewer sweep, plan approved by @matteoramin): the structural findings that have **real behavioral consequences today**. Each fix removes a copy-pasted flow whose copies had drifted apart — in four cases into user-visible bugs.

### Fixes

1. **Item status toggle** — `/items/[id]` and `/user/items` each hand-rolled `?/toggleStatus` instead of calling `toggleItemStatus()` (`$lib/server/items.ts`). The item-detail copy reintroduced the exact bug the helper's docstring documents as fixed: a failed DB write was only `console.error`'d, so the UI showed success while nothing changed. The user-items copy did a redundant fetch + ownership re-check. Both now call the helper (same pattern as the conversations route).
2. **Conversation-start flow** — the "resume-or-create conversation + notify owner" logic was duplicated between `/items/[id]` and `/items/[id]/terms` (the code itself flagged this in a comment). The terms copy had **no try/catch**, so a backend rejection (e.g. `lending_requirement_unmet`) surfaced as a raw 500 instead of a friendly form error. Extracted to `findResumableConversation()` / `startConversationAndNotify()` in `$lib/server/conversations.ts`; also removes the terms route's `locals: any` and file-level eslint-disable.
3. **Trust-add flow** — tripled across `/social`, `/users/[id]` and onboarding with divergent error handling: two copies silently swallowed edge-creation failures and reported success. Extracted to `addTrustAndNotify()` in `$lib/server/trust.ts`; all `removeTrust*` actions now `fail(500)` on error instead of only logging. Onboarding now also refuses deleted (anonymized) targets, matching the other two call sites.
4. **Push subscriptions** — onboarding's `StepPushNotifications.svelte` reimplemented `setupPushSubscription`/`urlBase64ToUint8Array` from `$lib/utils/pushSubscription.ts`; the local copy had gained a 10s `serviceWorker.ready` failsafe the shared one lacked. The failsafe now lives in the shared module (all callers benefit), the local copy is deleted, and `teardownAllPushSubscriptions` gains the same bounded 4s DELETE the single-device teardown already had — the "alle Geräte" toggle can no longer hang indefinitely.
5. **Sidecar-row upserts** — four hand-rolled "one row per user: update-or-create" implementations; only two carried the unique-index create-race retry. New shared `upsertSingletonRow()` gives all four (and future sidecar collections) the race guard — closes the live concurrent-double-submit gap in `user_geolocations` and `user_contacts`.
6. **Footer** — malformed mustache rendered a literal `}` at the end of the Mastodon link's `aria-label`.

### Behavior changes (intentional)

Failures that were previously swallowed (trust add/remove, item-status write, terms-route conversation create) now surface as proper form errors instead of fake success.

## Test notes

- Preflight: `npm run lint` ✓ · `npm run check` (0 errors) ✓ · `npx vitest run` 829/829 ✓ · `npm run build` ✓
- New regression tests: `singletonRow.test.ts` (create-race paths), `conversations.test.ts` (error mapping incl. `lending_requirement_unmet`, masked-item name resolution), `trust.test.ts` (`addTrustAndNotify` failure surfacing, deleted-target refusal).
- Manual verification suggested: request an item whose owner has lending requirements enabled via the terms-acceptance flow (previously raw 500 on rejection, now a form error).

Phases 2–4 of the review land as follow-up PRs stacked on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)