### PR TITLE
feat(seo): name the instance city in metadata and add page h1s

### DIFF
--- a/docs/text-management.md
+++ b/docs/text-management.md
@@ -94,7 +94,7 @@ return fail(400, {
 | `onboarding` | 10-step post-registration onboarding wizard texts |
 | `notifications` | Notification inbox text; also contains the push notification title |
 | `lending` | Lending workflow status labels, action buttons, and role-specific descriptions (owner vs. borrower) |
-| `seo` | `<title>` and `<meta description>` values for each page |
+| `seo` | `<title>` and `<meta description>` values for each page. The entries with local search intent (`home`, `search`, `about`, `guide`, `contact`, `itemDetail*`) interpolate the city from `CITY` (`$lib/instance.ts`) and must never hardcode it — one build serves several city instances, and a test enforces it. `APP_NAME` is only partially adopted; the block comment above `seo` in `texts.ts` explains why and lists the pages deliberately left without a city. Title ≤ 60 / description ≤ 155 chars is the guideline; it is enforced only for the local-intent entries (`LOCAL_PAGES` in `src/lib/texts.test.ts`) — some older strings exceed it |
 | `onboardingPrompt` | Nudge banner shown to users who skipped or have not completed onboarding |
 | `pwa` | PWA install prompt and browser notification permission banner |
 | `alerts` | Flash message prefix strings |

--- a/e2e/fixtures/instance.ts
+++ b/e2e/fixtures/instance.ts
@@ -1,0 +1,15 @@
+/**
+ * Instance values the e2e specs assert against.
+ *
+ * Duplicated from `$lib/instance.ts`'s defaults rather than imported: e2e specs run outside
+ * the Vite/SvelteKit `$lib` alias resolution the unit tests get, and the e2e dev server
+ * (`playwright.config.ts` → webServer) starts with no `PUBLIC_*` overrides, so the defaults
+ * are what the app actually serves. Kept here, not inline per spec, so there is one place to
+ * change when the reference instance changes.
+ */
+
+/** `instance.city` default — see `$lib/instance.ts`. */
+export const CITY = 'Lüneburg';
+
+/** `instance.origin` default (`DEFAULT_ORIGIN`) — see `$lib/instance.ts`. */
+export const ORIGIN = 'https://allerleih.org';

--- a/e2e/fixtures/instance.ts
+++ b/e2e/fixtures/instance.ts
@@ -2,10 +2,12 @@
  * Instance values the e2e specs assert against.
  *
  * Duplicated from `$lib/instance.ts`'s defaults rather than imported: e2e specs run outside
- * the Vite/SvelteKit `$lib` alias resolution the unit tests get, and the e2e dev server
- * (`playwright.config.ts` → webServer) starts with no `PUBLIC_*` overrides, so the defaults
- * are what the app actually serves. Kept here, not inline per spec, so there is one place to
- * change when the reference instance changes.
+ * the Vite/SvelteKit `$lib` alias resolution the unit tests get. `playwright.config.ts` imports
+ * these same constants and pins them into the e2e dev server's `webServer.env` (`PUBLIC_INSTANCE_CITY`
+ * / `PUBLIC_SITE_ORIGIN`), so the values here don't just describe the app's defaults — they drive
+ * what the dev server actually serves, overriding any `PUBLIC_*` a developer's local `.env` sets
+ * for their own multi-city work. Kept here, not inline per spec, so there is one place to change
+ * when the reference instance changes.
  */
 
 /** `instance.city` default — see `$lib/instance.ts`. */

--- a/e2e/tests/seo-canonical.spec.ts
+++ b/e2e/tests/seo-canonical.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { ORIGIN } from '../fixtures/instance';
 
 /**
  * Regression test for issue #473 (round 4): `SeoHead`'s canonical link and the invite page's
@@ -17,11 +18,6 @@ import { test, expect } from '@playwright/test';
  * `page.request.get()` fetches the raw HTML the way a crawler (or `curl`) would — no browser
  * rendering, so no hydration to paper over a wrong SSR value.
  */
-
-// The e2e dev server (playwright.config.ts webServer) runs with no PUBLIC_SITE_ORIGIN override,
-// so `$lib/instance`'s DEFAULT_ORIGIN applies. Not imported from `src/lib/instance.ts`: e2e specs
-// run outside the Vite/SvelteKit `$lib` alias resolution the unit tests get.
-const ORIGIN = 'https://allerleih.org';
 
 test.describe('canonical / og:url — raw SSR HTML (issue #473 round 4 regression)', () => {
 	test('root route has a clean canonical link', async ({ page }) => {

--- a/e2e/tests/seo-local.spec.ts
+++ b/e2e/tests/seo-local.spec.ts
@@ -10,8 +10,7 @@ import { test, expect } from '@playwright/test';
  *
  * Why this can't live in a unit test: `src/lib/texts.test.ts` pins the *strings*, but nothing
  * unit-level proves they reach the rendered `<title>`/`<meta>` or that the markup uses a
- * heading element. Note the trade-off — per `docs/testing-strategy.md` the e2e suite does not
- * run in CI, so this file is a local/manual gate, not an automated one.
+ * heading element.
  */
 
 import { CITY } from '../fixtures/instance';

--- a/e2e/tests/seo-local.spec.ts
+++ b/e2e/tests/seo-local.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Local-SEO regressions: the indexable public pages must carry the instance's city in the
+ * metadata a crawler actually reads, and must have exactly one `<h1>`.
+ *
+ * Why raw `page.request.get()` for the metadata (same reasoning as `seo-canonical.spec.ts`):
+ * a crawler reads the server response, not a hydrated DOM. Asserting on the raw HTML is the
+ * only way to see what Google sees.
+ *
+ * Why this can't live in a unit test: `src/lib/texts.test.ts` pins the *strings*, but nothing
+ * unit-level proves they reach the rendered `<title>`/`<meta>` or that the markup uses a
+ * heading element. Note the trade-off — per `docs/testing-strategy.md` the e2e suite does not
+ * run in CI, so this file is a local/manual gate, not an automated one.
+ */
+
+import { CITY } from '../fixtures/instance';
+
+test.describe('local SEO — raw SSR metadata', () => {
+	for (const path of ['/', '/search']) {
+		test(`${path} names the city in its title and description`, async ({ page }) => {
+			const res = await page.request.get(path);
+			expect(res.ok()).toBeTruthy();
+			const html = await res.text();
+
+			const title = html.match(/<title>([^<]*)<\/title>/)?.[1];
+			expect(title, `${path} should render a <title>`).toBeDefined();
+			expect(title).toContain(CITY);
+
+			// Attribute-order-agnostic: `SeoHead.svelte` renders name-then-content today, but a
+			// reordering there should not read as "meta description missing".
+			const description = html.match(
+				/<meta[^>]*\bname="description"[^>]*\bcontent="([^"]*)"/
+			)?.[1];
+			expect(description, `${path} should render a meta description`).toBeDefined();
+			expect(description).toContain(CITY);
+		});
+	}
+});
+
+test.describe('local SEO — heading structure', () => {
+	for (const path of ['/', '/search']) {
+		test(`${path} has exactly one h1, naming the city`, async ({ page }) => {
+			await page.goto(path);
+			const h1 = page.getByRole('heading', { level: 1 });
+			await expect(h1).toHaveCount(1);
+			await expect(h1).toContainText(CITY);
+		});
+	}
+});

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -8,6 +8,8 @@ test.describe('smoke (logged out)', () => {
 		await page.goto('/');
 
 		await expect(page).toHaveTitle(/AllerLeih/);
+		// Stays a plain text assertion: the smoke test's job is "the page renders". The
+		// tagline's heading level is pinned once, in `seo-local.spec.ts`.
 		await expect(
 			page.getByText('Leihe und teile kostenlos Dinge in Lüneburg')
 		).toBeVisible();

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from '@playwright/test';
 import { STORAGE_STATE } from './e2e/fixtures/users';
+import { CITY, ORIGIN } from './e2e/fixtures/instance';
 
 /**
  * End-to-end tests (see e2e/README.md).
@@ -93,6 +94,8 @@ export default defineConfig({
 		env: {
 			PUBLIC_PB_URL: pbUrl,
 			DEV_DISABLE_MKCERT: 'true',
+			PUBLIC_INSTANCE_CITY: CITY,
+			PUBLIC_SITE_ORIGIN: ORIGIN,
 		},
 	},
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
 				'tests/search-focus.spec.ts',
 				'tests/search-focus.mobile.spec.ts',
 				'tests/seo-canonical.spec.ts',
+				'tests/seo-local.spec.ts',
 			],
 		},
 		{

--- a/src/lib/texts.test.ts
+++ b/src/lib/texts.test.ts
@@ -25,6 +25,9 @@ import { texts } from './texts';
 const TITLE_MAX = 60;
 const DESCRIPTION_MAX = 155;
 
+/** Mirrors `$lib/instance.ts`'s `city` fallback — the default instance's reference city. */
+const DEFAULT_CITY = 'Lüneburg';
+
 /**
  * Item name that must still fit inside `TITLE_MAX` alongside the fixed part of the item-detail
  * title. Expressed as a name budget rather than pinning the fixed part's exact length: pinning
@@ -53,26 +56,26 @@ const LOCAL_PAGES = [
 describe('texts.seo — local SEO strings (default instance)', () => {
 	it.each(LOCAL_PAGES)('$key: title names the city and fits the budget', (entry) => {
 		if ('cityInTitle' in entry && entry.cityInTitle === false) {
-			expect(entry.title).not.toContain('Lüneburg');
+			expect(entry.title).not.toContain(DEFAULT_CITY);
 		} else {
-			expect(entry.title).toContain('Lüneburg');
+			expect(entry.title).toContain(DEFAULT_CITY);
 		}
 		expect(entry.title.length).toBeLessThanOrEqual(TITLE_MAX);
 	});
 
 	it.each(LOCAL_PAGES)('$key: description names the city and fits the budget', (entry) => {
-		expect(entry.description).toContain('Lüneburg');
+		expect(entry.description).toContain(DEFAULT_CITY);
 		expect(entry.description.length).toBeLessThanOrEqual(DESCRIPTION_MAX);
 	});
 
 	it('uses the city in the visible /search heading', () => {
-		expect(texts.pages.search.title).toContain('Lüneburg');
+		expect(texts.pages.search.title).toContain(DEFAULT_CITY);
 	});
 
 	describe('item detail', () => {
 		it('names the city in both title and description', () => {
-			expect(texts.seo.itemDetail('Bohrmaschine')).toContain('Lüneburg');
-			expect(texts.seo.itemDetailDescription('Bohrmaschine', 'Anna')).toContain('Lüneburg');
+			expect(texts.seo.itemDetail('Bohrmaschine')).toContain(DEFAULT_CITY);
+			expect(texts.seo.itemDetailDescription('Bohrmaschine', 'Anna')).toContain(DEFAULT_CITY);
 		});
 
 		it('leaves room in the title budget for a typical item name', () => {
@@ -105,6 +108,11 @@ describe('texts.seo — city is interpolated, not hardcoded', () => {
 	 * Scoped to `texts.seo` on purpose: `texts.pages.imprint.address.city` is legitimately
 	 * "Lüneburg" — it comes from `instance.imprint`, the operator's postal address (§5 TMG),
 	 * which is deliberately *not* per-instance. A repo-wide walk would fail on it.
+	 *
+	 * Assumes every function under `texts.seo` takes 1–2 string args — it calls each with
+	 * `('X', 'Y')` regardless of arity. Adding a 3-arg entry will fail this test with an opaque
+	 * runtime error (wrong argument, `undefined` in the output, etc.); if that happens, extend
+	 * the call here rather than debugging the entry itself.
 	 */
 	function collectSeoStrings(node: unknown): string[] {
 		if (typeof node === 'string') return [node];
@@ -132,7 +140,7 @@ describe('texts.seo — city is interpolated, not hardcoded', () => {
 		// The regression this whole file exists for: any future hardcoded "Lüneburg" anywhere
 		// under `texts.seo` fails here, not just in the keys this change happened to touch.
 		for (const value of strings) {
-			expect(value).not.toContain('Lüneburg');
+			expect(value).not.toContain(DEFAULT_CITY);
 		}
 		expect(strings.filter((value) => value.includes('Marburg')).length).toBeGreaterThan(0);
 	});

--- a/src/lib/texts.test.ts
+++ b/src/lib/texts.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Hermetic default env — same reasoning as `instance.test.ts`: a local `.env` may set real
+// PUBLIC_* vars for dev, which would otherwise decide what "no env vars set" means here.
+vi.mock('$env/dynamic/public', () => ({ env: {} }));
+
+import { texts } from './texts';
+
+/**
+ * Guards the local-SEO strings (`texts.seo`, plus the visible `/search` h1).
+ *
+ * Two things are pinned, and only these:
+ *  1. The indexable pages carry the instance's city — the whole point of the change. Without
+ *     it the site only ranked on its brand name; "leihen <Stadt>" matched nothing.
+ *  2. The city is *interpolated from `instance.city`*, never a literal. One build artifact
+ *     serves N city instances (see `$lib/instance.ts`), so a hardcoded "Lüneburg" would ship
+ *     the wrong city to every other instance — silently, since nothing else would break.
+ *
+ * Deliberately NOT tested here: the `<h1>` markup changes on `/` and `/search`. Per
+ * `write-tests`, component rendering has no harness in this repo and this change is not the
+ * place to introduce one — those are covered by the Playwright specs instead.
+ */
+
+/** Titles Google truncates past ~60 chars; descriptions past ~155. */
+const TITLE_MAX = 60;
+const DESCRIPTION_MAX = 155;
+
+/**
+ * Item name that must still fit inside `TITLE_MAX` alongside the fixed part of the item-detail
+ * title. Expressed as a name budget rather than pinning the fixed part's exact length: pinning
+ * mirrors `CITY` + `APP_NAME` into this file and fails with "expected 36 to be 31" the moment
+ * either changes, even when the title is still perfectly fine. Phrased this way a failure means
+ * the budget is genuinely used up — whether from padding the fixed part or from a longer city.
+ */
+const ITEM_NAME_BUDGET = 29;
+
+/**
+ * The indexable pages whose metadata should name the city. One row per page, so adding a new
+ * SEO entry means touching one list — three parallel `it.each` blocks would let a new page slip
+ * into only one of them and be silently half-tested.
+ *
+ * `cityInTitle: false` marks a deliberate exception: "Wie funktioniert AllerLeih?" is a brand
+ * query, so the city belongs in its description only.
+ */
+const LOCAL_PAGES = [
+	{ key: 'home', ...texts.seo.home },
+	{ key: 'search', ...texts.seo.search },
+	{ key: 'about', ...texts.seo.about },
+	{ key: 'guide', ...texts.seo.guide, cityInTitle: false },
+	{ key: 'contact', ...texts.seo.contact },
+] as const;
+
+describe('texts.seo — local SEO strings (default instance)', () => {
+	it.each(LOCAL_PAGES)('$key: title names the city and fits the budget', (entry) => {
+		if ('cityInTitle' in entry && entry.cityInTitle === false) {
+			expect(entry.title).not.toContain('Lüneburg');
+		} else {
+			expect(entry.title).toContain('Lüneburg');
+		}
+		expect(entry.title.length).toBeLessThanOrEqual(TITLE_MAX);
+	});
+
+	it.each(LOCAL_PAGES)('$key: description names the city and fits the budget', (entry) => {
+		expect(entry.description).toContain('Lüneburg');
+		expect(entry.description.length).toBeLessThanOrEqual(DESCRIPTION_MAX);
+	});
+
+	it('uses the city in the visible /search heading', () => {
+		expect(texts.pages.search.title).toContain('Lüneburg');
+	});
+
+	describe('item detail', () => {
+		it('names the city in both title and description', () => {
+			expect(texts.seo.itemDetail('Bohrmaschine')).toContain('Lüneburg');
+			expect(texts.seo.itemDetailDescription('Bohrmaschine', 'Anna')).toContain('Lüneburg');
+		});
+
+		it('leaves room in the title budget for a typical item name', () => {
+			expect(texts.seo.itemDetail('x'.repeat(ITEM_NAME_BUDGET)).length).toBeLessThanOrEqual(
+				TITLE_MAX
+			);
+		});
+	});
+
+	describe('item detail — owner placement', () => {
+		it('keeps the owner out of the title (it costs characters and earns no ranking)', () => {
+			expect(texts.seo.itemDetail('Bohrmaschine')).not.toContain('Anna');
+		});
+
+		it('names both item and owner in the description', () => {
+			const description = texts.seo.itemDetailDescription('Bohrmaschine', 'Anna');
+			expect(description).toContain('Bohrmaschine');
+			expect(description).toContain('Anna');
+		});
+	});
+});
+
+describe('texts.seo — city is interpolated, not hardcoded', () => {
+	beforeEach(() => vi.resetModules());
+	afterEach(() => vi.doUnmock('$env/dynamic/public'));
+
+	/**
+	 * Walks every string reachable under `texts.seo`, calling functions with placeholder args.
+	 *
+	 * Scoped to `texts.seo` on purpose: `texts.pages.imprint.address.city` is legitimately
+	 * "Lüneburg" — it comes from `instance.imprint`, the operator's postal address (§5 TMG),
+	 * which is deliberately *not* per-instance. A repo-wide walk would fail on it.
+	 */
+	function collectSeoStrings(node: unknown): string[] {
+		if (typeof node === 'string') return [node];
+		if (typeof node === 'function') {
+			const produced = (node as (...args: string[]) => unknown)('X', 'Y');
+			// Fail loudly instead of returning []: an entry that doesn't yield a string would
+			// otherwise drop out of the hardcoding guard below without anyone noticing.
+			if (typeof produced !== 'string') {
+				throw new Error(
+					`texts.seo contains a function returning ${typeof produced}; extend collectSeoStrings() so it stays covered by the hardcoded-city guard.`
+				);
+			}
+			return [produced];
+		}
+		if (node && typeof node === 'object') return Object.values(node).flatMap(collectSeoStrings);
+		return [];
+	}
+
+	it('renders every seo string with the configured city and no trace of the default', async () => {
+		vi.doMock('$env/dynamic/public', () => ({ env: { PUBLIC_INSTANCE_CITY: 'Marburg' } }));
+		const { texts: overridden } = await import('./texts');
+
+		const strings = collectSeoStrings(overridden.seo);
+		expect(strings.length).toBeGreaterThan(0);
+		// The regression this whole file exists for: any future hardcoded "Lüneburg" anywhere
+		// under `texts.seo` fails here, not just in the keys this change happened to touch.
+		for (const value of strings) {
+			expect(value).not.toContain('Lüneburg');
+		}
+		expect(strings.filter((value) => value.includes('Marburg')).length).toBeGreaterThan(0);
+	});
+
+	it('carries the configured city into the visible /search heading', async () => {
+		vi.doMock('$env/dynamic/public', () => ({ env: { PUBLIC_INSTANCE_CITY: 'Marburg' } }));
+		const { texts: overridden } = await import('./texts');
+		expect(overridden.pages.search.title).toBe('Gegenstände leihen in Marburg');
+	});
+});

--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -1223,8 +1223,8 @@ export const texts = {
 	// ein Build-Artefakt bedient mehrere Stadt-Instanzen (siehe `$lib/instance.ts`).
 	// `src/lib/texts.test.ts` pinnt beides — Ortsbezug und Interpolierbarkeit.
 	//
-	// Bewusst OHNE Ort — die Liste ist vollständig, damit niemand einen der Fälle für ein
-	// Versehen hält:
+	// Bewusst OHNE Ort — Stand dieser Änderung vollständig, damit niemand einen der Fälle für ein
+	// Versehen hält (spätere Ergänzungen bitte hier nachpflegen):
 	//   · noindex-Seiten, die kein Crawler sieht: adminMetrics, conversations, social,
 	//     onboarding, userImport, register, resetConfirm, confirmVerification,
 	//     confirmEmailChange

--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -672,7 +672,10 @@ export const texts = {
 			},
 		},
 		search: {
-			title: 'Suche',
+			// Sichtbare <h1> von `/search` (nicht der Navigationslabel — das ist `nav.search`).
+			// Trägt den Ort, weil `/search` eine indexierbare Landingpage ist und ein blankes
+			// "Suche" als h1 kein lokales Signal liefert.
+			title: `Gegenstände leihen in ${CITY}`,
 			welcome: 'Nutze einfach die Suche oben oder',
 			description:
 				'Bei AllerLeih findest du allerlei Dinge aus deiner Umgebung zum leihen, teilen, mieten, ...',
@@ -1211,22 +1214,44 @@ export const texts = {
 		},
 	},
 
-	// SEO meta titles and descriptions
+	// SEO meta titles and descriptions.
+	//
+	// Lokale Auffindbarkeit: die indexierbaren Seiten tragen den Ortsnamen (`CITY`) in Title
+	// und/oder Description. Ohne ihn rankte die Instanz nur auf den Markennamen — lokale
+	// Anfragen wie "leihen <Stadt>" oder "bohrmaschine leihen <Stadt>" fanden keinerlei
+	// Übereinstimmung. Der Ort kommt IMMER aus `CITY` (= `instance.city`), nie als Literal:
+	// ein Build-Artefakt bedient mehrere Stadt-Instanzen (siehe `$lib/instance.ts`).
+	// `src/lib/texts.test.ts` pinnt beides — Ortsbezug und Interpolierbarkeit.
+	//
+	// Bewusst OHNE Ort — die Liste ist vollständig, damit niemand einen der Fälle für ein
+	// Versehen hält:
+	//   · noindex-Seiten, die kein Crawler sieht: adminMetrics, conversations, social,
+	//     onboarding, userImport, register, resetConfirm, confirmVerification,
+	//     confirmEmailChange
+	//   · indexierbar, aber ohne lokale Suchintention: login, reset, app, publicStats,
+	//     newsletter
+	//   · userProfile/userProfileDescription: die Query ist der Username, nicht der Ort
+	//   · imprint: trägt die Postadresse ohnehin
+	//
+	// Gemischtes Bild `${APP_NAME}` vs. Literal "AllerLeih" ist ebenfalls Absicht: Fortsetzung
+	// der partiellen #473-Entscheidung (siehe `$lib/instance.ts` → `appName`). Umgestellt sind
+	// nur die ohnehin angefassten Strings; die übrigen ~89 Vorkommen in der deutschen Copy
+	// bleiben Literale. Neue oder überarbeitete Strings nutzen `${APP_NAME}`.
+	//
+	// Längenbudget der angefassten Strings: Title ≤ 60, Description ≤ 155 Zeichen (ab da
+	// kürzen Suchmaschinen). Im Test als `it.each` hinterlegt.
 	seo: {
 		home: {
-			title: 'AllerLeih',
-			description:
-				'Kostenlos Gegenstände leihen und teilen mit Menschen in deiner Umgebung. Spare Geld, Platz und Ressourcen und stärke deine Gemeinschaft.',
+			title: `Dinge leihen und verleihen in ${CITY} – ${APP_NAME}`,
+			description: `Kostenlos Dinge leihen und verleihen in ${CITY} und Umgebung: Werkzeug, Garten, Küche, Sport und mehr. Spare Geld, Platz und Ressourcen.`,
 		},
 		search: {
-			title: 'Gegenstände suchen – AllerLeih',
-			description:
-				'Durchsuche Gegenstände in deiner Nähe. Filtere nach Kategorie und Entfernung und finde, was du brauchst.',
+			title: `Gegenstände ausleihen in ${CITY} – ${APP_NAME}`,
+			description: `Durchsuche Gegenstände zum Ausleihen in ${CITY} und Umgebung. Filtere nach Kategorie und Entfernung und finde kostenlos, was du gerade brauchst.`,
 		},
 		about: {
-			title: 'Über uns – AllerLeih',
-			description:
-				'AllerLeih ist eine gemeinnützige Plattform für lokales Leihen und Teilen. Lerne das Team dahinter kennen.',
+			title: `Über uns – ${APP_NAME} ${CITY}`,
+			description: `${APP_NAME} ist eine gemeinnützige Initiative aus ${CITY} für lokales Leihen und Teilen. Lerne das Team dahinter kennen.`,
 		},
 		adminMetrics: {
 			title: 'Kennzahlen – Admin – AllerLeih',
@@ -1237,9 +1262,9 @@ export const texts = {
 				'Offene Kennzahlen der AllerLeih-Plattform: registrierte Nutzer:innen, verfügbare Gegenstände und abgeschlossene Ausleihen.',
 		},
 		guide: {
+			// Title bleibt ohne Ort: "Wie funktioniert AllerLeih?" ist eine Brand-Query.
 			title: 'Wie funktioniert AllerLeih? – Anleitung',
-			description:
-				'Schritt-für-Schritt-Anleitungen zum Leihen und Verleihen auf AllerLeih. Tipps, FAQs und erste Schritte.',
+			description: `Schritt-für-Schritt-Anleitungen zum Leihen und Verleihen in ${CITY}. Tipps, FAQs und erste Schritte mit ${APP_NAME}.`,
 		},
 		app: {
 			title: 'AllerLeih als App installieren',
@@ -1247,8 +1272,8 @@ export const texts = {
 				'Lege AllerLeih als App auf deinen Startbildschirm – ohne App-Store. So installierst du die Progressive Web App Schritt für Schritt auf iPhone, Android und Computer.',
 		},
 		contact: {
-			title: 'Kontakt – AllerLeih',
-			description: 'Schreib uns! Fragen, Feedback oder Kooperationsanfragen sind herzlich willkommen.',
+			title: `Kontakt – ${APP_NAME} ${CITY}`,
+			description: `Schreib uns! Fragen, Feedback oder Kooperationsanfragen rund um ${APP_NAME} in ${CITY} sind herzlich willkommen.`,
 		},
 		imprint: {
 			title: 'Impressum – AllerLeih',
@@ -1285,9 +1310,15 @@ export const texts = {
 			title: 'Neue E-Mail-Adresse bestätigen – AllerLeih',
 			description: 'Bestätige die Änderung deiner E-Mail-Adresse für dein AllerLeih-Konto.',
 		},
-		itemDetail: (name: string, owner: string) => `${name} leihen bei ${owner} – AllerLeih`,
+		// Der Owner steht bewusst NICHT mehr im Title: er bringt kein Ranking und verdrängt
+		// bei langen Item-Namen den Ortsnamen aus dem angezeigten Snippet. Sein Platz ist die
+		// Description. Der Fixteil muss einem Item-Namen von ~29 Zeichen Platz im 60-Zeichen-
+		// Budget lassen (im Test gepinnt); bei längeren Namen kürzt Google nach Pixelbreite,
+		// der Ort steht direkt hinter dem Namen und überlebt das in aller Regel. Bewusst
+		// keine Kürzungslogik hier.
+		itemDetail: (name: string) => `${name} leihen in ${CITY} – ${APP_NAME}`,
 		itemDetailDescription: (name: string, owner: string) =>
-			`Leihe ${name} von ${owner} über AllerLeih – die kostenlose Plattform zum Teilen in deiner Umgebung.`,
+			`Leihe ${name} von ${owner} in ${CITY} – kostenlos und nachbarschaftlich über ${APP_NAME}.`,
 		userProfile: (username: string) => `@${username} – AllerLeih`,
 		userProfileDescription: (username: string) =>
 			`Sieh dir die Gegenstände von @${username} auf AllerLeih an und kontaktiere ihn oder sie für eine Leihanfrage.`,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -115,12 +115,12 @@
 			<div class="text-center lg:text-left">
 				<img src="/AllerLeih.png" alt={texts.names.app} class="h-32 mx-auto" />
 				<!--
-					Die Tagline ist das <h1> der Startseite — sie enthält Tätigkeit und Ort und ist
-					damit der einzige Text hier, der als Seitenüberschrift taugt (das Logo ist ein
-					Bild). Vorher war sie ein <p>, die Seite hatte GAR KEIN h1 und begann mit den
-					Überschriften der Info-Cards (axe: `page-has-heading-one`, WCAG 1.3.1).
-					Tailwind Preflight entstylt Headings (font-size/-weight/margin: inherit bzw. 0),
-					und die Klassen sind unverändert übernommen — der Tausch ist pixelgleich.
+					The tagline is the homepage's <h1> — it contains both the activity and the
+					location, making it the only text here that qualifies as a page heading (the
+					logo is an image). It used to be a <p>, and the page had NO h1 at all, starting
+					instead with the info cards' headings (axe: `page-has-heading-one`, WCAG 1.3.1).
+					Tailwind Preflight strips heading styling (font-size/-weight/margin: inherit or
+					0), and the classes carried over unchanged — the swap is pixel-identical.
 				-->
 				<h1
 					class="text-center text-tinte-500 lg:text-xl dark:text-tinte-400 mb-8"
@@ -156,8 +156,8 @@
 		>
 			{#each internalInfoCards as card (card.title)}
 				<div class={styles.card}>
-					<!-- h2, nicht h3: unter dem neuen h1 wäre h3 eine übersprungene Ebene (axe
-					     `heading-order`). Klassen unverändert ⇒ optisch identisch. -->
+					<!-- h2, not h3: under the new h1, h3 would be a skipped level (axe
+					     `heading-order`). Classes unchanged ⇒ visually identical. -->
 					<h2 class={styles.cardTitle}>{card.title}</h2>
 					<p class={styles.cardBody}>
 						{card.before}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -114,11 +114,19 @@
 		>
 			<div class="text-center lg:text-left">
 				<img src="/AllerLeih.png" alt={texts.names.app} class="h-32 mx-auto" />
-				<p
+				<!--
+					Die Tagline ist das <h1> der Startseite — sie enthält Tätigkeit und Ort und ist
+					damit der einzige Text hier, der als Seitenüberschrift taugt (das Logo ist ein
+					Bild). Vorher war sie ein <p>, die Seite hatte GAR KEIN h1 und begann mit den
+					Überschriften der Info-Cards (axe: `page-has-heading-one`, WCAG 1.3.1).
+					Tailwind Preflight entstylt Headings (font-size/-weight/margin: inherit bzw. 0),
+					und die Klassen sind unverändert übernommen — der Tausch ist pixelgleich.
+				-->
+				<h1
 					class="text-center text-tinte-500 lg:text-xl dark:text-tinte-400 mb-8"
 				>
 					{landingTexts.tagline} <span class="font-bold text-tinte-700">{texts.names.city}</span>
-				</p>
+				</h1>
 				<div class="flex flex-col sm:flex-row justify-center gap-3">
 					{#each ctaButtons as cta (cta.href)}
 						<Button href={cta.href} color={cta.color} size="xl" class="w-full sm:w-auto">
@@ -148,7 +156,9 @@
 		>
 			{#each internalInfoCards as card (card.title)}
 				<div class={styles.card}>
-					<h3 class={styles.cardTitle}>{card.title}</h3>
+					<!-- h2, nicht h3: unter dem neuen h1 wäre h3 eine übersprungene Ebene (axe
+					     `heading-order`). Klassen unverändert ⇒ optisch identisch. -->
+					<h2 class={styles.cardTitle}>{card.title}</h2>
 					<p class={styles.cardBody}>
 						{card.before}
 						<a href={resolve(card.route)} class={styles.cardLink}
@@ -158,7 +168,7 @@
 				</div>
 			{/each}
 			<div class={styles.card}>
-				<h3 class={styles.cardTitle}>{contributeInfoCard.title}</h3>
+				<h2 class={styles.cardTitle}>{contributeInfoCard.title}</h2>
 				<p class={styles.cardBody}>
 					{contributeInfoCard.before}
 					<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- buildRedirectHref() returns an already-resolved /api/redirect proxy URL; the rule cannot see through the call -->

--- a/src/routes/items/[id]/+page.svelte
+++ b/src/routes/items/[id]/+page.svelte
@@ -6,7 +6,7 @@
 	import { texts } from '$lib/texts';
 	import { instanceUrl } from '$lib/instance';
 	import { getCategoryPlaceholder } from '$lib/utils/categoryPlaceholder';
-	import { itemImageUrl, itemImageUrls } from '$lib/utils/utils';
+	import { itemImageUrl, itemImageUrls, displayName } from '$lib/utils/utils';
 	import type { ItemPublic, UserPublic } from '$lib/types/models';
 	import ItemImage from './ItemImage.svelte';
 	import ItemTravelTime from './ItemTravelTime.svelte';
@@ -55,10 +55,7 @@
 	const seoDesc = $derived(
 		item.description
 			? item.description.replace(/\s+/g, ' ').trim().slice(0, 155)
-			: texts.seo.itemDetailDescription(
-					item.name,
-					item.username ?? ''
-				)
+			: texts.seo.itemDetailDescription(item.name, displayName(owner))
 	);
 	const seoImage = $derived(itemImageUrl(data.PB_IMG_URL, item) ?? instanceUrl('/og-invite.png'));
 </script>

--- a/src/routes/items/[id]/+page.svelte
+++ b/src/routes/items/[id]/+page.svelte
@@ -51,7 +51,7 @@
 			: null
 	);
 
-	const seoTitle = $derived(texts.seo.itemDetail(item.name, item.username ?? ''));
+	const seoTitle = $derived(texts.seo.itemDetail(item.name));
 	const seoDesc = $derived(
 		item.description
 			? item.description.replace(/\s+/g, ' ').trim().slice(0, 155)

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -124,9 +124,9 @@
 <!-- HEADER -->
 <div class="mx-auto max-w-7xl">
 	<div class="mx-auto max-w-screen-sm text-center">
-		<!-- h1, nicht h2: /search steht in der Sitemap, ist ohne Auth erreichbar und trägt kein
-		     noindex — eine indexierbare Landingpage ohne h1. Klassen unverändert (Tailwind
-		     Preflight entstylt Headings), der Tausch ist optisch folgenlos. -->
+		<!-- h1, not h2: /search is in the sitemap, reachable without auth, and carries no
+		     noindex — an indexable landing page without an h1. Classes unchanged (Tailwind
+		     Preflight strips heading styling), the swap has no visual effect. -->
 		<h1 class="text-2xl tracking-tight font-extrabold text-tinte-900 dark:text-white">
 			{texts.pages.search.title}
 		</h1>
@@ -161,17 +161,17 @@
 	/>
 
 	<!--
-		Statuszeile, KEIN Heading. Vorher standen hier zwei <h5> — die richtige Antwort auf den
-		daraus folgenden `heading-order`-Sprung unter dem neuen h1 ist nicht ein höheres Heading,
-		sondern gar keins: "12 Dinge gefunden" ist eine Statusmeldung, keine Abschnitts-
-		überschrift. Als Heading wäre die Dokumentgliederung von /search instabil (der Text
-		wechselt bei jedem Filter) und Screenreader würden bei jedem Ergebnis-Update die Rolle
-		mit ansagen ("Überschrift Ebene 2, 12 Dinge gefunden"). WCAG 1.3.1.
-		`role="status"` impliziert `aria-live="polite"` und `aria-atomic="true"` bereits; beide
-		stehen defensiv trotzdem explizit da, weil ältere Screenreader/Browser-Kombinationen die
-		impliziten Werte nicht zuverlässig anwenden. Kein `aria-busy` — die Zeile hat keinen
-		eigenen Ladezustand, Ergebnis-Updates laufen über die SvelteKit-Navigation und deren
-		globaler Loader in `+layout.svelte` trägt es bereits.
+		Status line, NOT a heading. This used to be two <h5>s — the right fix for the resulting
+		`heading-order` jump under the new h1 isn't a higher heading, it's no heading at all:
+		"12 items found" is a status message, not a section heading. As a heading, /search's
+		document outline would be unstable (the text changes on every filter) and screen readers
+		would announce the role on every result update ("heading level 2, 12 items found").
+		WCAG 1.3.1.
+		`role="status"` already implies `aria-live="polite"` and `aria-atomic="true"`; both are
+		still listed explicitly as a defensive measure, because some older screen reader/browser
+		combinations don't reliably apply the implicit values. No `aria-busy` — the line has no
+		loading state of its own, result updates go through SvelteKit navigation, and the global
+		loader in `+layout.svelte` already covers that.
 	-->
 	<div
 		class="w-full items-center justify-center text-center mt-2"

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -124,9 +124,12 @@
 <!-- HEADER -->
 <div class="mx-auto max-w-7xl">
 	<div class="mx-auto max-w-screen-sm text-center">
-		<h2 class="text-2xl tracking-tight font-extrabold text-tinte-900 dark:text-white">
+		<!-- h1, nicht h2: /search steht in der Sitemap, ist ohne Auth erreichbar und trägt kein
+		     noindex — eine indexierbare Landingpage ohne h1. Klassen unverändert (Tailwind
+		     Preflight entstylt Headings), der Tausch ist optisch folgenlos. -->
+		<h1 class="text-2xl tracking-tight font-extrabold text-tinte-900 dark:text-white">
 			{texts.pages.search.title}
-		</h2>
+		</h1>
 	</div>
 </div>
 
@@ -157,11 +160,29 @@
 		onApply={handleApply}
 	/>
 
-	<div class="w-full items-center justify-center text-center mt-2" aria-live="polite">
+	<!--
+		Statuszeile, KEIN Heading. Vorher standen hier zwei <h5> — die richtige Antwort auf den
+		daraus folgenden `heading-order`-Sprung unter dem neuen h1 ist nicht ein höheres Heading,
+		sondern gar keins: "12 Dinge gefunden" ist eine Statusmeldung, keine Abschnitts-
+		überschrift. Als Heading wäre die Dokumentgliederung von /search instabil (der Text
+		wechselt bei jedem Filter) und Screenreader würden bei jedem Ergebnis-Update die Rolle
+		mit ansagen ("Überschrift Ebene 2, 12 Dinge gefunden"). WCAG 1.3.1.
+		`role="status"` impliziert `aria-live="polite"` und `aria-atomic="true"` bereits; beide
+		stehen defensiv trotzdem explizit da, weil ältere Screenreader/Browser-Kombinationen die
+		impliziten Werte nicht zuverlässig anwenden. Kein `aria-busy` — die Zeile hat keinen
+		eigenen Ladezustand, Ergebnis-Updates laufen über die SvelteKit-Navigation und deren
+		globaler Loader in `+layout.svelte` trägt es bereits.
+	-->
+	<div
+		class="w-full items-center justify-center text-center mt-2"
+		role="status"
+		aria-live="polite"
+		aria-atomic="true"
+	>
 		{#if data.q || data.selectedCategories.length > 0 || data.selectedGroup}
-			<h5>{texts.ui.resultsFound(filterActive ? filteredItems.length : (data.totalItems ?? 0))}</h5>
+			<p>{texts.ui.resultsFound(filterActive ? filteredItems.length : (data.totalItems ?? 0))}</p>
 		{:else}
-			<h5>{texts.pages.search.newestItemsHeading}</h5>
+			<p>{texts.pages.search.newestItemsHeading}</p>
 		{/if}
 	</div>
 


### PR DESCRIPTION
## What
The site ranked on its brand name only — "Lüneburg" appeared in no `<title>`, no meta description, and no `<h1>`, so local search queries ("leihen lüneburg", "bohrmaschine leihen lüneburg") had nothing to match on.

- `texts.ts`: SEO entries with local search intent (home, search, about, guide, contact, `itemDetail*`) now interpolate the city from `CITY` (= `instance.city`) instead of a literal, so one build serves N city instances. A block comment lists the pages deliberately left without a city.
- `itemDetail()` drops its owner argument — the owner earns no ranking and crowds the city out of the displayed snippet; it moves into the description instead.
- Landing page had no `h1` at all and started at `h3` (axe: `page-has-heading-one` + `heading-order`). The tagline becomes the `h1`; info cards go `h3` → `h2`.
- `/search` is an indexable sitemap page with no `h1`: its heading becomes the `h1` and now names the city. The result count below it drops its heading role entirely — it's a status message in an `aria-live` region, not a section title (WCAG 1.3.1).

## Why
Local SEO was invisible to crawlers and to assistive tech alike — same root cause (missing/misused headings, no city in metadata).

## Out of scope (follow-ups)
Category landing pages, Schema.org Product/LocalBusiness markup, sitemap changes.

## Test notes
- `texts.test.ts` (new): walks `texts.seo` and fails on any hardcoded "Lüneburg"; also pins that the city is present.
- `seo-local.spec.ts` (new, Playwright, registered in the public project): asserts rendered metadata and exactly one `h1` per page.
- Preflight run clean: `npm run lint`, `npm run check` (0 errors), `npx vitest run` (750/750), `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)