### PR TITLE
perf(layout): parallelize the root layout's PocketBase reads

### DIFF
--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -17,26 +17,43 @@ export const load = async (event) => {
 	// $lib/server/metrics.ts), so the nav's admin link needs its own lookup here.
 	let isAdminUser = false;
 	if (currentUser) {
-		// Independent reads, so they go out concurrently: one round trip instead of three
-		// sequential ones on *every* authenticated SSR request. Safe together — the two
-		// `locals.pb` reads hit different paths and isAdmin runs on the separate superuser
-		// client, so the SDK's path-keyed auto-cancellation can't have them cancel each
-		// other. The catch stays per-promise: Promise.all rejects on the first rejection,
-		// so a group-level catch would drop the other two reads with it.
-		const [notificationList, preferences, adminFlag] = await Promise.all([
-			event.locals.pb
-				.collection('notifications')
-				.getList(1, 1, {
+		// Hoisted out of the Promise.all below to keep that call readable — inline, this read's
+		// filter, requestKey and error handling bury the two sibling reads next to it. try/catch
+		// rather than a trailing .catch, so it also covers the synchronous `pb.filter(...)` in the
+		// arguments — the enclosing try covered that too, before these reads were parallelised.
+		const unreadCountRead = (async () => {
+			try {
+				return await event.locals.pb.collection('notifications').getList(1, 1, {
 					filter: event.locals.pb.filter('recipient={:userId} && read=false', {
 						userId: currentUser.id,
 					}),
-					// Distinct requestKey per concurrent call site, per $lib/server/userPreferences.ts —
-					// precautionary here (no other notifications read is concurrent with this one today).
+					// Distinct requestKey, and load-bearing rather than precautionary: `/notifications`'s
+					// page load lists the same collection and runs concurrently with this layout load on
+					// the same `locals.pb`. The SDK keys auto-cancellation by method+path and ignores the
+					// query string, so on a shared key the two abort each other at random — the badge
+					// falls back to 0, or the list renders empty. Same trap as
+					// $lib/server/userPreferences.ts and trust.ts.
 					requestKey: 'notifications-unread-layout',
-				})
+				});
+			} catch {
 				// notifications collection may not exist yet during setup
-				.catch(() => null),
-			getUserPreferences(event.locals.pb, currentUser.id, 'user-preferences-layout'),
+				return null;
+			}
+		})();
+
+		// Independent reads, so they go out concurrently: one round trip instead of three
+		// sequential ones on *every* authenticated SSR request. Safe together — the two
+		// `locals.pb` reads use distinct requestKeys and isAdmin runs on the separate superuser
+		// client, so the SDK's auto-cancellation can't have them cancel each other. Each read
+		// keeps its own error handling: Promise.all rejects on the first rejection, so a
+		// group-level catch would drop the other two reads with it.
+		const [notificationList, preferences, adminFlag] = await Promise.all([
+			unreadCountRead,
+			getUserPreferences(
+				event.locals.pb,
+				currentUser.id,
+				'user-preferences-layout'
+			),
 			isAdmin(currentUser.id),
 		]);
 		unreadNotificationCount = notificationList?.totalItems ?? 0;

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -17,24 +17,31 @@ export const load = async (event) => {
 	// $lib/server/metrics.ts), so the nav's admin link needs its own lookup here.
 	let isAdminUser = false;
 	if (currentUser) {
-		try {
-			const result = await event.locals.pb
+		// Independent reads, so they go out concurrently: one round trip instead of three
+		// sequential ones on *every* authenticated SSR request. Safe together — the two
+		// `locals.pb` reads hit different paths and isAdmin runs on the separate superuser
+		// client, so the SDK's path-keyed auto-cancellation can't have them cancel each
+		// other. The catch stays per-promise: Promise.all rejects on the first rejection,
+		// so a group-level catch would drop the other two reads with it.
+		const [notificationList, preferences, adminFlag] = await Promise.all([
+			event.locals.pb
 				.collection('notifications')
 				.getList(1, 1, {
 					filter: event.locals.pb.filter('recipient={:userId} && read=false', {
 						userId: currentUser.id,
 					}),
-				});
-			unreadNotificationCount = result.totalItems;
-		} catch {
-			// notifications collection may not exist yet during setup
-		}
-		currentUserPreferences = await getUserPreferences(
-			event.locals.pb,
-			currentUser.id,
-			'user-preferences-layout'
-		);
-		isAdminUser = await isAdmin(currentUser.id);
+					// Distinct requestKey per concurrent call site, per $lib/server/userPreferences.ts —
+					// precautionary here (no other notifications read is concurrent with this one today).
+					requestKey: 'notifications-unread-layout',
+				})
+				// notifications collection may not exist yet during setup
+				.catch(() => null),
+			getUserPreferences(event.locals.pb, currentUser.id, 'user-preferences-layout'),
+			isAdmin(currentUser.id),
+		]);
+		unreadNotificationCount = notificationList?.totalItems ?? 0;
+		currentUserPreferences = preferences;
+		isAdminUser = adminFlag;
 	}
 
 	return {

--- a/src/routes/layout.server.test.ts
+++ b/src/routes/layout.server.test.ts
@@ -72,8 +72,8 @@ describe('Root layout load', () => {
 	});
 
 	it('issues the three authenticated reads concurrently, not sequentially', async () => {
-		// Hold the notifications read open. Promise.all invokes all three calls synchronously
-		// before awaiting, so all three mocks are hit before this promise ever settles.
+		// Hold the notifications read open. The load issues all three reads synchronously before
+		// its first await, so all three mocks are hit before this promise ever settles.
 		// Under the old sequential `await`s, preferences and isAdmin were awaited *after* the
 		// notifications read resolved, so neither would have been called at this point —
 		// that's what makes this assertion a real guard against a regression to sequencing.
@@ -106,10 +106,13 @@ describe('Root layout load', () => {
 		getList.mockRejectedValueOnce(new Error('collection missing'));
 		isAdmin.mockResolvedValue(true);
 		const result = await load(buildEvent({ id: 'user1' }));
-		// Promise.all rejects as soon as any input rejects, so the per-promise catch on the
-		// notifications read is what stops one missing collection from sinking the other two.
+		// Promise.all rejects as soon as any input rejects, so the notifications read's own
+		// try/catch is what stops one missing collection from sinking the other two.
 		expect(result.unreadNotificationCount).toBe(0);
-		expect(result.currentUserPreferences).toEqual({ hasOnboarded: true, preferredTransportMode: 'car' });
+		expect(result.currentUserPreferences).toEqual({
+			hasOnboarded: true,
+			preferredTransportMode: 'car',
+		});
 		expect(result.isAdminUser).toBe(true);
 	});
 

--- a/src/routes/layout.server.test.ts
+++ b/src/routes/layout.server.test.ts
@@ -71,6 +71,48 @@ describe('Root layout load', () => {
 		expect(depends).toHaveBeenCalledWith(NOTIFICATIONS_DEP);
 	});
 
+	it('issues the three authenticated reads concurrently, not sequentially', async () => {
+		// Hold the notifications read open. Promise.all invokes all three calls synchronously
+		// before awaiting, so all three mocks are hit before this promise ever settles.
+		// Under the old sequential `await`s, preferences and isAdmin were awaited *after* the
+		// notifications read resolved, so neither would have been called at this point —
+		// that's what makes this assertion a real guard against a regression to sequencing.
+		let releaseNotifications!: (value: { totalItems: number }) => void;
+		getList.mockReturnValueOnce(
+			new Promise<{ totalItems: number }>((resolve) => {
+				releaseNotifications = resolve;
+			})
+		);
+
+		const pending = load(buildEvent({ id: 'user1' }));
+
+		expect(prefsGetFirstListItem).toHaveBeenCalled();
+		expect(isAdmin).toHaveBeenCalled();
+
+		releaseNotifications({ totalItems: 7 });
+		expect((await pending).unreadNotificationCount).toBe(7);
+	});
+
+	it('reads the unread count with a distinct requestKey so a concurrent read cannot auto-cancel it', async () => {
+		await load(buildEvent({ id: 'user1' }));
+		expect(getList).toHaveBeenCalledWith(
+			1,
+			1,
+			expect.objectContaining({ requestKey: 'notifications-unread-layout' })
+		);
+	});
+
+	it('keeps the preferences and admin reads when the notifications query fails', async () => {
+		getList.mockRejectedValueOnce(new Error('collection missing'));
+		isAdmin.mockResolvedValue(true);
+		const result = await load(buildEvent({ id: 'user1' }));
+		// Promise.all rejects as soon as any input rejects, so the per-promise catch on the
+		// notifications read is what stops one missing collection from sinking the other two.
+		expect(result.unreadNotificationCount).toBe(0);
+		expect(result.currentUserPreferences).toEqual({ hasOnboarded: true, preferredTransportMode: 'car' });
+		expect(result.isAdminUser).toBe(true);
+	});
+
 	it('surfaces the user preferences with a distinct requestKey (issue #426)', async () => {
 		const result = await load(buildEvent({ id: 'user1' }));
 		expect(result.currentUserPreferences).toEqual({ hasOnboarded: true, preferredTransportMode: 'car' });


### PR DESCRIPTION
## What & why

The root layout's server load awaited three **independent** PocketBase reads sequentially, on *every* authenticated SSR request:

1. the unread-notification count,
2. the user-preferences sidecar (#426),
3. the superuser-only `isAdmin` lookup for the nav's admin link.

None of them needs a previous result — they were sequential only because of how they were written. They now go out concurrently via `Promise.all`, so the layout costs one round trip instead of three. Since this is the *root* layout, it applies to every authenticated page render.

**Context.** This surfaced while analysing #526 (throttling the per-request `authRefresh`). That refresh is one of **four** sequential round trips on an authenticated request; parallelising these three is the larger win, and unlike throttling the auth refresh it carries no staleness or revocation-latency trade-off. #526 is left open and undecided.

### Two details worth a reviewer's eye

- **A distinct `requestKey`** is pinned on the notifications read, per the repo's convention for concurrent call sites (`$lib/server/userPreferences.ts`, `$lib/server/trust.ts`). Safe because `cancelControllers` is a per-`Client` instance field and `hooks.server.ts` builds a new client per request, so a fixed key is scoped to a single request — it cannot collide across requests or leak between users. Concurrency is safe among the three reads regardless: the two `locals.pb` reads hit different paths, and `isAdmin` runs on the separate superuser client.
- **The catch stays per-promise.** `Promise.all` rejects on the first rejection, so a group-level catch would drop the other two reads with it. Error outcomes are otherwise identical to before: a missing `notifications` collection still yields a count of 0; preferences and `isAdmin` still swallow their own failures internally.

No behavior change, no schema change, no user-facing strings. No docs needed — the "Keep in sync" rule covers routes/endpoints/collections/helpers/env vars, none of which this touches, and the two doc mentions of the root layout describe *what* it computes, not the ordering.

## Test notes

Preflight, all green: `npm run lint` · `npm run check` (0 errors, 10 pre-existing warnings) · `npx vitest run` (**705 passed / 67 files**) · `npm run build`.

Three tests added to `src/routes/layout.server.test.ts`:
- **concurrency** — holds the notifications read open and asserts the sibling reads were already issued. Verified to **fail against the old sequential code**, so a regression to sequencing cannot slip through.
- the `requestKey` on the notifications read.
- a failing notifications query does not sink the preferences and admin reads (the regression `Promise.all` would otherwise introduce).

E2E was run against a local stack. The suite is flaky in that environment **on `main` too** (the `locked user` auth setup and `search-focus.spec.ts:29` fail intermittently there, with varying errors). With `--retries=2` the suspect specs — `feedback`, `groups`, `lending` — pass 11/11 on **both** `main` and this branch, so no regression.

**Reviewer:** worth a click through the notification badge, the admin nav link, and a logged-out page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)