### PR TITLE
Refactor/quality p4 polish (new PR, got jumbled)

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -108,7 +108,8 @@ export const authorization: Handle = async ({ event, resolve }) => {
 
 export const handle = sequence(authentication, authorization);
 
-// TODO: Check if this is used anywhere implicitly
+// Standard SvelteKit hook: the framework calls this for every unhandled error
+// during request processing — the log line below is our only server-side trace.
 export function handleError({ error, event }): void {
 	console.error('Error occurred during request processing:', {
 		error,

--- a/src/lib/components/FooterComponent.svelte
+++ b/src/lib/components/FooterComponent.svelte
@@ -9,6 +9,13 @@
 		FooterLinkGroup,
 	} from 'flowbite-svelte';
 	import { GithubSolid } from 'flowbite-svelte-icons';
+
+	// One place for the shared footer-link styling — every FooterLink spreads this,
+	// so a hover/underline tweak is a single edit instead of ten.
+	const footerLinkProps = {
+		classes: { link: 'hover:no-underline' },
+		class: 'mb-2 hover:text-accent',
+	};
 </script>
 
 <Footer footerType="socialmedia" class="mt-5">
@@ -39,16 +46,16 @@
 						AllerLeih
 					</h2>
 					<FooterLinkGroup>
-						<FooterLink classes={{ link: "hover:no-underline" }} class="mb-2 hover:text-accent" href={resolve('/misc/guide')}
+						<FooterLink {...footerLinkProps} href={resolve('/misc/guide')}
 							>{texts.nav.guide}</FooterLink
 						>
-						<FooterLink classes={{ link: "hover:no-underline" }} class="mb-2 hover:text-accent" href={resolve('/misc/app')}
+						<FooterLink {...footerLinkProps} href={resolve('/misc/app')}
 							>{texts.nav.app}</FooterLink
 						>
-						<FooterLink classes={{ link: "hover:no-underline" }} class="mb-2 hover:text-accent" href={resolve('/misc/newsletter')}
+						<FooterLink {...footerLinkProps} href={resolve('/misc/newsletter')}
 							>{texts.nav.newsletter}</FooterLink
 						>
-						<FooterLink classes={{ link: "hover:no-underline" }} class="mb-2 hover:text-accent" 
+						<FooterLink {...footerLinkProps} 
 							href="/api/redirect?to=https%3A%2F%2Fallerleih.notion.site%2F36de086dc6ab80f69529e6cf68afe7c4%3Fv%3D36de086dc6ab80869c89000c98bbac63&source=footer"
 							target="_blank"
 							>{texts.nav.contribute}</FooterLink
@@ -62,13 +69,13 @@
 						Über
 					</h2>
 					<FooterLinkGroup>
-						<FooterLink classes={{ link: "hover:no-underline" }} class="mb-2 hover:text-accent" href={resolve('/misc/about')}
+						<FooterLink {...footerLinkProps} href={resolve('/misc/about')}
 							>{texts.nav.about}</FooterLink
 						>
-						<FooterLink classes={{ link: "hover:no-underline" }} class="mb-2 hover:text-accent" href={resolve('/misc/contact')}
+						<FooterLink {...footerLinkProps} href={resolve('/misc/contact')}
 							>{texts.nav.contact}</FooterLink
 						>
-						<FooterLink classes={{ link: "hover:no-underline" }} class="mb-2 hover:text-accent" href="https://github.com/share-open-sharing-infrastructure/share-mvp" target="_blank" rel="noopener noreferrer">
+						<FooterLink {...footerLinkProps} href="https://github.com/share-open-sharing-infrastructure/share-mvp" target="_blank" rel="noopener noreferrer">
 							<span class="flex items-center gap-1">
 								<GithubSolid class="h-4 w-4" />
 								GitHub
@@ -84,8 +91,7 @@
 					</h2>
 					<FooterLinkGroup>
 						<FooterLink
-							classes={{ link: "hover:no-underline" }}
-							class="mb-2 hover:text-accent"
+							{...footerLinkProps}
 							href="/api/redirect?to=https%3A%2F%2Fpixelfed.de%2FAllerLeih&source=footer"
 							target="_blank"
 							rel="noopener noreferrer"
@@ -107,8 +113,7 @@
 							</span>
 						</FooterLink>
 						<FooterLink
-							classes={{ link: "hover:no-underline" }}
-							class="mb-2 hover:text-accent"
+							{...footerLinkProps}
 							href="/api/redirect?to=https%3A%2F%2Fnorden.social%2F%40AllerLeih&source=footer"
 							target="_blank"
 							rel="noopener noreferrer"
@@ -130,8 +135,7 @@
 							</span>
 						</FooterLink>
 						<FooterLink
-							classes={{ link: "hover:no-underline" }}
-							class="mb-2 hover:text-accent"
+							{...footerLinkProps}
 							href="/api/redirect?to=https%3A%2F%2Fwww.instagram.com%2Faller.leih%2F&source=footer"
 							target="_blank"
 							rel="noopener noreferrer"
@@ -161,13 +165,13 @@
 						Rechtliches
 					</h2>
 					<FooterLinkGroup>
-						<FooterLink classes={{ link: "hover:no-underline" }} class="mb-2 hover:text-accent" href={resolve('/misc/imprint')}
+						<FooterLink {...footerLinkProps} href={resolve('/misc/imprint')}
 							>{texts.nav.imprint}</FooterLink
 						>
-						<FooterLink classes={{ link: "hover:no-underline" }} class="mb-2 hover:text-accent" href={resolve('/misc/privacy')}
+						<FooterLink {...footerLinkProps} href={resolve('/misc/privacy')}
 							>{texts.nav.privacy}</FooterLink
 						>
-						<FooterLink classes={{ link: "hover:no-underline" }} class="mb-2 hover:text-accent" href={resolve('/misc/tos')}
+						<FooterLink {...footerLinkProps} href={resolve('/misc/tos')}
 							>{texts.nav.tos}</FooterLink
 						>
 					</FooterLinkGroup>

--- a/src/lib/server/integrations/core/http.ts
+++ b/src/lib/server/integrations/core/http.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared HTTP plumbing for the per-integration clients (leihbackend, WINBIAP).
+ * Both previously defined identical copies of these — shared behavior changes
+ * (e.g. a `retryable` flag on the error) now land once.
+ */
+
+/** Strips trailing slashes from an integration base URL. */
+export function normalizeBaseUrl(url: string): string {
+	return url.replace(/\/+$/, '');
+}
+
+/** Base for per-integration fetch errors: message, offending base URL, optional
+ *  HTTP status and cause. Integrations extend it with only their `name` so
+ *  `instanceof` checks per integration keep working. */
+export class IntegrationFetchError extends Error {
+	readonly baseUrl: string;
+	readonly status?: number;
+
+	constructor(message: string, baseUrl: string, options?: { status?: number; cause?: unknown }) {
+		super(message, { cause: options?.cause });
+		this.name = 'IntegrationFetchError';
+		this.baseUrl = baseUrl;
+		this.status = options?.status;
+	}
+}

--- a/src/lib/server/integrations/core/write.ts
+++ b/src/lib/server/integrations/core/write.ts
@@ -25,11 +25,13 @@ function syncedFieldsOf(item: MappedItem): Pick<MappedItem, (typeof SYNCED_FIELD
 	>;
 }
 
+/** Batch size + inter-batch pause travel as one value so a call site can't swap
+ *  the two same-typed numbers (or mix one phase's size with the other's pause). */
+type BatchPolicy = { batchSize: number; pauseMs: number };
+
 // Stays under PocketBase's default *:create rate limit of 20/5s.
-const UPDATE_BATCH = 50;
-const UPDATE_PAUSE_MS = 300;
-const CREATE_BATCH = 15;
-const CREATE_PAUSE_MS = 5500;
+const UPDATE_POLICY: BatchPolicy = { batchSize: 50, pauseMs: 300 };
+const CREATE_POLICY: BatchPolicy = { batchSize: 15, pauseMs: 5500 };
 
 /**
  * Sends `items` to PocketBase in sequential batches, pausing between each batch.
@@ -37,8 +39,7 @@ const CREATE_PAUSE_MS = 5500;
  *
  * @param pb - PocketBase client.
  * @param items - All items to write in this pass.
- * @param batchSize - Maximum number of operations per PocketBase batch request.
- * @param interBatchPauseMs - Milliseconds to wait between consecutive batches (rate-limit compliance).
+ * @param policy - Batch size + pause between consecutive batches (rate-limit compliance).
  * @param addToBatch - Callback that registers one item onto the batch (e.g. create or update).
  * @param retry - Wrapper applied to each batch send (e.g. superuser re-auth on 401); identity by default.
  * @returns `sent`: items in successful batches. `errors`: one raw error message per failed batch.
@@ -46,13 +47,13 @@ const CREATE_PAUSE_MS = 5500;
 async function sendBatched<T>(
 	pb: PocketBase,
 	items: T[],
-	batchSize: number,
-	interBatchPauseMs: number,
+	policy: BatchPolicy,
 	addToBatch: (batch: ReturnType<typeof pb.createBatch>, item: T) => void,
 	retry: RetryWrapper = noRetry,
 ): Promise<{ sent: number; errors: string[] }> {
 	let sent = 0;
 	const batchErrors: string[] = [];
+	const { batchSize, pauseMs } = policy;
 
 	for (let offset = 0; offset < items.length; offset += batchSize) {
 		const chunk = items.slice(offset, offset + batchSize);
@@ -66,7 +67,7 @@ async function sendBatched<T>(
 		} catch (err) {
 			batchErrors.push(pbErrorMessage(err));
 		}
-		if (offset + batchSize < items.length) await delay(interBatchPauseMs);
+		if (offset + batchSize < items.length) await delay(pauseMs);
 	}
 
 	return { sent, errors: batchErrors };
@@ -84,15 +85,15 @@ async function sendBatched<T>(
 export async function applyDiff(pb: PocketBase, diff: DiffResult, retry: RetryWrapper = noRetry): Promise<WriteResult> {
 	const errors: string[] = [];
 
-	const updateResult = await sendBatched(pb, diff.toUpdate, UPDATE_BATCH, UPDATE_PAUSE_MS,
+	const updateResult = await sendBatched(pb, diff.toUpdate, UPDATE_POLICY,
 		(batch, { id, data }) => batch.collection('items').update(id, syncedFieldsOf(data)), retry);
 	errors.push(...updateResult.errors.map((e) => `update batch: ${e}`));
 
-	const createResult = await sendBatched(pb, diff.toCreate, CREATE_BATCH, CREATE_PAUSE_MS,
+	const createResult = await sendBatched(pb, diff.toCreate, CREATE_POLICY,
 		(batch, item) => batch.collection('items').create(item), retry);
 	errors.push(...createResult.errors.map((e) => `create batch: ${e}`));
 
-	const archiveResult = await sendBatched(pb, diff.toArchive, UPDATE_BATCH, UPDATE_PAUSE_MS,
+	const archiveResult = await sendBatched(pb, diff.toArchive, UPDATE_POLICY,
 		(batch, item: ExistingItem) => batch.collection('items').update(item.id, {
 			status: 'unavailable',
 			description: archiveDescription(item.description),

--- a/src/lib/server/integrations/leihbackend/client.ts
+++ b/src/lib/server/integrations/leihbackend/client.ts
@@ -1,6 +1,9 @@
 import { dev } from '$app/environment';
 import { assertPublicHttpUrl } from '../core/urlGuard';
+import { IntegrationFetchError, normalizeBaseUrl } from '../core/http';
 import type { LeihbackendItem } from './mapping';
+
+export { normalizeBaseUrl } from '../core/http';
 
 interface ItemPublicListResponse {
 	page: number;
@@ -12,15 +15,10 @@ interface ItemPublicListResponse {
 
 /** Thrown when fetching `item_public` from a leihbackend instance fails for any reason.
  *  The caller must treat the institution's pull as failed — no partial results. */
-export class LeihbackendFetchError extends Error {
-	readonly baseUrl: string;
-	readonly status?: number;
-
+export class LeihbackendFetchError extends IntegrationFetchError {
 	constructor(message: string, baseUrl: string, options?: { status?: number; cause?: unknown }) {
-		super(message, { cause: options?.cause });
+		super(message, baseUrl, options);
 		this.name = 'LeihbackendFetchError';
-		this.baseUrl = baseUrl;
-		this.status = options?.status;
 	}
 }
 
@@ -29,11 +27,6 @@ const MAX_ITEMS = 5000;
 // A source reporting an absurd `totalPages` must not drive endless sequential GETs.
 const MAX_PAGES = Math.ceil(MAX_ITEMS / PER_PAGE) + 1;
 const TIMEOUT_MS = 15000;
-
-/** Strips trailing slashes from a leihbackend base URL. */
-export function normalizeBaseUrl(url: string): string {
-	return url.replace(/\/+$/, '');
-}
 
 /**
  * Pages through `{base}/api/collections/item_public/records` until exhausted.

--- a/src/lib/server/integrations/winbiap/client.ts
+++ b/src/lib/server/integrations/winbiap/client.ts
@@ -1,20 +1,18 @@
 import { dev } from '$app/environment';
 import type { Item } from '$lib/types/models';
 import { assertPublicHttpUrl } from '../core/urlGuard';
+import { IntegrationFetchError, normalizeBaseUrl } from '../core/http';
+
+export { normalizeBaseUrl } from '../core/http';
 
 type ItemStatus = Item['status']; // 'available' | 'unavailable' | 'unknown'
 
 /** Thrown when a WINBIAP WebOPAC request fails (network, non-2xx, or an unexpected body).
  *  Treated as a transient failure by the refresh flow — the item is left untouched. */
-export class WinbiapFetchError extends Error {
-	readonly baseUrl: string;
-	readonly status?: number;
-
+export class WinbiapFetchError extends IntegrationFetchError {
 	constructor(message: string, baseUrl: string, options?: { status?: number; cause?: unknown }) {
-		super(message, { cause: options?.cause });
+		super(message, baseUrl, options);
 		this.name = 'WinbiapFetchError';
-		this.baseUrl = baseUrl;
-		this.status = options?.status;
 	}
 }
 
@@ -43,11 +41,6 @@ interface CatalogueRecord {
 
 interface SearchResponse {
 	Data?: CatalogueRecord[];
-}
-
-/** Strips trailing slashes from a WebOPAC base URL. */
-export function normalizeBaseUrl(url: string): string {
-	return url.replace(/\/+$/, '');
 }
 
 /**

--- a/src/routes/conversations/ConversationListItem.svelte
+++ b/src/routes/conversations/ConversationListItem.svelte
@@ -52,6 +52,29 @@
 			? texts.lending.statusLabel[conversation.lendingStatus as keyof typeof texts.lending.statusLabel]
 			: null
 	);
+
+	// Row background: active wins; otherwise an unread row is tinted in the role's
+	// color (primary = borrowing, accent = lending); read rows only tint on hover.
+	const rowBackgroundClass = $derived(
+		isActive
+			? 'bg-white dark:bg-tinte-800 shadow-sm'
+			: isUnread
+				? role === 'borrowing'
+					? 'bg-primary-100 dark:bg-primary-900/20 hover:bg-primary-200/60'
+					: 'bg-accent-100 dark:bg-accent-900/20 hover:bg-accent-200/60'
+				: 'hover:bg-white dark:hover:bg-tinte-800 hover:shadow-sm'
+	);
+
+	// Title text: active rows use the role color, unread rows just go bold.
+	const titleTextClass = $derived(
+		isActive
+			? role === 'borrowing'
+				? 'font-semibold text-primary'
+				: 'font-semibold text-accent'
+			: isUnread
+				? 'font-semibold text-tinte-900 dark:text-white'
+				: 'font-medium text-tinte-700 dark:text-tinte-200'
+	);
 </script>
 
 <li class="w-full">
@@ -59,13 +82,7 @@
 		href={resolve('/conversations/[conversationId]', { conversationId: conversation.id })}
 		class="flex items-center gap-3 rounded-xl border-l-4 px-2.5 py-2.5 transition-all min-h-14
 			{role === 'borrowing' ? 'border-primary' : 'border-accent'}
-			{isActive
-				? 'bg-white dark:bg-tinte-800 shadow-sm'
-				: isUnread
-					? role === 'borrowing'
-						? 'bg-primary-100 dark:bg-primary-900/20 hover:bg-primary-200/60'
-						: 'bg-accent-100 dark:bg-accent-900/20 hover:bg-accent-200/60'
-					: 'hover:bg-white dark:hover:bg-tinte-800 hover:shadow-sm'}"
+			{rowBackgroundClass}"
 	>
 		<!-- Item thumbnail -->
 		<div class="shrink-0 w-11 h-11 rounded-full border border-tinte-400 overflow-hidden bg-tinte-200 dark:bg-tinte-700">
@@ -82,14 +99,7 @@
 
 		<!-- Text -->
 		<div class="flex-1 min-w-0">
-			<p class="text-sm truncate leading-tight
-				{isActive
-					? role === 'borrowing'
-						? 'font-semibold text-primary'
-						: 'font-semibold text-accent'
-					: isUnread
-						? 'font-semibold text-tinte-900 dark:text-white'
-						: 'font-medium text-tinte-700 dark:text-tinte-200'}">
+			<p class="text-sm truncate leading-tight {titleTextClass}">
 				{itemName}
 			</p>
 			<p class="text-xs text-tinte-400 dark:text-tinte-500 truncate leading-tight mt-0.5">

--- a/src/routes/legal/accept/+page.server.ts
+++ b/src/routes/legal/accept/+page.server.ts
@@ -12,10 +12,18 @@ function safeRedirect(target: string | null): string {
 	return '/';
 }
 
-export async function load({ locals, url }) {
+/** All entry points bounce unauthenticated users through login preserving the FULL
+ *  current URL (incl. ?redirectTo=…). In practice dead code — hooks.server.ts already
+ *  gates /legal behind login — but kept in one place so the guards can't drift and a
+ *  future change can't silently lose the user's original destination. */
+function requireUser(locals: App.Locals, url: URL): void {
 	if (!locals.user) {
 		redirect(307, `/auth/login?redirectTo=${encodeURIComponent(url.pathname + url.search)}`);
 	}
+}
+
+export async function load({ locals, url }) {
+	requireUser(locals, url);
 	const user = locals.user as unknown as LegalUser;
 	const redirectTo = safeRedirect(url.searchParams.get('redirectTo'));
 
@@ -53,9 +61,7 @@ export async function load({ locals, url }) {
 
 export const actions = {
 	accept: async ({ locals, request, url }) => {
-		if (!locals.user) {
-			redirect(307, `/auth/login?redirectTo=${encodeURIComponent('/legal/accept')}`);
-		}
+		requireUser(locals, url);
 		const user = locals.user as unknown as LegalUser;
 		const redirectTo = safeRedirect(url.searchParams.get('redirectTo'));
 		const versions = await getActiveLegalVersions(locals.pb);
@@ -89,10 +95,8 @@ export const actions = {
 		redirect(303, redirectTo);
 	},
 
-	decline: async ({ locals }) => {
-		if (!locals.user) {
-			redirect(307, `/auth/login?redirectTo=${encodeURIComponent('/legal/accept')}`);
-		}
+	decline: async ({ locals, url }) => {
+		requireUser(locals, url);
 		try {
 			// Decline + account lock run in the backend hook (superuser context).
 			await locals.pb.send('/api/legal/decline', { method: 'POST' });

--- a/src/routes/search/TravelTimeFilter.svelte
+++ b/src/routes/search/TravelTimeFilter.svelte
@@ -6,8 +6,13 @@
 	import TransportModeIcon from '$lib/components/TransportModeIcon.svelte';
 	import AllerLoader from '$lib/components/AllerLoader.svelte';
 	import type { ItemPublic } from '$lib/types/models';
-
-	type TransportMode = 'foot' | 'bicycle' | 'car';
+	import {
+		fetchTravelTimes,
+		persistTransportMode,
+		requestBrowserLocation,
+		type GeoPoint,
+		type TransportMode,
+	} from './travelTimeClient';
 
 	interface Props {
 		preferredMode: TransportMode | undefined;
@@ -33,55 +38,24 @@
 	let showNoLocationPrompt = $state(false);
 	let locationStatus = $state<'idle' | 'requesting' | 'denied'>('idle');
 	let isFetchingTravelTimes = $state(false);
-	let cachedUserLocation: { lon: number; lat: number } | null = null;
+	let cachedUserLocation: GeoPoint | null = null;
 	let mounted = false;
 
-	// Fire-and-forget: sends a diagnostic event to the server log. Never throws.
-	function sendDiag(payload: Record<string, unknown>) {
-		fetch('/api/diagnostics', { method: 'POST', body: JSON.stringify(payload) }).catch(() => {});
-	}
-
-	async function fetchTravelTimes(mode: TransportMode, userLocation: { lon: number; lat: number }) {
+	// The fetch itself (timeout, diagnostics) lives in travelTimeClient.ts; this
+	// wrapper only drives the spinner and applies the result to the bound prop.
+	async function runTravelTimeFetch(mode: TransportMode, userLocation: GeoPoint) {
 		isFetchingTravelTimes = true;
-
-		const ownerIds = [...new Set(items.map((item) => item.userId).filter(Boolean))];
-		if (ownerIds.length === 0) {
-			isFetchingTravelTimes = false;
-			return;
-		}
-
-		// Abort after 15s so a hanging ORS response doesn't leave the UI stuck indefinitely
-		const controller = new AbortController();
-		const timeoutId = setTimeout(() => controller.abort(), 15_000);
-		try {
-			const response = await fetch('/api/travel-times/search', {
-				method: 'POST',
-				signal: controller.signal,
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ userLocation, transportMode: mode, ownerIds }),
-			});
-			
-			if (response.ok) {
-				travelTimes = await response.json();
-			} else {
-				sendDiag({ event: 'fetch_error', page: 'search', status: response.status });
-			}
-		} catch (err) {
-			// AbortError means our 15s timeout fired; any other error is a network failure
-			const isTimeout = err instanceof DOMException && err.name === 'AbortError';
-			sendDiag({ event: isTimeout ? 'fetch_timeout' : 'fetch_error', page: 'search' });
-		} finally {
-			clearTimeout(timeoutId);
-			isFetchingTravelTimes = false;
-		}
+		const result = await fetchTravelTimes(mode, userLocation, items);
+		if (result) travelTimes = result;
+		isFetchingTravelTimes = false;
 	}
 
 	function requestLocation(mode: TransportMode, { onDenied }: { onDenied?: () => void } = {}) {
-		navigator.geolocation.getCurrentPosition(
-			(pos) => {
+		requestBrowserLocation(
+			(location) => {
 				if (!mounted) { return; }
-				cachedUserLocation = { lon: pos.coords.longitude, lat: pos.coords.latitude };
-				fetchTravelTimes(mode, cachedUserLocation);
+				cachedUserLocation = location;
+				runTravelTimeFetch(mode, location);
 				showNoLocationPrompt = false;
 				locationStatus = 'idle';
 			},
@@ -108,15 +82,11 @@
 		showNoLocationPrompt = false;
 
 		if (isLoggedIn) {
-			const fd = new FormData();
-			fd.append('mode', mode);
-			fetch('?/saveTransportMode', { method: 'POST', body: fd }).catch((err) =>
-				console.error('Failed to save transport mode:', err)
-			);
+			persistTransportMode(mode);
 		}
 
 		if (cachedUserLocation) {
-			fetchTravelTimes(mode, cachedUserLocation);
+			runTravelTimeFetch(mode, cachedUserLocation);
 			return;
 		}
 
@@ -134,7 +104,7 @@
 			if (!mounted) {  return; }
 			if (!transportMode) { return; }
 			if (!cachedUserLocation) { return; }
-			fetchTravelTimes(transportMode, cachedUserLocation);
+			runTravelTimeFetch(transportMode, cachedUserLocation);
 		});
 	});
 

--- a/src/routes/search/TravelTimeFilter.svelte
+++ b/src/routes/search/TravelTimeFilter.svelte
@@ -45,9 +45,12 @@
 	// wrapper only drives the spinner and applies the result to the bound prop.
 	async function runTravelTimeFetch(mode: TransportMode, userLocation: GeoPoint) {
 		isFetchingTravelTimes = true;
-		const result = await fetchTravelTimes(mode, userLocation, items);
-		if (result) travelTimes = result;
-		isFetchingTravelTimes = false;
+		try {
+			const result = await fetchTravelTimes(mode, userLocation, items);
+			if (result) travelTimes = result;
+		} finally {
+			isFetchingTravelTimes = false;
+		}
 	}
 
 	function requestLocation(mode: TransportMode, { onDenied }: { onDenied?: () => void } = {}) {

--- a/src/routes/search/travelTimeClient.ts
+++ b/src/routes/search/travelTimeClient.ts
@@ -1,0 +1,77 @@
+import type { ItemPublic } from '$lib/types/models';
+
+/**
+ * Framework-free plumbing for the search page's travel-time filter (mirrors how the
+ * conversations route splits chatScroll/presenceHeartbeat out of its components):
+ * the ORS fetch with its timeout + diagnostics, the browser-geolocation wrapper and
+ * the fire-and-forget mode persistence. All UI state stays in TravelTimeFilter.svelte.
+ */
+
+export type TransportMode = 'foot' | 'bicycle' | 'car';
+export type GeoPoint = { lon: number; lat: number };
+
+/** Fire-and-forget: sends a diagnostic event to the server log. Never throws. */
+export function sendDiag(payload: Record<string, unknown>): void {
+	fetch('/api/diagnostics', { method: 'POST', body: JSON.stringify(payload) }).catch(() => {});
+}
+
+/**
+ * Fetches travel times from the user's location to every item owner via
+ * /api/travel-times/search. Aborts after 15s so a hanging ORS response doesn't leave
+ * the UI stuck indefinitely. Returns the owner-id → minutes map, or null when there
+ * was nothing to fetch or the request failed (failures are logged via sendDiag —
+ * the filter then simply stays inactive).
+ */
+export async function fetchTravelTimes(
+	mode: TransportMode,
+	userLocation: GeoPoint,
+	items: ItemPublic[]
+): Promise<Record<string, number> | null> {
+	const ownerIds = [...new Set(items.map((item) => item.userId).filter(Boolean))];
+	if (ownerIds.length === 0) return null;
+
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), 15_000);
+	try {
+		const response = await fetch('/api/travel-times/search', {
+			method: 'POST',
+			signal: controller.signal,
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ userLocation, transportMode: mode, ownerIds }),
+		});
+
+		if (response.ok) {
+			return await response.json();
+		}
+		sendDiag({ event: 'fetch_error', page: 'search', status: response.status });
+		return null;
+	} catch (err) {
+		// AbortError means our 15s timeout fired; any other error is a network failure
+		const isTimeout = err instanceof DOMException && err.name === 'AbortError';
+		sendDiag({ event: isTimeout ? 'fetch_timeout' : 'fetch_error', page: 'search' });
+		return null;
+	} finally {
+		clearTimeout(timeoutId);
+	}
+}
+
+/** Asks the browser for the user's position; exactly one of the callbacks runs. */
+export function requestBrowserLocation(
+	onSuccess: (location: GeoPoint) => void,
+	onDenied: () => void
+): void {
+	navigator.geolocation.getCurrentPosition(
+		(pos) => onSuccess({ lon: pos.coords.longitude, lat: pos.coords.latitude }),
+		onDenied
+	);
+}
+
+/** Persists the chosen mode to user_preferences via the page's form action.
+ *  Fire-and-forget — a failed save only costs the default on the next visit. */
+export function persistTransportMode(mode: TransportMode): void {
+	const fd = new FormData();
+	fd.append('mode', mode);
+	fetch('?/saveTransportMode', { method: 'POST', body: fd }).catch((err) =>
+		console.error('Failed to save transport mode:', err)
+	);
+}

--- a/src/routes/social/+page.svelte
+++ b/src/routes/social/+page.svelte
@@ -1,25 +1,18 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
-	import {
-		Table,
-		TableHead,
-		TableHeadCell,
-		TableBody,
-		TableBodyRow,
-		TableBodyCell,
-		Tooltip
-	} from 'flowbite-svelte';
+	import { Tooltip } from 'flowbite-svelte';
 	import Button from '$lib/components/ui/Button.svelte';
-	import { UserAddOutline, SearchOutline, ArrowUpDownOutline, ArrowUpOutline, ArrowDownOutline, CheckCircleOutline } from 'flowbite-svelte-icons';
+	import { UserAddOutline, SearchOutline } from 'flowbite-svelte-icons';
 	import { resolve } from '$app/paths';
 	import { texts } from '$lib/texts.js';
 	import CustomAlert from '$lib/components/CustomAlert.svelte';
 	import ShareButton from '$lib/components/ShareButton.svelte';
 	import SeoHead from '$lib/components/SeoHead.svelte';
+	import TrustNetworkTable from './TrustNetworkTable.svelte';
 
 	const { data } = $props();
 
-	// ── Unified search ───────────────────────────────────────────────────────────
+	// ── Unified search (shared with the table via its `search` prop) ─────────────
 	let search = $state('');
 	let showAddDropdown = $state(false);
 	let addFeedback = $state<{ type: 'success' | 'error'; message: string } | null>(null);
@@ -34,38 +27,6 @@
 				)
 			: []
 	);
-
-	// ── Table: sort / paginate ────────────────────────────────────────────────────
-	type SortCol = 'username' | 'theyTrustMe' | 'iTrustThem';
-	let sortCol = $state<SortCol>('username');
-	let sortDir = $state<'asc' | 'desc'>('asc');
-	let currentPage = $state(0);
-	const perPage = 10;
-
-	let filtered = $derived(
-		[...data.trustNetwork]
-			.filter((e) => e.username.toLowerCase().includes(search.toLowerCase()))
-			.sort((a, b) => {
-				const mul = sortDir === 'asc' ? 1 : -1;
-				if (sortCol === 'username') return mul * a.username.localeCompare(b.username);
-				// boolean sort: true=1, false=0; desc puts true first
-				return mul * (Number(a[sortCol]) - Number(b[sortCol]));
-			})
-	);
-
-	let totalPages = $derived(Math.ceil(filtered.length / perPage));
-	let paginated = $derived(filtered.slice(currentPage * perPage, (currentPage + 1) * perPage));
-
-	function toggleSort(col: SortCol) {
-		if (sortCol === col) {
-			sortDir = sortDir === 'asc' ? 'desc' : 'asc';
-		} else {
-			sortCol = col;
-			// Boolean columns: start desc so "true" rows appear first
-			sortDir = col === 'username' ? 'asc' : 'desc';
-		}
-		currentPage = 0;
-	}
 </script>
 
 <SeoHead title={texts.seo.social.title} robots="noindex, nofollow" />
@@ -125,7 +86,7 @@
 				placeholder={texts.pages.social.searchPlaceholder}
 				class="search-bar w-full pr-10"
 				bind:value={search}
-				oninput={() => { currentPage = 0; showAddDropdown = false; }}
+				oninput={() => (showAddDropdown = false)}
 			/>
 			{#if search.length > 1}
 				<button
@@ -198,108 +159,5 @@
 
 
 
-{#snippet sortIcon(col: SortCol)}
-	{#if sortCol !== col}
-		<ArrowUpDownOutline class="shrink-0 h-3 w-3" />
-	{:else if sortDir === 'asc'}
-		<ArrowUpOutline class="shrink-0 h-3 w-3" />
-	{:else}
-		<ArrowDownOutline class="shrink-0 h-3 w-3" />
-	{/if}
-{/snippet}
-
 <!-- TRUST NETWORK TABLE -->
-<div class="mx-auto max-w-2xl px-2">
-	<Table hoverable classes={{ div: "relative overflow-x-auto bg-transparent" }} class="w-full text-sm text-left text-gray-500 dark:text-gray-400 bg-transparent">
-		<TableHead defaultRow={false} class="bg-transparent!">
-			<!-- Sort header row -->
-			<tr>
-				<TableHeadCell
-					class="cursor-pointer select-none bg-transparent!"
-					onclick={() => toggleSort('username')}
-				>
-					<span class="flex items-center gap-1 whitespace-nowrap">Nutzer:in {@render sortIcon('username')}</span>
-				</TableHeadCell>
-				<TableHeadCell
-					class="w-15 sm:w-40 cursor-pointer select-none text-center bg-transparent!"
-					onclick={() => toggleSort('theyTrustMe')}
-				>
-					<span class="flex flex-wrap items-center justify-center gap-1">{texts.ui.theyTrustYou} {@render sortIcon('theyTrustMe')}</span>
-				</TableHeadCell>
-				<TableHeadCell
-					class="w-15 sm:w-40 cursor-pointer select-none text-center bg-transparent!"
-					onclick={() => toggleSort('iTrustThem')}
-				>
-					<span class="flex flex-wrap items-center justify-center gap-1">{texts.ui.youTrustThem} {@render sortIcon('iTrustThem')}</span>
-				</TableHeadCell>
-			</tr>
-		</TableHead>
-		<TableBody>
-			{#if paginated.length === 0}
-				<TableBodyRow class="bg-transparent!">
-					<TableBodyCell colspan={4} class="text-center text-tinte-500 dark:text-tinte-400 bg-transparent!">
-						{search ? 'Keine Treffer.' : texts.ui.trustNetworkEmpty}
-					</TableBodyCell>
-				</TableBodyRow>
-			{/if}
-			{#each paginated as entry (entry.id)}
-				<TableBodyRow class="bg-transparent!">
-
-					<!-- Username -->
-					<TableBodyCell class="max-w-30 whitespace-nowrap overflow-hidden text-ellipsis">
-						<a
-							href={resolve('/users/[id]', { id: entry.id })}
-							class="flex flex-row items-center font-medium text-tinte-900 dark:text-white hover:underline"
-						>
-							<img
-								src={entry.profilePic}
-								alt="@{entry.username}"
-								class="h-9 w-9 mr-4 shrink-0 rounded-full object-cover hidden sm:block"
-							/>
-							{entry.username}
-						</a>
-					</TableBodyCell>
-
-					<!-- Vertraut dir (read-only) -->
-					<TableBodyCell class="text-center">
-						{#if entry.theyTrustMe}
-							<CheckCircleOutline class="h-5 w-5 text-green-500 inline" />
-						{/if}
-					</TableBodyCell>
-
-					<!-- Du vertraust (interactive) -->
-					<TableBodyCell class="text-center">
-						<form
-							method="POST"
-							action={entry.iTrustThem ? '?/removeTrustee' : '?/addTrustee'}
-							use:enhance
-						>
-							<input type="hidden" name="trusteeId" value={entry.id} />
-							<input
-								type="checkbox"
-								checked={entry.iTrustThem}
-								class="w-4 h-4 rounded-full border-tinte-600 text-green-500 bg-gray-100 dark:bg-gray-700 dark:border-gray-600 cursor-pointer focus:ring-primary-500"
-								onchange={(e) => (e.target as HTMLInputElement).form?.requestSubmit()}
-							/>
-						</form>
-					</TableBodyCell>
-				</TableBodyRow>
-			{/each}
-		</TableBody>
-	</Table>
-
-	<!-- PAGINATION -->
-	{#if totalPages > 1}
-		<div class="flex items-center justify-between mt-4 px-1">
-			<Button size="sm" disabled={currentPage === 0} onclick={() => (currentPage -= 1)}>
-				← Zurück
-			</Button>
-			<span class="text-sm text-tinte-500 dark:text-tinte-400">
-				{currentPage + 1} / {totalPages}
-			</span>
-			<Button size="sm" disabled={currentPage >= totalPages - 1} onclick={() => (currentPage += 1)}>
-				Weiter →
-			</Button>
-		</div>
-	{/if}
-</div>
+<TrustNetworkTable trustNetwork={data.trustNetwork} {search} />

--- a/src/routes/social/TrustNetworkTable.svelte
+++ b/src/routes/social/TrustNetworkTable.svelte
@@ -1,0 +1,176 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import {
+		Table,
+		TableHead,
+		TableHeadCell,
+		TableBody,
+		TableBodyRow,
+		TableBodyCell
+	} from 'flowbite-svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import { ArrowUpDownOutline, ArrowUpOutline, ArrowDownOutline, CheckCircleOutline } from 'flowbite-svelte-icons';
+	import { resolve } from '$app/paths';
+	import { texts } from '$lib/texts.js';
+
+	/**
+	 * The sortable, paginated trust-network table of /social (rows post to the page's
+	 * ?/addTrustee / ?/removeTrustee actions). Owns all sort/pagination state; the page
+	 * passes the network plus the shared search term (also used by its add-user dropdown).
+	 */
+	interface Props {
+		trustNetwork: {
+			id: string;
+			username: string;
+			profilePic: string;
+			iTrustThem: boolean;
+			theyTrustMe: boolean;
+		}[];
+		search: string;
+	}
+
+	const { trustNetwork, search }: Props = $props();
+
+	type SortCol = 'username' | 'theyTrustMe' | 'iTrustThem';
+	let sortCol = $state<SortCol>('username');
+	let sortDir = $state<'asc' | 'desc'>('asc');
+	let currentPage = $state(0);
+	const perPage = 10;
+
+	// A changed search term re-filters the rows — jump back to the first page so the
+	// pager can't point past the (possibly shorter) new result set.
+	$effect(() => {
+		void search;
+		currentPage = 0;
+	});
+
+	let filtered = $derived(
+		[...trustNetwork]
+			.filter((e) => e.username.toLowerCase().includes(search.toLowerCase()))
+			.sort((a, b) => {
+				const mul = sortDir === 'asc' ? 1 : -1;
+				if (sortCol === 'username') return mul * a.username.localeCompare(b.username);
+				// boolean sort: true=1, false=0; desc puts true first
+				return mul * (Number(a[sortCol]) - Number(b[sortCol]));
+			})
+	);
+
+	let totalPages = $derived(Math.ceil(filtered.length / perPage));
+	let paginated = $derived(filtered.slice(currentPage * perPage, (currentPage + 1) * perPage));
+
+	function toggleSort(col: SortCol) {
+		if (sortCol === col) {
+			sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+		} else {
+			sortCol = col;
+			// Boolean columns: start desc so "true" rows appear first
+			sortDir = col === 'username' ? 'asc' : 'desc';
+		}
+		currentPage = 0;
+	}
+</script>
+
+{#snippet sortIcon(col: SortCol)}
+	{#if sortCol !== col}
+		<ArrowUpDownOutline class="shrink-0 h-3 w-3" />
+	{:else if sortDir === 'asc'}
+		<ArrowUpOutline class="shrink-0 h-3 w-3" />
+	{:else}
+		<ArrowDownOutline class="shrink-0 h-3 w-3" />
+	{/if}
+{/snippet}
+
+<div class="mx-auto max-w-2xl px-2">
+	<Table hoverable classes={{ div: "relative overflow-x-auto bg-transparent" }} class="w-full text-sm text-left text-gray-500 dark:text-gray-400 bg-transparent">
+		<TableHead defaultRow={false} class="bg-transparent!">
+			<!-- Sort header row -->
+			<tr>
+				<TableHeadCell
+					class="cursor-pointer select-none bg-transparent!"
+					onclick={() => toggleSort('username')}
+				>
+					<span class="flex items-center gap-1 whitespace-nowrap">Nutzer:in {@render sortIcon('username')}</span>
+				</TableHeadCell>
+				<TableHeadCell
+					class="w-15 sm:w-40 cursor-pointer select-none text-center bg-transparent!"
+					onclick={() => toggleSort('theyTrustMe')}
+				>
+					<span class="flex flex-wrap items-center justify-center gap-1">{texts.ui.theyTrustYou} {@render sortIcon('theyTrustMe')}</span>
+				</TableHeadCell>
+				<TableHeadCell
+					class="w-15 sm:w-40 cursor-pointer select-none text-center bg-transparent!"
+					onclick={() => toggleSort('iTrustThem')}
+				>
+					<span class="flex flex-wrap items-center justify-center gap-1">{texts.ui.youTrustThem} {@render sortIcon('iTrustThem')}</span>
+				</TableHeadCell>
+			</tr>
+		</TableHead>
+		<TableBody>
+			{#if paginated.length === 0}
+				<TableBodyRow class="bg-transparent!">
+					<TableBodyCell colspan={4} class="text-center text-tinte-500 dark:text-tinte-400 bg-transparent!">
+						{search ? 'Keine Treffer.' : texts.ui.trustNetworkEmpty}
+					</TableBodyCell>
+				</TableBodyRow>
+			{/if}
+			{#each paginated as entry (entry.id)}
+				<TableBodyRow class="bg-transparent!">
+
+					<!-- Username -->
+					<TableBodyCell class="max-w-30 whitespace-nowrap overflow-hidden text-ellipsis">
+						<a
+							href={resolve('/users/[id]', { id: entry.id })}
+							class="flex flex-row items-center font-medium text-tinte-900 dark:text-white hover:underline"
+						>
+							<img
+								src={entry.profilePic}
+								alt="@{entry.username}"
+								class="h-9 w-9 mr-4 shrink-0 rounded-full object-cover hidden sm:block"
+							/>
+							{entry.username}
+						</a>
+					</TableBodyCell>
+
+					<!-- Vertraut dir (read-only) -->
+					<TableBodyCell class="text-center">
+						{#if entry.theyTrustMe}
+							<CheckCircleOutline class="h-5 w-5 text-green-500 inline" />
+						{/if}
+					</TableBodyCell>
+
+					<!-- Du vertraust (interactive) -->
+					<TableBodyCell class="text-center">
+						<form
+							method="POST"
+							action={entry.iTrustThem ? '?/removeTrustee' : '?/addTrustee'}
+							use:enhance
+						>
+							<input type="hidden" name="trusteeId" value={entry.id} />
+							<input
+								type="checkbox"
+								checked={entry.iTrustThem}
+								class="w-4 h-4 rounded-full border-tinte-600 text-green-500 bg-gray-100 dark:bg-gray-700 dark:border-gray-600 cursor-pointer focus:ring-primary-500"
+								onchange={(e) => (e.target as HTMLInputElement).form?.requestSubmit()}
+							/>
+						</form>
+					</TableBodyCell>
+				</TableBodyRow>
+			{/each}
+		</TableBody>
+	</Table>
+
+	<!-- PAGINATION -->
+	{#if totalPages > 1}
+		<div class="flex items-center justify-between mt-4 px-1">
+			<Button size="sm" disabled={currentPage === 0} onclick={() => (currentPage -= 1)}>
+				← Zurück
+			</Button>
+			<span class="text-sm text-tinte-500 dark:text-tinte-400">
+				{currentPage + 1} / {totalPages}
+			</span>
+			<Button size="sm" disabled={currentPage >= totalPages - 1} onclick={() => (currentPage += 1)}>
+				Weiter →
+			</Button>
+		</div>
+	{/if}
+</div>

--- a/src/routes/social/TrustNetworkTable.svelte
+++ b/src/routes/social/TrustNetworkTable.svelte
@@ -108,7 +108,7 @@
 		<TableBody>
 			{#if paginated.length === 0}
 				<TableBodyRow class="bg-transparent!">
-					<TableBodyCell colspan={4} class="text-center text-tinte-500 dark:text-tinte-400 bg-transparent!">
+					<TableBodyCell colspan={3} class="text-center text-tinte-500 dark:text-tinte-400 bg-transparent!">
 						{search ? 'Keine Treffer.' : texts.ui.trustNetworkEmpty}
 					</TableBodyCell>
 				</TableBodyRow>

--- a/src/routes/user/groups/[id]/GroupItemsSection.svelte
+++ b/src/routes/user/groups/[id]/GroupItemsSection.svelte
@@ -50,6 +50,17 @@
 	const PAGE_SIZE = 12;
 	let visibleCount = $state(PAGE_SIZE);
 	const pagedItems = $derived(displayedItems.slice(0, visibleCount));
+
+	// Empty-state message. Only shown while a filter is active — with no filters,
+	// displayedItems === items, which is non-empty wherever this section renders —
+	// so exactly one of the three filter cases applies.
+	const emptyStateMessage = $derived(
+		normalizedSearch !== ''
+			? texts.groups.noItemsForSearch
+			: onlyAvailable
+				? texts.groups.noAvailableItems
+				: texts.groups.noItemsInCategory
+	);
 </script>
 
 <section class="bg-sand border border-tinte-200 rounded-lg shadow-sm dark:bg-tinte-800 dark:border-tinte-700 p-6 sm:p-8 space-y-4">
@@ -115,13 +126,7 @@
 
 		{#if displayedItems.length === 0}
 			<p class="text-tinte-500 dark:text-tinte-400 text-sm text-center">
-				{normalizedSearch !== ''
-					? texts.groups.noItemsForSearch
-					: onlyAvailable
-						? texts.groups.noAvailableItems
-						: selectedCategory !== null
-							? texts.groups.noItemsInCategory
-							: texts.groups.noItemsForSearch}
+				{emptyStateMessage}
 			</p>
 		{:else}
 			<div class="grid grid-cols-1 sm:grid-cols-2 gap-3">

--- a/src/routes/user/groups/[id]/members/+page.server.ts
+++ b/src/routes/user/groups/[id]/members/+page.server.ts
@@ -87,24 +87,32 @@ export async function load({ locals, params }) {
 	};
 }
 
+// Load the group and assert the caller owns it (defense-in-depth on top of the
+// backend collection rule) — the shared opener of both actions below. One read
+// serves the owner check AND the group name the notification bodies need. A
+// missing/unreadable group (e.g. deleted in a race with the request) yields a
+// clean fail instead of a generic 500.
+async function loadOwnedGroup(locals: App.Locals, groupId: string) {
+	let group: { id: string; owner: string; name: string };
+	try {
+		group = await locals.pb
+			.collection('groups')
+			.getOne<{ id: string; owner: string; name: string }>(groupId, {
+				fields: 'id,owner,name',
+			});
+	} catch {
+		return { failure: fail(404, { fail: true, message: texts.errors.somethingWentWrong }) };
+	}
+	if (group.owner !== locals.user!.id)
+		return { failure: fail(403, { fail: true, message: texts.errors.noPermission }) };
+	return { group };
+}
+
 export const actions = {
 	addMember: async ({ locals, params, request }) => {
-		// Load the group once: the owner check (defense-in-depth on top of the backend
-		// collection rule) and the group name the notification body needs both come from
-		// this single read. A missing/unreadable group (e.g. deleted in a race with the
-		// request) yields a clean fail instead of a generic 500.
-		let group: { id: string; owner: string; name: string };
-		try {
-			group = await locals.pb
-				.collection('groups')
-				.getOne<{ id: string; owner: string; name: string }>(params.id, {
-					fields: 'id,owner,name',
-				});
-		} catch {
-			return fail(404, { fail: true, message: texts.errors.somethingWentWrong });
-		}
-		if (group.owner !== locals.user!.id)
-			return fail(403, { fail: true, message: texts.errors.noPermission });
+		const owned = await loadOwnedGroup(locals, params.id);
+		if ('failure' in owned) return owned.failure;
+		const { group } = owned;
 
 		const formData = await request.formData();
 		// The add-member search posts a resolved userId; fall back to an exact
@@ -158,21 +166,9 @@ export const actions = {
 	},
 
 	removeMember: async ({ locals, params, request }) => {
-		// Load the group once: the owner check and the group name the removal
-		// notification needs both come from this single read (as in addMember). A
-		// missing/unreadable group yields a clean fail instead of a generic 500.
-		let group: { id: string; owner: string; name: string };
-		try {
-			group = await locals.pb
-				.collection('groups')
-				.getOne<{ id: string; owner: string; name: string }>(params.id, {
-					fields: 'id,owner,name',
-				});
-		} catch {
-			return fail(404, { fail: true, message: texts.errors.somethingWentWrong });
-		}
-		if (group.owner !== locals.user!.id)
-			return fail(403, { fail: true, message: texts.errors.noPermission });
+		const owned = await loadOwnedGroup(locals, params.id);
+		if ('failure' in owned) return owned.failure;
+		const { group } = owned;
 
 		const membershipId = (await request.formData()).get('membershipId')?.toString();
 		if (!membershipId) return fail(400, { fail: true, message: texts.errors.missingId });


### PR DESCRIPTION
What & why
Phase 4 (final) of the full-codebase quality review: the approved nice-to-haves. Stacked on #588 (base: refactor/quality-p3-decompose); GitHub retargets as the stack merges.

Dead/opaque paths: GroupItemsSection's empty-state ternary had an unreachable fourth branch — now a named $derived with the three real cases and a comment explaining why. ConversationListItem's two nested class ternaries become named $deriveds.
Guard dedup: groups/[id]/members gets one loadOwnedGroup() opener for both actions; legal/accept's three login-redirect guards share requireUser() — fixing the inconsistency where decline hardcoded the redirect target and would have lost the user's original destination.
Parameter-order footgun: sendBatched's adjacent same-typed numbers (batchSize, pauseMs) become a BatchPolicy object with named UPDATE_POLICY/CREATE_POLICY constants. (The sendMessage 7-params finding was already fixed by #585 — no change needed.)
Integration twins: the byte-identical normalizeBaseUrl and structurally identical LeihbackendFetchError/WinbiapFetchError move to a shared integrations/core/http.ts; the clients re-export/extend, so import sites, tests and instanceof checks are unchanged.
Logic/UI splits: TravelTimeFilter's ORS fetch (timeout + diagnostics) and geolocation plumbing move to co-located travelTimeClient.ts (mirroring the conversations route's chatScroll/presenceHeartbeat pattern); /social's sortable/paginated trust table becomes TrustNetworkTable.svelte (page: 305 → 133 lines).
Cosmetics: stale handleError TODO replaced with an accurate comment; the footer's repeated two-prop styling pair becomes one spread constant.
Test notes
Preflight: npm run lint ✓ · npm run check (0 errors) ✓ · npx vitest run 851/851 ✓ · npm run build ✓
No behavior changes intended. Manual check suggested: the /social table (sort, paginate, search resets to page 1, trust checkbox), the search page's travel-time filter (mode pick, slider, denied-location prompt), and one integration sync if convenient.
This completes the 4-phase review-driven refactor (#586 → #587 → #588 → this).

🤖 Generated with Claude Code