### PR TITLE
Remove remote_key_pass from deploy workflow

### DIFF
--- a/.github/workflows/deploy-to-uberspace.yaml
+++ b/.github/workflows/deploy-to-uberspace.yaml
@@ -41,7 +41,6 @@ jobs:
           remote_host: ${{ vars.SSH_HOST }}
           remote_user: ${{ vars.SSH_USERNAME }}
           remote_key: ${{ secrets.SSH_PRIVATE_KEY }}
-          remote_key_pass: ${{ secrets.SSH_PRIVATE_KEY_PASS }}
       - name: Install node modules on server
         uses: appleboy/ssh-action@v1
         with:


### PR DESCRIPTION
Removed the remote_key_pass parameter from the deployment workflow, flagged as unused #597
