### PR TITLE
Remove stale LOGIN_SECRET from environment variables

### DIFF
--- a/.github/workflows/deploy-to-uberspace.yaml
+++ b/.github/workflows/deploy-to-uberspace.yaml
@@ -20,7 +20,6 @@ jobs:
         run: npm run build
         env:
           PUBLIC_PB_URL: ${{ secrets.PUBLIC_PB_URL }}
-          LOGIN_SECRET: ${{ secrets.LOGIN_SECRET }}
           ORS_API_KEY: ${{ secrets.ORS_API_KEY }}
           PUBLIC_VAPID_PUBLIC_KEY: ${{ secrets.PUBLIC_VAPID_PUBLIC_KEY }}
           VAPID_PRIVATE_KEY: ${{ secrets.VAPID_PRIVATE_KEY }}

--- a/.github/workflows/vitest.yaml
+++ b/.github/workflows/vitest.yaml
@@ -26,7 +26,6 @@ jobs:
         run: npm run build
         env:
           PUBLIC_PB_URL: ${{ secrets.PUBLIC_PB_URL }}
-          LOGIN_SECRET: ${{ secrets.LOGIN_SECRET }}
           # Static private env members must exist at build time or `$env/static/private` fails
           # with "Missing export". SYNC_SECRET is gone with #487 Phase 3 (the integrations moved
           # into the backend); PB_SUPERUSER_* stay — `$lib/server/superuser.ts` reads them for the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,7 +100,7 @@ Some logic runs inside PocketBase itself (JS hooks) so it can use backend privil
 - **Platform:** Uberspace shared hosting (Linux, Node.js, supervisord)
 - **Deploy trigger:** push to `main` → GitHub Actions (`.github/workflows/deploy-to-uberspace.yaml`) → `npm ci && npm run build` → `rsync` to Uberspace
 - **Process restart:** `supervisorctl restart svelte`
-- **Build-time secrets injected:** `PUBLIC_PB_URL`, `ORS_API_KEY`, `MISTRAL_API_KEY`, VAPID keys (`PUBLIC_VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`), `LOGIN_SECRET`; a tracked `.env.example` lists all required vars. (Integration sync/refresh + the CSV write path run entirely in the backend as of #487 Phase 3 — no frontend sync secret. `PB_SUPERUSER_*` are used only by local seed/e2e tooling, not the app runtime.)
+- **Build-time secrets injected:** `PUBLIC_PB_URL`, `ORS_API_KEY`, `MISTRAL_API_KEY`, VAPID keys (`PUBLIC_VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`); a tracked `.env.example` lists all required vars. (Integration sync/refresh + the CSV write path run entirely in the backend as of #487 Phase 3 — no frontend sync secret. `PB_SUPERUSER_*` are used only by local seed/e2e tooling, not the app runtime.)
 - **Body size limit:** 10 MB, set via `BODY_SIZE_LIMIT` env var on the server after each deploy
 - **PocketBase:** runs as a separate process on Uberspace (repo `allerleih-backend`; schema + JS hooks version-controlled, migrations auto-applied on start); SQLite data and file uploads live on the server filesystem — not managed by the SvelteKit CI/CD pipeline. ⚠️ The backend now requires **`ORS_API_KEY`** in **its own** environment (used by the `/api/travel-times` hook) — not only in the SvelteKit build.
 


### PR DESCRIPTION
Eliminate the LOGIN_SECRET from the build-time secrets as it is no longer needed. Update documentation to reflect this change.

This was a leftover from when we shielded the whole page with a password