### PR TITLE
Add tests for the shared PocketBase mock helper

### DIFF
--- a/src/lib/test-utils/pocketbase.test.ts
+++ b/src/lib/test-utils/pocketbase.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mockFilter, makeMockPb } from './pocketbase';
+
+describe('mockFilter', () => {
+	it('returns raw unchanged when no params are given', () => {
+		expect(mockFilter('id = {:id}')).toBe('id = {:id}');
+	});
+
+	it('quotes and escapes string params', () => {
+		expect(mockFilter('name = {:name}', { name: "O'Brien" })).toBe("name = 'O\\'Brien'");
+	});
+
+	it('leaves numbers and booleans unquoted', () => {
+		expect(mockFilter('count > {:n} && active = {:b}', { n: 3, b: true })).toBe(
+			'count > 3 && active = true'
+		);
+	});
+
+	it('substitutes every occurrence of a repeated placeholder', () => {
+		expect(mockFilter('a = {:x} || b = {:x}', { x: 'v1' })).toBe("a = 'v1' || b = 'v1'");
+	});
+
+	it('leaves unknown placeholders untouched', () => {
+		expect(mockFilter('a = {:known} && b = {:unknown}', { known: 'v' })).toBe(
+			"a = 'v' && b = {:unknown}"
+		);
+	});
+});
+
+describe('makeMockPb', () => {
+	it('dispatches collection() to the matching impl', () => {
+		const getOne = vi.fn().mockResolvedValue({ id: 'item1' });
+		const pb = makeMockPb({ items: { getOne } });
+
+		expect(pb.collection('items')).toEqual({ getOne });
+	});
+
+	it('returns undefined for an unstubbed collection', () => {
+		const pb = makeMockPb({ items: { getOne: vi.fn() } });
+
+		expect(pb.collection('conversations')).toBeUndefined();
+	});
+
+	it('exposes pb.filter as an assertable spy delegating to mockFilter', () => {
+		const pb = makeMockPb({});
+
+		const result = pb.filter('id = {:id}', { id: 'abc' });
+
+		expect(result).toBe("id = 'abc'");
+		expect(pb.filter).toHaveBeenCalledWith('id = {:id}', { id: 'abc' });
+	});
+});


### PR DESCRIPTION
## What & why

`src/lib/test-utils/pocketbase.ts` (`mockFilter` + `makeMockPb`, extracted in #585) is now imported by 7 test files, but has **no test of its own**. The semantics those files silently depend on are unpinned:

- string params get quoted **and** `'`-escaped; numbers/booleans stay unquoted
- a repeated `{:x}` is substituted at **every** occurrence, not just the first (this is exactly where the old hand-rolled per-file copies diverged)
- unknown placeholders are left untouched
- `collection()` on an unstubbed collection returns `undefined` — deliberately, so a typo'd collection name fails loudly instead of silently yielding `{}`

This adds the co-located `pocketbase.test.ts` covering those four. No change to the helper itself.

## Provenance

The test is ported from #581, which — while sitting in review — built the same helper in parallel under `src/lib/server/test-helpers.ts`. #585 landed first with a byte-identical implementation at the `test-utils` path, so #581 is superseded and closed; this is the one piece of it that `main` didn't already have.

## Scope

Single new test file. No production code, no backend, no schema, no UI. #446 stays open — 11 test files still carry their own inline filter mock, tracked in #601.

## Test notes

- `npx vitest run src/lib/test-utils/pocketbase.test.ts` → 8/8 pass
- `npx vitest run` (full suite) → 68 files / 710 tests pass
- `npm run lint` → clean
- `npm run check` → 0 errors (10 pre-existing warnings, none in touched files)

Note on formatting: the file follows the surrounding repo style rather than `.prettierrc`, whose `printWidth: 80` is violated by 141 existing files. CI gates on ESLint + `svelte-check` only, both of which pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
