### PR TITLE
refactor(quality): dedupe copy-pasted boilerplate across routes (review phase 2)

### DIFF
--- a/src/lib/server/flash.ts
+++ b/src/lib/server/flash.ts
@@ -1,0 +1,24 @@
+import type { Cookies } from '@sveltejs/kit';
+
+/**
+ * Sets the post-redirect "flash" cookie (the universal flash pattern used by the
+ * auth flows: confirm an action, set the flash, redirect to /auth/login).
+ *
+ * The envelope (cookie name, JSON shape, path, 60 s maxAge) is a cross-file
+ * convention — every writer must produce exactly this form, which is why it lives
+ * here instead of being copy-pasted per action.
+ *
+ * NOTE: as of the 2026-07 quality sweep nothing in src/ reads this cookie back —
+ * the messages are written but never displayed. When a reader is added (e.g. on
+ * the login page), match this envelope.
+ */
+export function setFlash(
+	cookies: Cookies,
+	message: string,
+	type: 'success' | 'error' = 'success'
+): void {
+	cookies.set('flash', JSON.stringify({ type, message }), {
+		path: '/',
+		maxAge: 60, // seconds
+	});
+}

--- a/src/lib/server/items.ts
+++ b/src/lib/server/items.ts
@@ -1,4 +1,5 @@
 import type PocketBase from 'pocketbase';
+import type { RecordModel } from 'pocketbase';
 import { OPEN_LENDING_STATES, lendingStatusFilter } from '$lib/lending';
 import { deleteConversation } from './conversations';
 
@@ -7,6 +8,32 @@ export type DeleteItemResult =
 	| { status: 'not_found' }
 	| { status: 'not_owner' }
 	| { status: 'has_open_conversations'; conversationIds: string[] };
+
+export type OwnedItemResult =
+	| { status: 'ok'; item: RecordModel }
+	| { status: 'not_found' }
+	| { status: 'not_owner' };
+
+/**
+ * Loads an item and verifies the caller owns it — the shared guard for every
+ * owner-only item mutation in this module (and for route actions with the same
+ * precondition). A failed fetch is reported as `not_found`, a foreign item as
+ * `not_owner`; only `ok` carries the record.
+ */
+export async function getOwnedItem(
+	pb: PocketBase,
+	itemId: string,
+	ownerUserId: string
+): Promise<OwnedItemResult> {
+	let item;
+	try {
+		item = await pb.collection('items').getOne(itemId);
+	} catch {
+		return { status: 'not_found' };
+	}
+	if (item.owner !== ownerUserId) return { status: 'not_owner' };
+	return { status: 'ok', item };
+}
 
 /**
  * Deletes an item and all related closed conversations (with their notifications).
@@ -19,14 +46,8 @@ export async function deleteItem(
 	itemId: string,
 	ownerUserId: string
 ): Promise<DeleteItemResult> {
-	let item;
-	try {
-		item = await pb.collection('items').getOne(itemId);
-	} catch {
-		return { status: 'not_found' };
-	}
-
-	if (item.owner !== ownerUserId) return { status: 'not_owner' };
+	const owned = await getOwnedItem(pb, itemId, ownerUserId);
+	if (owned.status !== 'ok') return owned;
 
 	const open = await pb.collection('conversations').getFullList({
 		filter: pb.filter(
@@ -90,14 +111,8 @@ export async function setItemStatus(
 	ownerUserId: string,
 	newStatus: 'available' | 'unavailable'
 ): Promise<boolean> {
-	let item;
-	try {
-		item = await pb.collection('items').getOne(itemId);
-	} catch {
-		return false;
-	}
-
-	if (item.owner !== ownerUserId) return false;
+	const owned = await getOwnedItem(pb, itemId, ownerUserId);
+	if (owned.status !== 'ok') return false;
 
 	await pb.collection('items').update(itemId, { status: newStatus });
 	return true;
@@ -122,16 +137,10 @@ export async function toggleItemStatus(
 	itemId: string,
 	ownerUserId: string
 ): Promise<ToggleItemStatusResult> {
-	let item;
-	try {
-		item = await pb.collection('items').getOne(itemId);
-	} catch {
-		return { status: 'not_found' };
-	}
+	const owned = await getOwnedItem(pb, itemId, ownerUserId);
+	if (owned.status !== 'ok') return owned;
 
-	if (item.owner !== ownerUserId) return { status: 'not_owner' };
-
-	const newStatus = item.status === 'available' ? 'unavailable' : 'available';
+	const newStatus = owned.item.status === 'available' ? 'unavailable' : 'available';
 	await pb.collection('items').update(itemId, { status: newStatus });
 	return { status: 'ok', newStatus };
 }

--- a/src/lib/server/items.ts
+++ b/src/lib/server/items.ts
@@ -1,5 +1,5 @@
 import type PocketBase from 'pocketbase';
-import type { RecordModel } from 'pocketbase';
+import type { Item } from '$lib/types/models';
 import { OPEN_LENDING_STATES, lendingStatusFilter } from '$lib/lending';
 import { deleteConversation } from './conversations';
 
@@ -10,7 +10,7 @@ export type DeleteItemResult =
 	| { status: 'has_open_conversations'; conversationIds: string[] };
 
 export type OwnedItemResult =
-	| { status: 'ok'; item: RecordModel }
+	| { status: 'ok'; item: Item }
 	| { status: 'not_found' }
 	| { status: 'not_owner' };
 
@@ -27,7 +27,7 @@ export async function getOwnedItem(
 ): Promise<OwnedItemResult> {
 	let item;
 	try {
-		item = await pb.collection('items').getOne(itemId);
+		item = await pb.collection('items').getOne<Item>(itemId);
 	} catch {
 		return { status: 'not_found' };
 	}

--- a/src/lib/server/pbErrors.ts
+++ b/src/lib/server/pbErrors.ts
@@ -1,0 +1,16 @@
+import { fail } from '@sveltejs/kit';
+import type { ClientResponseError } from 'pocketbase';
+import { texts } from '$lib/texts';
+
+/**
+ * The standard form-action fallback for a thrown PocketBase error: translate it into
+ * `fail(status, { fail: true, message })`, defaulting to the error's own HTTP status
+ * (500 when absent) and the generic German error message.
+ *
+ * Replaces the identical catch-block previously copy-pasted across the /user routes —
+ * a change to this fallback (logging, status-specific handling) now lands in one place.
+ */
+export function failFromPbError(err: unknown, message: string = texts.errors.somethingWentWrong) {
+	const e = err as Partial<ClientResponseError>;
+	return fail(e?.status ?? 500, { fail: true, message });
+}

--- a/src/lib/utils/itemStatus.ts
+++ b/src/lib/utils/itemStatus.ts
@@ -1,0 +1,41 @@
+import { texts } from '$lib/texts';
+
+export type ItemStatus = 'available' | 'unavailable' | 'unknown';
+
+/**
+ * Single source for the item-status badge (label + colors), used by the item page,
+ * the item image overlay and the conversation header. Previously each rendered its
+ * own copy of this mapping and they had drifted (missing `unknown` branch, differing
+ * border shades) — a color/label change now lands in one place.
+ */
+
+/** German label for an item's availability status ('unknown' covers external items). */
+export function itemStatusLabel(status: string | null | undefined): string {
+	if (status === 'available') return texts.itemStatus.available;
+	if (status === 'unavailable') return texts.itemStatus.unavailable;
+	return texts.itemStatus.unknown;
+}
+
+const BADGE_COLORS: Record<ItemStatus, { base: string; hover: string }> = {
+	available: { base: 'bg-green-100 text-green-800 border-green-300', hover: 'hover:bg-green-200' },
+	unavailable: {
+		base: 'bg-accent-100 text-accent-800 border-accent-300',
+		hover: 'hover:bg-accent-200',
+	},
+	unknown: { base: 'bg-gray-100 text-gray-600 border-gray-300', hover: 'hover:bg-gray-200' },
+};
+
+/**
+ * Color classes for a status badge. Pass `interactive: true` for badges that are
+ * buttons (adds the hover colors). Layout classes (padding, font, position) stay
+ * at the call site — they legitimately differ per context.
+ */
+export function itemStatusBadgeClasses(
+	status: string | null | undefined,
+	opts: { interactive?: boolean } = {}
+): string {
+	const key: ItemStatus =
+		status === 'available' || status === 'unavailable' ? status : 'unknown';
+	const { base, hover } = BADGE_COLORS[key];
+	return opts.interactive ? `${base} ${hover}` : base;
+}

--- a/src/routes/auth/confirm-email-change/+page.server.ts
+++ b/src/routes/auth/confirm-email-change/+page.server.ts
@@ -1,6 +1,7 @@
 import { fail, redirect } from '@sveltejs/kit';
 import type { ClientResponseError } from 'pocketbase';
 import { texts } from '$lib/texts';
+import { setFlash } from '$lib/server/flash';
 
 export async function load({ url }) {
 	return { token: url.searchParams.get('token') };
@@ -30,18 +31,7 @@ export const actions = {
 			return fail(400, { fail: true, message: texts.errors.emailChangeFailed });
 		}
 
-		// universal flash pattern:
-		cookies.set(
-			'flash',
-			JSON.stringify({
-				type: 'success',
-				message: texts.success.emailChanged,
-			}),
-			{
-				path: '/',
-				maxAge: 60, // seconds
-			}
-		);
+		setFlash(cookies, texts.success.emailChanged);
 		redirect(303, '/auth/login');
 	},
 };

--- a/src/routes/auth/confirm-verification/+page.server.ts
+++ b/src/routes/auth/confirm-verification/+page.server.ts
@@ -1,6 +1,7 @@
 import { fail, redirect } from '@sveltejs/kit';
 import type { ClientResponseError } from 'pocketbase';
 import { texts } from '$lib/texts';
+import { setFlash } from '$lib/server/flash';
 
 export async function load({ url }) {
 	return { token: url.searchParams.get('token') };
@@ -23,18 +24,7 @@ export const actions = {
 			return fail(400, { fail: true, message: texts.errors.invalidOrExpiredVerificationToken });
 		}
 
-		// universal flash pattern:
-		cookies.set(
-			'flash',
-			JSON.stringify({
-				type: 'success',
-				message: texts.success.emailVerified,
-			}),
-			{
-				path: '/',
-				maxAge: 60, // seconds
-			}
-		);
+		setFlash(cookies, texts.success.emailVerified);
 		redirect(303, '/auth/login');
 	},
 };

--- a/src/routes/auth/reset/+page.server.ts
+++ b/src/routes/auth/reset/+page.server.ts
@@ -1,6 +1,7 @@
 import { fail, redirect } from '@sveltejs/kit';
 import type { ClientResponseError } from 'pocketbase';
 import { texts } from '$lib/texts';
+import { setFlash } from '$lib/server/flash';
 import { normalizeEmail } from '$lib/server/email';
 
 export async function load({ locals }) {
@@ -32,18 +33,7 @@ export const actions = {
 			});
 		}
 
-		// universal flash pattern:
-		cookies.set(
-			'flash',
-			JSON.stringify({
-				type: 'success',
-				message: texts.success.passwordResetSent,
-			}),
-			{
-				path: '/',
-				maxAge: 60, // seconds
-			}
-		);
+		setFlash(cookies, texts.success.passwordResetSent);
 		redirect(303, '/auth/login');
 	},
 };

--- a/src/routes/auth/reset/confirm/+page.server.ts
+++ b/src/routes/auth/reset/confirm/+page.server.ts
@@ -1,6 +1,7 @@
 import { fail, redirect } from '@sveltejs/kit';
 import type { ClientResponseError } from 'pocketbase';
 import { texts } from '$lib/texts';
+import { setFlash } from '$lib/server/flash';
 
 export async function load({ url }) {
 	return { token: url.searchParams.get('token') };
@@ -39,18 +40,7 @@ export const actions = {
 			return fail(400, { fail: true, message: texts.errors.invalidOrExpiredResetToken });
 		}
 
-		// universal flash pattern:
-		cookies.set(
-			'flash',
-			JSON.stringify({
-				type: 'success',
-				message: texts.success.passwordResetConfirmed,
-			}),
-			{
-				path: '/',
-				maxAge: 60, // seconds
-			}
-		);
+		setFlash(cookies, texts.success.passwordResetConfirmed);
 		redirect(303, '/auth/login');
 	},
 };

--- a/src/routes/conversations/[conversationId]/ConversationHeader.svelte
+++ b/src/routes/conversations/[conversationId]/ConversationHeader.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { texts } from '$lib/texts';
+	import { itemStatusBadgeClasses, itemStatusLabel } from '$lib/utils/itemStatus';
 	import { formatTimestamp, displayName, itemOwnFileUrls, buildItemRedirectHref } from '$lib/utils/utils';
 	import { PUBLIC_PB_URL } from '$env/static/public';
 	import { TrashBinSolid, ChevronLeftOutline } from 'flowbite-svelte-icons';
@@ -116,25 +117,17 @@
 							<button
 								type="submit"
 								class="mt-0.5 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold border transition-colors cursor-pointer
-									{item.status === 'available'
-										? 'bg-green-100 text-green-800 border-green-300 hover:bg-green-200'
-										: 'bg-accent-100 text-accent-800 border-accent-300 hover:bg-accent-200'}"
+									{itemStatusBadgeClasses(item.status, { interactive: true })}"
 							>
-								{item.status === 'available'
-									? texts.itemStatus.available
-									: texts.itemStatus.unavailable}
+								{itemStatusLabel(item.status)}
 							</button>
 						</form>
 					{:else}
 						<span
 							class="mt-0.5 self-start inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold border
-								{item.status === 'available'
-									? 'bg-green-100 text-green-800 border-green-300'
-									: 'bg-accent-100 text-accent-800 border-accent-300'}"
+								{itemStatusBadgeClasses(item.status)}"
 						>
-							{item.status === 'available'
-								? texts.itemStatus.available
-								: texts.itemStatus.unavailable}
+							{itemStatusLabel(item.status)}
 						</span>
 					{/if}
 				</div>

--- a/src/routes/items/[id]/ItemCta.svelte
+++ b/src/routes/items/[id]/ItemCta.svelte
@@ -4,6 +4,7 @@
 	import { MessagesOutline } from 'flowbite-svelte-icons';
 	import { enhance } from '$app/forms';
 	import { texts } from '$lib/texts';
+	import { itemStatusBadgeClasses, itemStatusLabel } from '$lib/utils/itemStatus';
 	import { resolve } from '$app/paths';
 	import { buildMailtoHref, buildItemRedirectHref } from '$lib/utils/utils';
 	import type { ItemPublic, UnmetRequirement } from '$lib/types/models';
@@ -78,17 +79,9 @@
 			<button
 				type="submit"
 				class="inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold border transition-colors cursor-pointer
-					{item.status === 'available'
-						? 'bg-green-100 text-green-800 border-green-300 hover:bg-green-200'
-						: item.status === 'unavailable'
-						? 'bg-accent-100 text-accent-800 border-accent-300 hover:bg-accent-200'
-						: 'bg-gray-100 text-gray-600 border-gray-300 hover:bg-gray-200'}"
+					{itemStatusBadgeClasses(item.status, { interactive: true })}"
 			>
-				{item.status === 'available'
-					? texts.itemStatus.available
-					: item.status === 'unavailable'
-					? texts.itemStatus.unavailable
-					: texts.itemStatus.unknown}
+				{itemStatusLabel(item.status)}
 				{#if item.status !== 'unknown'}
 					<span class="ml-2 text-xs opacity-60">
 						{'→ ' + (item.status === 'available' ? texts.itemStatus.markUnavailable : texts.itemStatus.markAvailable)}

--- a/src/routes/items/[id]/ItemImage.svelte
+++ b/src/routes/items/[id]/ItemImage.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { ImageOutline } from 'flowbite-svelte-icons';
 	import { texts } from '$lib/texts';
+	import { itemStatusBadgeClasses, itemStatusLabel } from '$lib/utils/itemStatus';
 
 	interface Props {
 		/** All image URLs for this item, cover first. Empty when there is no uploaded image. */
@@ -17,16 +18,8 @@
 	// Guard against the index pointing past the list (e.g. after a data refresh).
 	const activeUrl = $derived(imageUrls[activeIndex] ?? imageUrls[0] ?? null);
 
-	const statusLabel = $derived(
-		status === 'available' ? texts.itemStatus.available :
-		status === 'unavailable' ? texts.itemStatus.unavailable :
-		texts.itemStatus.unknown
-	);
-	const statusClass = $derived(
-		status === 'available' ? 'bg-green-100 text-green-800 border-green-800' :
-		status === 'unavailable' ? 'bg-accent-100 text-accent-800' :
-		'bg-gray-100 text-gray-500'
-	);
+	const statusLabel = $derived(itemStatusLabel(status));
+	const statusClass = $derived(itemStatusBadgeClasses(status));
 </script>
 
 {#snippet statusBadge()}

--- a/src/routes/onboarding/+page.server.ts
+++ b/src/routes/onboarding/+page.server.ts
@@ -38,6 +38,9 @@ export async function load({ locals, url }) {
 	};
 }
 
+/** Shared fallback for onboarding actions with no more specific error mapping. */
+const genericFailure = () => fail(500, { error: true, message: texts.errors.somethingWentWrong });
+
 export const actions = {
 	saveLocation: async ({ locals, request }) => {
 		const formData = await request.formData();
@@ -67,7 +70,7 @@ export const actions = {
 			if (geo !== undefined) await upsertUserGeolocation(locals.pb, locals.user.id, geo);
 			return { success: true };
 		} catch {
-			return fail(500, { error: true, message: texts.errors.somethingWentWrong });
+			return genericFailure();
 		}
 	},
 
@@ -95,7 +98,7 @@ export const actions = {
 			await locals.pb.collection('users').update(locals.user.id, pbFormData);
 			return { success: true };
 		} catch {
-			return fail(500, { error: true, message: texts.errors.somethingWentWrong });
+			return genericFailure();
 		}
 	},
 
@@ -119,7 +122,7 @@ export const actions = {
 			await removeTrust(locals.pb, locals.user.id, toRemoveTrusteeId);
 		} catch (error: Error | any) {
 			console.error(error?.message ?? error);
-			return fail(500, { error: true, message: texts.errors.somethingWentWrong });
+			return genericFailure();
 		}
 	},
 
@@ -161,7 +164,7 @@ export const actions = {
 			await upsertOwnContact(locals.pb, locals.user.id, contact);
 			return { success: true };
 		} catch {
-			return fail(500, { error: true, message: texts.errors.somethingWentWrong });
+			return genericFailure();
 		}
 	},
 };

--- a/src/routes/user/groups/+page.server.ts
+++ b/src/routes/user/groups/+page.server.ts
@@ -1,6 +1,6 @@
 import { fail } from '@sveltejs/kit';
-import type { ClientResponseError } from 'pocketbase';
 import { texts } from '$lib/texts';
+import { failFromPbError } from '$lib/server/pbErrors';
 import { getUserGroups } from '$lib/server/groups';
 
 export async function load({ locals }) {
@@ -25,8 +25,7 @@ export const actions = {
 				owner: locals.user.id,
 			});
 		} catch (err) {
-			const e = err as Partial<ClientResponseError>;
-			return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });
+			return failFromPbError(err);
 		}
 
 		return { success: true };
@@ -47,8 +46,7 @@ export const actions = {
 				);
 			await locals.pb.collection('group_members').delete(membership.id);
 		} catch (err) {
-			const e = err as Partial<ClientResponseError>;
-			return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });
+			return failFromPbError(err);
 		}
 
 		return { success: true };

--- a/src/routes/user/groups/[id]/members/+page.server.ts
+++ b/src/routes/user/groups/[id]/members/+page.server.ts
@@ -1,6 +1,6 @@
 import { fail } from '@sveltejs/kit';
-import type { ClientResponseError } from 'pocketbase';
 import { texts } from '$lib/texts';
+import { failFromPbError } from '$lib/server/pbErrors';
 import { requireGroupMembership } from '$lib/server/groups';
 import { createNotification, sendPushToUser } from '$lib/server/notifications';
 import { displayName } from '$lib/utils/utils';
@@ -140,7 +140,6 @@ export const actions = {
 			await createNotification(locals.pb, user.id, locals.user!.id, 'group_member_added', params.id, body);
 			await sendPushToUser(locals.pb, user.id, texts.notifications.pushTitle, body, notifUrl);
 		} catch (err) {
-			const e = err as Partial<ClientResponseError>;
 			// A 400 is most likely the unique (group,user) index firing because the
 			// user is already a member. Confirm that's actually the case rather than
 			// swallowing every 400 (which would hide genuine create failures).
@@ -152,7 +151,7 @@ export const actions = {
 					);
 				// Already a member -> idempotent success.
 			} catch {
-				return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });
+				return failFromPbError(err);
 			}
 		}
 		return { success: true };
@@ -199,8 +198,7 @@ export const actions = {
 				await sendPushToUser(locals.pb, m.user, texts.notifications.pushTitle, body, notifUrl);
 			}
 		} catch (err) {
-			const e = err as Partial<ClientResponseError>;
-			return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });
+			return failFromPbError(err);
 		}
 		return { success: true };
 	},

--- a/src/routes/user/groups/[id]/settings/+page.server.ts
+++ b/src/routes/user/groups/[id]/settings/+page.server.ts
@@ -1,6 +1,6 @@
 import { fail, redirect } from '@sveltejs/kit';
-import type { ClientResponseError } from 'pocketbase';
 import { texts } from '$lib/texts';
+import { failFromPbError } from '$lib/server/pbErrors';
 import { requireGroupMembership, isGroupOwner } from '$lib/server/groups';
 import type { GroupInvite } from '$lib/types/models';
 
@@ -61,8 +61,7 @@ export const actions = {
 		try {
 			await locals.pb.collection('groups').update(params.id, { name, description, isPublic });
 		} catch (err) {
-			const e = err as Partial<ClientResponseError>;
-			return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });
+			return failFromPbError(err);
 		}
 		return { success: true };
 	},
@@ -99,8 +98,7 @@ export const actions = {
 				...(expiresAt ? { expiresAt } : {}),
 			});
 		} catch (err) {
-			const e = err as Partial<ClientResponseError>;
-			return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });
+			return failFromPbError(err);
 		}
 		return { success: true };
 	},
@@ -114,8 +112,7 @@ export const actions = {
 		try {
 			await locals.pb.collection('group_invites').delete(inviteId);
 		} catch (err) {
-			const e = err as Partial<ClientResponseError>;
-			return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });
+			return failFromPbError(err);
 		}
 		return { success: true };
 	},
@@ -127,8 +124,7 @@ export const actions = {
 		try {
 			await locals.pb.collection('groups').delete(params.id);
 		} catch (err) {
-			const e = err as Partial<ClientResponseError>;
-			return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });
+			return failFromPbError(err);
 		}
 		redirect(303, '/user/groups');
 	},

--- a/src/routes/user/import/+page.svelte
+++ b/src/routes/user/import/+page.svelte
@@ -16,6 +16,16 @@
 	let selectedFile = $state<File | null>(null);
 	let submitting = $state(false);
 
+	/** Shared use:enhance callback for all three forms (refresh/preview/apply):
+	 *  raise the loader flag on submit, clear it once the result is applied. */
+	function withSubmitting() {
+		submitting = true;
+		return async ({ update }: { update: () => Promise<void> }) => {
+			await update();
+			submitting = false;
+		};
+	}
+
 	$effect(() => {
 		if (form?.preview) step = 'preview';
 		if (form?.done) step = 'done';
@@ -58,7 +68,7 @@
 </div>
 
 <form method="POST" action="?/refresh" 
-	use:enhance={() => { submitting = true; return async ({ update }) => { await update(); submitting = false; }; }} 
+	use:enhance={withSubmitting} 
 	class="px-4 mx-auto max-w-7xl justify-center flex">	
 	<Button type="submit">{texts.institutional.importRefreshButton}</Button>
 </form>
@@ -93,7 +103,7 @@
 				<CustomAlert type="error" message={form?.message ?? fileError} />
 			{/if}
 
-			<form method="POST" action="?/preview" enctype="multipart/form-data" use:enhance={() => { submitting = true; return async ({ update }) => { await update(); submitting = false; }; }}>
+			<form method="POST" action="?/preview" enctype="multipart/form-data" use:enhance={withSubmitting}>
 				<div class="space-y-4">
 					<div>
 						<label for="csv" class="block text-sm font-medium text-tinte-900 mb-1">
@@ -187,7 +197,7 @@
 			{/if}
 
 			<!-- Apply form -->
-			<form method="POST" action="?/apply" use:enhance={() => { submitting = true; return async ({ update }) => { await update(); submitting = false; }; }} class="flex gap-3 justify-end">
+			<form method="POST" action="?/apply" use:enhance={withSubmitting} class="flex gap-3 justify-end">
 				<input type="hidden" name="csvText" value={form.csvText} />
 				<Button variant="secondary" onclick={() => { step = 'upload'; }}>
 					{texts.institutional.importBackButton}

--- a/src/routes/user/items/+page.server.ts
+++ b/src/routes/user/items/+page.server.ts
@@ -1,10 +1,16 @@
 import { fail } from '@sveltejs/kit';
-import type { ClientResponseError } from 'pocketbase';
 import { PUBLIC_PB_URL } from '../../../hooks.server';
 import { texts } from '$lib/texts';
+import { failFromPbError } from '$lib/server/pbErrors';
 import type { Item } from '$lib/types/models';
 import { getAttachableGroups } from '$lib/server/groups';
-import { deleteItem, deleteMultipleItems, setItemStatus, toggleItemStatus } from '$lib/server/items';
+import {
+	deleteItem,
+	deleteMultipleItems,
+	getOwnedItem,
+	setItemStatus,
+	toggleItemStatus,
+} from '$lib/server/items';
 import {
 	extractItemForm,
 	sanitizeCategories,
@@ -188,21 +194,15 @@ export const actions = {
 		const itemId = formData.get('itemId')?.toString();
 		if (!itemId) return fail(400, { fail: true, message: texts.errors.missingId });
 
-		let item: Item;
-		try {
-			item = await locals.pb.collection('items').getOne<Item>(itemId);
-		} catch {
-			return fail(404, { fail: true, message: texts.errors.itemNotFound });
-		}
-
-		if (item.owner !== locals.user.id) return fail(403, { fail: true, message: texts.errors.noPermission });
+		const owned = await getOwnedItem(locals.pb, itemId, locals.user.id);
+		if (owned.status === 'not_found') return fail(404, { fail: true, message: texts.errors.itemNotFound });
+		if (owned.status === 'not_owner') return fail(403, { fail: true, message: texts.errors.noPermission });
 
 		try {
 			// Trustees and groups are independent — only flip the trustees flag here.
-			await locals.pb.collection('items').update(itemId, { trusteesOnly: !item.trusteesOnly });
+			await locals.pb.collection('items').update(itemId, { trusteesOnly: !owned.item.trusteesOnly });
 		} catch (err) {
-			const e = err as Partial<ClientResponseError>;
-			return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });
+			return failFromPbError(err);
 		}
 	},
 
@@ -216,8 +216,7 @@ export const actions = {
 			if (result.status === 'not_found') return fail(404, { fail: true, message: texts.errors.itemNotFound });
 			if (result.status === 'not_owner') return fail(403, { fail: true, message: texts.errors.noPermission });
 		} catch (err) {
-			const e = err as Partial<ClientResponseError>;
-			return fail(e.status ?? 500, { fail: true, message: texts.errors.somethingWentWrong });
+			return failFromPbError(err);
 		}
 	},
 };


### PR DESCRIPTION
## What & why

Phase 2 of the full-codebase quality review: pure extract-and-replace dedup — no intended behavior changes. **Stacked on #586** (base: `refactor/quality-p1-behavior-fixes`); GitHub will retarget to `main` once #586 merges.

- **`failFromPbError()`** (`$lib/server/pbErrors.ts`) — the identical `catch → fail(e.status ?? 500, somethingWentWrong)` block appeared 10× across `user/groups`, `user/groups/[id]/members`, `user/groups/[id]/settings` and `user/items`. Future changes to the fallback (logging, status-specific handling) now land in one place.
- **`setFlash()`** (`$lib/server/flash.ts`) — the flash-cookie envelope (name, JSON shape, path, 60s maxAge) was copy-pasted verbatim in 4 auth actions; the envelope is a cross-file convention, so it now has one home. ⚠️ Finding along the way: **nothing in `src/` ever reads the flash cookie back** — the post-reset/verification success messages are written but never displayed. Documented on the helper; adding a reader (e.g. on the login page) would be a small follow-up feature if wanted.
- **onboarding** — the 4 identical generic-500 catches share one local `genericFailure()`.
- **`getOwnedItem()`** (`$lib/server/items.ts`) — the fetch-item-verify-ownership guard existed 4× (three helpers + the `toggleTrusteesOnly` action) with already-diverged result shapes; now one helper with a typed result.
- **`itemStatusLabel()` / `itemStatusBadgeClasses()`** (`$lib/utils/itemStatus.ts`) — the status-badge label/color mapping was written out in `ConversationHeader.svelte` (2×), `ItemCta.svelte` and `ItemImage.svelte`, with drift (missing `unknown` branch in the header, differing border shades on the image overlay). Only visual delta: `ItemImage`'s badge border normalizes from `green-800` to the `green-300` every other badge uses, and its unavailable/unknown badges gain the explicit border colors the others have.
- **`user/import`** — three identical inline `use:enhance` submitting-flag callbacks become one `withSubmitting()` factory.

## Test notes

- Preflight: `npm run lint` ✓ · `npm run check` (0 errors) ✓ · `npx vitest run` 829/829 ✓ · `npm run build` ✓
- The existing auth-flow tests assert the exact `cookies.set('flash', …)` call and still pass — the helper produces the identical envelope.
- Manual check suggested: item-status badge rendering on item page / image overlay / conversation header (the one deliberate visual normalization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)