### PR TITLE
ci(deploy): supply the analytics runtime env to the svelte service

### DIFF
--- a/.github/workflows/deploy-to-uberspace.yaml
+++ b/.github/workflows/deploy-to-uberspace.yaml
@@ -44,12 +44,33 @@ jobs:
           remote_key_pass: ${{ secrets.SSH_PRIVATE_KEY_PASS }}
       - name: Install node modules on server
         uses: appleboy/ssh-action@v1
+        # Forwarded to the remote shell via `envs:` and expanded there, rather than
+        # interpolated into `script:` as `${{ … }}`. Textual interpolation would break on a
+        # value containing a quote or `;` and is a shell-injection shape even when the input
+        # is repo-admin-controlled.
+        env:
+          ANALYTICS_ORIGIN: ${{ vars.PUBLIC_ANALYTICS_ORIGIN }}
+          ANALYTICS_WEBSITE_ID: ${{ vars.PUBLIC_ANALYTICS_WEBSITE_ID }}
         with:
           host: ${{ vars.SSH_HOST }}
           username: ${{ vars.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
+          envs: ANALYTICS_ORIGIN,ANALYTICS_WEBSITE_ID
           script: |
             cd share-mvp
             npm ci
-            echo "BODY_SIZE_LIMIT=10485760" > .env
+            # Runtime environment for the `svelte` service. `~/etc/services.d/share-mvp.ini`
+            # starts it as `node -r dotenv/config build`, so this file — and only this file —
+            # is what reaches `process.env`. The service has no `environment=` line, and the
+            # `>` truncates, so every runtime var must be listed here: anything added to
+            # `.env` by hand on the server is discarded on the next deploy.
+            #
+            # Build-time vars (`$env/static/*`) belong in the build step above instead; they
+            # are baked into the artefact. These are the `$env/dynamic/public` ones read by
+            # `src/lib/instance.ts` at server start, so the build step cannot supply them.
+            {
+              echo "BODY_SIZE_LIMIT=10485760"
+              echo "PUBLIC_ANALYTICS_ORIGIN=${ANALYTICS_ORIGIN}"
+              echo "PUBLIC_ANALYTICS_WEBSITE_ID=${ANALYTICS_WEBSITE_ID}"
+            } > .env
             supervisorctl restart svelte


### PR DESCRIPTION
## What & why

Implements the deploy note from #597. `$lib/instance.ts` reads `PUBLIC_ANALYTICS_ORIGIN` and `PUBLIC_ANALYTICS_WEBSITE_ID` through `$env/dynamic/public` — i.e. from `process.env` when the server starts. The build step's `env:` block cannot supply them, because it only reaches `$env/static/*`. Without this change, Umami tracking stops the moment #597 is deployed, and it stops **silently**: no error, just no data.

## How the runtime environment actually reaches the process

Established on the server (thanks @MaRaMinden) — `~/etc/services.d/share-mvp.ini`:

```ini
[program:svelte]
directory=%(ENV_HOME)s/share-mvp
command=node -r dotenv/config build
```

Three consequences:

1. `dotenv` is preloaded via `-r`, so the `.env` written by the deploy **is** read into `process.env`. `dotenv` is therefore a load-bearing **runtime** dependency (it currently sits in `dependencies`, correctly) — moving it to `devDependencies` would silently kill every runtime var.
2. The service has no `environment=` line, so that `.env` is the *only* source of its runtime environment.
3. The step writes it with a truncating `>`, so it holds `BODY_SIZE_LIMIT` and nothing else after each deploy. Every runtime var has to be listed on that line; anything hand-added on the server is discarded on the next deploy.

## Required before this merges

Two repo **variables** (Settings → Secrets and variables → Actions → Variables):

```
PUBLIC_ANALYTICS_ORIGIN      = https://analytics.allerleih.org
PUBLIC_ANALYTICS_WEBSITE_ID  = 6cfb6acd-259e-4771-baa7-c677387ea292
```

Variables rather than secrets, deliberately: both values are public — they are emitted into every rendered page — and as variables they stay readable and auditable in the settings UI instead of being masked.

Only these two. `PUBLIC_SITE_ORIGIN`, `PUBLIC_INSTANCE_CITY`, `PUBLIC_APP_NAME` and `PUBLIC_CONTACT_EMAIL` have defaults in `$lib/instance.ts` that match today's production exactly, so they must stay unset here.

## Merge order

Safe in either order, but this one first is preferable:

* **this PR, then #597** — the deploy in between writes two vars nothing reads yet. Harmless.
* **#597, then this PR** — leaves a window in which analytics is off in production.

If the variables are not set when this merges, both lines are written empty and `resolveAnalytics()` degrades to analytics-off rather than failing — so a forgotten variable costs tracking, not availability.

## Note on the implementation

The values are forwarded via the action's `envs:` input and expanded by the remote shell, rather than interpolated into `script:` as `${{ … }}`. Textual interpolation would break on a value containing a quote or `;`, and it is a shell-injection shape even when the input is repo-admin-controlled. The surrounding steps still interpolate `vars.SSH_*` directly; not changed here to keep the diff to one concern.

## Verification

`.github/workflows/deploy-to-uberspace.yaml` parses, and the resulting remote script and forwarded env were inspected from the parsed YAML rather than read off the diff.

Against the built artefact of #597 merged with `main`, started twice with `node build`:

* without `PUBLIC_ANALYTICS_*` in `process.env` — no analytics tags emitted at all
* with them — both `script.js` and `recorder.js` render with the correct `data-website-id`

which is the behaviour this change is there to produce.

## Follow-ups, not in scope

* `pocketbase_env` holds 9 secrets duplicating the repo-level ones, and no workflow in this repo declares `environment:` — so they are unreachable from CI and can be cleared.
* `SYNC_SECRET` is stale in both scopes since #487 phase 3, and `README.md:74` still documents it along with `/api/sync` + `/api/refresh`.
* `deploy-to-uberspace.yaml` references `secrets.SSH_PRIVATE_KEY_PASS`, which does not exist; it resolves to empty and works only because the key is passphrase-less.
* The `node -r dotenv/config build` detail is not recorded in any doc. Worth adding to the deployment section of `docs/architecture.md` once #597 lands — that file is touched by #597, so it is kept out of this PR to avoid a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
