### PR TITLE
Increase counterfactual poll to gain impact data

### DIFF
--- a/src/routes/conversations/[conversationId]/lending.server.ts
+++ b/src/routes/conversations/[conversationId]/lending.server.ts
@@ -11,7 +11,7 @@ import {
 import { texts } from '$lib/texts';
 import { notifyAndPush } from '$lib/server/notifications.js';
 
-const PERCENTAGE_OF_USERS_ASKED = 0.33;
+const PERCENTAGE_OF_USERS_ASKED = 0.8;
 
 export function shouldAskCounterfactual(rng: () => number = Math.random): boolean {
 	return rng() < PERCENTAGE_OF_USERS_ASKED;


### PR DESCRIPTION
Background: We set ourselves a goal to have a better indication on counterfactual user behavior (would they buy instead?). The rate of .33 was overall too low given our relatively low usage numbers at the moment. We might want to decrease this once there's more activity on the platform, but right now I think it's defensible.