### PR TITLE
perf(items): parallelize item detail page load, dedupe trust/terms lookups

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -88,8 +88,9 @@ These prevent the most common bugs/security issues here — follow them without 
 - **Trust visibility is enforced at the data layer**, not in app code: the `items` /
   `items_searchable` rules only return a trustees-only item to the owner's trustees (via the
   `trusts` join back-relation `owner.trusts_via_truster.trustee.id ?= @request.auth.id`). Read
-  trust through `$lib/server/trust.ts` (`isTrusting` / `getTrustees` / `getTrusters`; `addTrust` /
-  `removeTrust` for mutations); never re-implement trust filtering client-side. Unauthenticated
+  trust through `$lib/server/trust.ts` (`isTrusting` / `getTrustDirections` / `getTrustees` /
+  `getTrusters`; `addTrust` / `removeTrust` for mutations); never re-implement trust filtering
+  client-side. Unauthenticated
   browsing uses the `*_public` views — never leak email, raw coordinates, trusted items, or
   trust-graph data through them.
 - **Lending status values & groupings come only from `$lib/lending.ts`** (`LendingStatus`,

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -405,7 +405,11 @@ API rules: `listRule`/`viewRule` = `@request.auth.id = truster || @request.auth.
 parties may read an edge — the trustee needs to see who trusts them); `createRule`/`deleteRule` =
 `@request.auth.id = truster` (only the granter adds or revokes); `updateRule` = `null`. A backend
 hook (`trust.pb.js`) rejects a self-trust edge. The frontend reads/writes it exclusively through
-`$lib/server/trust.ts` (`isTrusting`, `addTrust`, `removeTrust`, `getTrustees`, `getTrusters`).
+`$lib/server/trust.ts` (`isTrusting`, `getTrustDirections`, `addTrust`, `removeTrust`,
+`getTrustees`, `getTrusters`). `getTrustDirections` resolves both directions between two users in
+one query — callers that need both (e.g. item detail, user profile) must not run two concurrent
+`isTrusting` calls, since PocketBase's request auto-cancellation keys by `method + path` and both
+directions hit the identical `trusts` list endpoint.
 
 Item/search/conversation visibility rules match trust via the back-relation
 `…trusts_via_truster.trustee.id ?= @request.auth.id` (rows where the owner is the truster; see the

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -411,10 +411,13 @@ both directions between two users in one query and returns
 `{ viewerTrustsOther, otherTrustsViewer }` (named from the viewer's perspective, so a swapped
 argument pair can't silently invert the display); its fail-closed fallback `NO_TRUST_DIRECTIONS` is
 `Object.freeze`n, since the same module-global object is handed to every request. Callers that need
-both directions (e.g. item detail, user profile) must not run two concurrent `isTrusting` calls —
-PocketBase's request auto-cancellation keys by `method + path`, both directions hit the identical
-`trusts` list endpoint, and the swallowed `AbortError` reads as "no trust". Every `trusts` reader
-here takes an optional `requestKey` for exactly that reason.
+both directions (e.g. item detail, user profile) must not run two concurrent `isTrusting` calls.
+PocketBase keys auto-cancellation by `options.requestKey || (method + path)` — the path form is
+only a fallback, and `getFirstListItem` already defaults to a per-filter key
+(`"one_by_filter_" + path + "_" + filter`), so it's collision-free on its own. The `trusts` helpers
+here collide only because they pass a shared **hardcoded** `requestKey` that overrides that
+default — both directions hit the identical key, and the swallowed `AbortError` reads as "no
+trust". That's exactly why every concurrent call site must supply its own distinct `requestKey`.
 
 Item/search/conversation visibility rules match trust via the back-relation
 `…trusts_via_truster.trustee.id ?= @request.auth.id` (rows where the owner is the truster; see the

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -405,11 +405,16 @@ API rules: `listRule`/`viewRule` = `@request.auth.id = truster || @request.auth.
 parties may read an edge — the trustee needs to see who trusts them); `createRule`/`deleteRule` =
 `@request.auth.id = truster` (only the granter adds or revokes); `updateRule` = `null`. A backend
 hook (`trust.pb.js`) rejects a self-trust edge. The frontend reads/writes it exclusively through
-`$lib/server/trust.ts` (`isTrusting`, `getTrustDirections`, `addTrust`, `removeTrust`,
-`getTrustees`, `getTrusters`). `getTrustDirections` resolves both directions between two users in
-one query — callers that need both (e.g. item detail, user profile) must not run two concurrent
-`isTrusting` calls, since PocketBase's request auto-cancellation keys by `method + path` and both
-directions hit the identical `trusts` list endpoint.
+`$lib/server/trust.ts` (`isTrusting`, `getTrustDirections`, `NO_TRUST_DIRECTIONS`, `addTrust`,
+`removeTrust`, `getTrustees`, `getTrusters`). `getTrustDirections(pb, viewerId, otherId)` resolves
+both directions between two users in one query and returns
+`{ viewerTrustsOther, otherTrustsViewer }` (named from the viewer's perspective, so a swapped
+argument pair can't silently invert the display); its fail-closed fallback `NO_TRUST_DIRECTIONS` is
+`Object.freeze`n, since the same module-global object is handed to every request. Callers that need
+both directions (e.g. item detail, user profile) must not run two concurrent `isTrusting` calls —
+PocketBase's request auto-cancellation keys by `method + path`, both directions hit the identical
+`trusts` list endpoint, and the swallowed `AbortError` reads as "no trust". Every `trusts` reader
+here takes an optional `requestKey` for exactly that reason.
 
 Item/search/conversation visibility rules match trust via the back-relation
 `…trusts_via_truster.trustee.id ?= @request.auth.id` (rows where the owner is the truster; see the

--- a/src/lib/server/lendingRequirements.test.ts
+++ b/src/lib/server/lendingRequirements.test.ts
@@ -65,6 +65,20 @@ describe('getOwnerRequirements', () => {
 		const [filter] = mockGetFirstListItem.mock.calls[0];
 		expect(filter).toContain("owner = 'owner1'");
 	});
+
+	// A concurrent sibling read on the same `pb` would otherwise auto-cancel this one
+	// (PocketBase keys by method+path) and the catch above turns that into "no
+	// requirements" — i.e. the requirements gate silently disappears.
+	it('sends the default requestKey and forwards a caller-supplied one', async () => {
+		mockGetFirstListItem.mockResolvedValue(stubRequirements);
+		await getOwnerRequirements(pb, 'owner1');
+		expect(mockGetFirstListItem.mock.calls[0][1]).toEqual({ requestKey: 'owner-requirements' });
+
+		await getOwnerRequirements(pb, 'owner1', 'owner-requirements-item');
+		expect(mockGetFirstListItem.mock.calls[1][1]).toEqual({
+			requestKey: 'owner-requirements-item',
+		});
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -136,6 +150,15 @@ describe('evaluateUnmetRequirements', () => {
 		// carries address-specific copy, not the email one
 		expect(unmet[0].actionLabel).not.toBe('');
 		expect(unmet[0].actionHref).toBe('/user/profile#address');
+	});
+
+	// The item-detail load runs this next to the terms gate in one Promise.all — it must
+	// be able to key its own read so a sibling can't auto-cancel it into an empty gate.
+	it('forwards a requestKey to the requirements read', async () => {
+		const get = vi.fn().mockResolvedValue(stubRequirements);
+		const pb = makeMockPb(() => ({ getFirstListItem: get }));
+		await evaluateUnmetRequirements(pb, 'owner1', { verified: true }, 'unmet-requirements-item');
+		expect(get.mock.calls[0][1]).toEqual({ requestKey: 'unmet-requirements-item' });
 	});
 });
 

--- a/src/lib/server/lendingRequirements.ts
+++ b/src/lib/server/lendingRequirements.ts
@@ -94,15 +94,25 @@ export function getRequirementSettings(req: LendingRequirements | null): Require
 	}));
 }
 
-/** Returns the owner's configured requirements, or null if none are set. */
+/**
+ * Returns the owner's configured requirements, or null if none are set.
+ *
+ * `requestKey` MUST be distinct per concurrent call site on the same `pb` (mirrors
+ * `getUserPreferences`): PocketBase's auto-cancellation keys by method+path, so a
+ * second identical GET aborts the first — and the `catch` below turns that
+ * `AbortError` into `null`, which reads as "no requirements" and opens the gate.
+ */
 export async function getOwnerRequirements(
 	pb: PocketBase,
-	ownerId: string
+	ownerId: string,
+	requestKey = 'owner-requirements'
 ): Promise<LendingRequirements | null> {
 	try {
 		return await pb
 			.collection('lending_requirements')
-			.getFirstListItem<LendingRequirements>(pb.filter('owner = {:ownerId}', { ownerId }));
+			.getFirstListItem<LendingRequirements>(pb.filter('owner = {:ownerId}', { ownerId }), {
+				requestKey,
+			});
 	} catch {
 		// PocketBase throws 404 when no record matches — translate to null.
 		return null;
@@ -132,13 +142,19 @@ export async function upsertOwnerRequirements(
  * Evaluates the owner's enabled requirements against a borrower and returns the
  * ones that are NOT met (empty array = borrower may request). Used for UX only;
  * the backend hook performs the binding check.
+ *
+ * `requestKey` is forwarded to `getOwnerRequirements` and MUST be distinct per
+ * concurrent call site on the same `pb` — see that function's doc comment. Note
+ * that a `RequirementDef.evaluate` issuing its own reads is subject to the same
+ * trap and must key them itself.
  */
 export async function evaluateUnmetRequirements(
 	pb: PocketBase,
 	ownerId: string,
-	borrower: Borrower
+	borrower: Borrower,
+	requestKey?: string
 ): Promise<UnmetRequirement[]> {
-	const req = await getOwnerRequirements(pb, ownerId);
+	const req = await getOwnerRequirements(pb, ownerId, requestKey);
 	if (!req) return [];
 
 	const unmet: UnmetRequirement[] = [];

--- a/src/lib/server/lendingTerms.test.ts
+++ b/src/lib/server/lendingTerms.test.ts
@@ -343,4 +343,56 @@ describe('hasAcceptedActiveTerms', () => {
 		const [filter] = acceptanceGet.mock.calls[0];
 		expect(filter).toContain(`terms = '${stubTerms.id}'`);
 	});
+
+	// #615 fix 1: resolveTermsGate (item detail load) now delegates here instead of
+	// re-implementing this composition, so the round-trip count must stay at exactly
+	// one `getActiveTerms` + one `getAcceptance` call regardless of the opts passed.
+	it('resolves the active terms and the acceptance exactly once each', async () => {
+		const termsGet = vi.fn().mockResolvedValue(stubTerms);
+		const acceptanceGet = vi.fn().mockResolvedValue(stubAcceptance);
+		const pb = makeMockPb((name) => ({
+			getFirstListItem: name === 'lending_terms' ? termsGet : acceptanceGet
+		}));
+
+		await hasAcceptedActiveTerms(pb, 'user1', 'owner1', {
+			termsRequestKey: 'terms-gate-item',
+			acceptanceRequestKey: 'terms-acceptance-item'
+		});
+
+		expect(termsGet).toHaveBeenCalledTimes(1);
+		expect(acceptanceGet).toHaveBeenCalledTimes(1);
+	});
+
+	it('forwards opts.termsRequestKey / opts.acceptanceRequestKey to the underlying reads', async () => {
+		const termsGet = vi.fn().mockResolvedValue(stubTerms);
+		const acceptanceGet = vi.fn().mockResolvedValue(stubAcceptance);
+		const pb = makeMockPb((name) => ({
+			getFirstListItem: name === 'lending_terms' ? termsGet : acceptanceGet
+		}));
+
+		await hasAcceptedActiveTerms(pb, 'user1', 'owner1', {
+			termsRequestKey: 'terms-gate-item',
+			acceptanceRequestKey: 'terms-acceptance-item'
+		});
+
+		const [, termsOptions] = termsGet.mock.calls[0];
+		const [, acceptanceOptions] = acceptanceGet.mock.calls[0];
+		expect(termsOptions).toMatchObject({ requestKey: 'terms-gate-item' });
+		expect(acceptanceOptions).toMatchObject({ requestKey: 'terms-acceptance-item' });
+	});
+
+	it('falls back to the stable default requestKeys when opts is omitted', async () => {
+		const termsGet = vi.fn().mockResolvedValue(stubTerms);
+		const acceptanceGet = vi.fn().mockResolvedValue(stubAcceptance);
+		const pb = makeMockPb((name) => ({
+			getFirstListItem: name === 'lending_terms' ? termsGet : acceptanceGet
+		}));
+
+		await hasAcceptedActiveTerms(pb, 'user1', 'owner1');
+
+		const [, termsOptions] = termsGet.mock.calls[0];
+		const [, acceptanceOptions] = acceptanceGet.mock.calls[0];
+		expect(termsOptions).toMatchObject({ requestKey: 'active-terms' });
+		expect(acceptanceOptions).toMatchObject({ requestKey: 'terms-acceptance' });
+	});
 });

--- a/src/lib/server/lendingTerms.test.ts
+++ b/src/lib/server/lendingTerms.test.ts
@@ -222,11 +222,20 @@ describe('getActiveTerms', () => {
 		expect(filter).toMatch(/effectiveFrom <= '/);
 	});
 
-	it('sorts by -effectiveFrom', async () => {
+	it('sorts by -effectiveFrom and carries the default requestKey', async () => {
 		mockGetFirstListItem.mockResolvedValue(stubTerms);
 		await getActiveTerms(pb, 'owner1');
 		const [, options] = mockGetFirstListItem.mock.calls[0];
-		expect(options).toEqual({ sort: '-effectiveFrom' });
+		expect(options).toEqual({ sort: '-effectiveFrom', requestKey: 'active-terms' });
+	});
+
+	// Concurrent callers on one `pb` must not auto-cancel each other (method+path
+	// keying) — a cancelled read is swallowed into a `null`, i.e. "no active terms".
+	it('forwards a caller-supplied requestKey', async () => {
+		mockGetFirstListItem.mockResolvedValue(stubTerms);
+		await getActiveTerms(pb, 'owner1', 'active-terms-elsewhere');
+		const [, options] = mockGetFirstListItem.mock.calls[0];
+		expect(options).toMatchObject({ requestKey: 'active-terms-elsewhere' });
 	});
 });
 
@@ -269,11 +278,18 @@ describe('getAcceptance', () => {
 		expect(filter).toContain("terms = 'terms1'");
 	});
 
-	it('sorts by -acceptedAt to get the most recent acceptance', async () => {
+	it('sorts by -acceptedAt to get the most recent acceptance, with the default requestKey', async () => {
 		mockGetFirstListItem.mockResolvedValue(stubAcceptance);
 		await getAcceptance(pb, 'user1', 'terms1');
 		const [, options] = mockGetFirstListItem.mock.calls[0];
-		expect(options).toEqual({ sort: '-acceptedAt' });
+		expect(options).toEqual({ sort: '-acceptedAt', requestKey: 'terms-acceptance' });
+	});
+
+	it('forwards a caller-supplied requestKey (auto-cancellation guard)', async () => {
+		mockGetFirstListItem.mockResolvedValue(stubAcceptance);
+		await getAcceptance(pb, 'user1', 'terms1', 'terms-acceptance-elsewhere');
+		const [, options] = mockGetFirstListItem.mock.calls[0];
+		expect(options).toMatchObject({ requestKey: 'terms-acceptance-elsewhere' });
 	});
 });
 

--- a/src/lib/server/lendingTerms.ts
+++ b/src/lib/server/lendingTerms.ts
@@ -50,10 +50,16 @@ export function cleanTermsHtml(raw: string | undefined | null): string {
  *
  * Active = `active == true`. We additionally require `effectiveFrom <= now` so that
  * future-dated versions can be staged without going live.
+ *
+ * `requestKey` MUST be distinct per concurrent call site on the same `pb` (mirrors
+ * `getUserPreferences`): PocketBase's auto-cancellation keys by method+path, so a
+ * second identical GET aborts the first — and this helper's `catch` turns that
+ * `AbortError` into a silent `null`, i.e. "no terms" and an open gate.
  */
 export async function getActiveTerms(
 	pb: PocketBase,
-	ownerId: string
+	ownerId: string,
+	requestKey = 'active-terms'
 ): Promise<LendingTerms | null> {
 	try {
 		const nowIso = new Date().toISOString().replace('T', ' ').replace('Z', '');
@@ -62,7 +68,7 @@ export async function getActiveTerms(
 				ownerId,
 				nowIso,
 			}),
-			{ sort: '-effectiveFrom' }
+			{ sort: '-effectiveFrom', requestKey }
 		);
 	} catch {
 		// PocketBase throws 404 if no record matches — translate to null.
@@ -73,16 +79,21 @@ export async function getActiveTerms(
 /**
  * Returns the most recent acceptance by `userId` of the given `termsId`, or `null`
  * if the user has not yet accepted that exact version.
+ *
+ * `requestKey` MUST be distinct per concurrent call site on the same `pb` — same
+ * auto-cancellation trap as `getActiveTerms` above (a cancelled read reads as
+ * "not accepted" here, which fails closed, but still lies about the state).
  */
 export async function getAcceptance(
 	pb: PocketBase,
 	userId: string,
-	termsId: string
+	termsId: string,
+	requestKey = 'terms-acceptance'
 ): Promise<TermAcceptance | null> {
 	try {
 		return await pb.collection('term_acceptances').getFirstListItem<TermAcceptance>(
 			pb.filter('user = {:userId} && terms = {:termsId}', { userId, termsId }),
-			{ sort: '-acceptedAt' }
+			{ sort: '-acceptedAt', requestKey }
 		);
 	} catch {
 		return null;
@@ -90,22 +101,12 @@ export async function getAcceptance(
 }
 
 /**
- * True if `userId` has accepted the given (already-resolved) `terms` version. Split
- * out from `hasAcceptedActiveTerms` so a caller that has already fetched the active
- * terms (e.g. the item detail load) can check acceptance without re-fetching them —
- * one definition of "has accepted" instead of two modules re-implementing it.
- */
-export async function hasAcceptedTerms(
-	pb: PocketBase,
-	userId: string,
-	terms: LendingTerms
-): Promise<boolean> {
-	return (await getAcceptance(pb, userId, terms.id)) !== null;
-}
-
-/**
  * Convenience: true if the user has already accepted the currently active terms
  * of the given owner. Returns false if there are no active terms (no gating needed).
+ *
+ * Resolves the active terms itself, so a caller that has ALREADY fetched them (e.g.
+ * the item detail load) should compose `getActiveTerms` + `getAcceptance` directly
+ * instead of paying for a second lookup here.
  */
 export async function hasAcceptedActiveTerms(
 	pb: PocketBase,
@@ -114,5 +115,6 @@ export async function hasAcceptedActiveTerms(
 ): Promise<boolean> {
 	const active = await getActiveTerms(pb, ownerId);
 	if (!active) return true; // no terms → nothing to accept → consider satisfied
-	return hasAcceptedTerms(pb, userId, active);
+	const acceptance = await getAcceptance(pb, userId, active.id);
+	return acceptance !== null;
 }

--- a/src/lib/server/lendingTerms.ts
+++ b/src/lib/server/lendingTerms.ts
@@ -90,6 +90,20 @@ export async function getAcceptance(
 }
 
 /**
+ * True if `userId` has accepted the given (already-resolved) `terms` version. Split
+ * out from `hasAcceptedActiveTerms` so a caller that has already fetched the active
+ * terms (e.g. the item detail load) can check acceptance without re-fetching them —
+ * one definition of "has accepted" instead of two modules re-implementing it.
+ */
+export async function hasAcceptedTerms(
+	pb: PocketBase,
+	userId: string,
+	terms: LendingTerms
+): Promise<boolean> {
+	return (await getAcceptance(pb, userId, terms.id)) !== null;
+}
+
+/**
  * Convenience: true if the user has already accepted the currently active terms
  * of the given owner. Returns false if there are no active terms (no gating needed).
  */
@@ -100,6 +114,5 @@ export async function hasAcceptedActiveTerms(
 ): Promise<boolean> {
 	const active = await getActiveTerms(pb, ownerId);
 	if (!active) return true; // no terms → nothing to accept → consider satisfied
-	const acceptance = await getAcceptance(pb, userId, active.id);
-	return acceptance !== null;
+	return hasAcceptedTerms(pb, userId, active);
 }

--- a/src/lib/server/lendingTerms.ts
+++ b/src/lib/server/lendingTerms.ts
@@ -104,17 +104,21 @@ export async function getAcceptance(
  * Convenience: true if the user has already accepted the currently active terms
  * of the given owner. Returns false if there are no active terms (no gating needed).
  *
- * Resolves the active terms itself, so a caller that has ALREADY fetched them (e.g.
- * the item detail load) should compose `getActiveTerms` + `getAcceptance` directly
- * instead of paying for a second lookup here.
+ * Resolves the active terms itself. A caller running this concurrently with other
+ * `lending_terms`/`term_acceptances` reads on the same `pb` (e.g. the item detail
+ * load's requirements-evaluation wave) should pass distinct `termsRequestKey` /
+ * `acceptanceRequestKey` via `opts` so PocketBase's auto-cancellation can't collide
+ * either read with a sibling task — no need to compose `getActiveTerms` +
+ * `getAcceptance` by hand just to get distinct keys.
  */
 export async function hasAcceptedActiveTerms(
 	pb: PocketBase,
 	userId: string,
-	ownerId: string
+	ownerId: string,
+	opts: { termsRequestKey?: string; acceptanceRequestKey?: string } = {}
 ): Promise<boolean> {
-	const active = await getActiveTerms(pb, ownerId);
+	const active = await getActiveTerms(pb, ownerId, opts.termsRequestKey);
 	if (!active) return true; // no terms → nothing to accept → consider satisfied
-	const acceptance = await getAcceptance(pb, userId, active.id);
+	const acceptance = await getAcceptance(pb, userId, active.id, opts.acceptanceRequestKey);
 	return acceptance !== null;
 }

--- a/src/lib/server/trust.test.ts
+++ b/src/lib/server/trust.test.ts
@@ -8,6 +8,7 @@ import {
 	removeTrust,
 	getTrustees,
 	getTrusters,
+	getTrustDirections,
 } from './trust';
 
 vi.mock('$lib/server/notifications', () => ({
@@ -240,5 +241,62 @@ describe('getTrustees / getTrusters', () => {
 		expect(k1).toBeTruthy();
 		expect(k2).toBeTruthy();
 		expect(k1).not.toBe(k2);
+	});
+});
+
+describe('getTrustDirections', () => {
+	it('resolves both true when both edges exist', async () => {
+		const getList = vi.fn().mockResolvedValue({
+			items: [
+				{ truster: 'a', trustee: 'b' },
+				{ truster: 'b', trustee: 'a' },
+			],
+		});
+		const pb = makePb({ getList });
+		expect(await getTrustDirections(pb, 'a', 'b')).toEqual({ aTrustsB: true, bTrustsA: true });
+	});
+
+	it('resolves only aTrustsB when just the a→b edge exists', async () => {
+		const getList = vi.fn().mockResolvedValue({ items: [{ truster: 'a', trustee: 'b' }] });
+		const pb = makePb({ getList });
+		expect(await getTrustDirections(pb, 'a', 'b')).toEqual({ aTrustsB: true, bTrustsA: false });
+	});
+
+	it('resolves only bTrustsA when just the b→a edge exists', async () => {
+		const getList = vi.fn().mockResolvedValue({ items: [{ truster: 'b', trustee: 'a' }] });
+		const pb = makePb({ getList });
+		expect(await getTrustDirections(pb, 'a', 'b')).toEqual({ aTrustsB: false, bTrustsA: true });
+	});
+
+	it('resolves both false when neither edge exists', async () => {
+		const getList = vi.fn().mockResolvedValue({ items: [] });
+		const pb = makePb({ getList });
+		expect(await getTrustDirections(pb, 'a', 'b')).toEqual({ aTrustsB: false, bTrustsA: false });
+	});
+
+	it('fails closed to both false when the query rejects', async () => {
+		const getList = vi.fn().mockRejectedValue(new Error('network error'));
+		const pb = makePb({ getList });
+		expect(await getTrustDirections(pb, 'a', 'b')).toEqual({ aTrustsB: false, bTrustsA: false });
+	});
+
+	it('issues exactly one request, built via pb.filter covering both directions, with a stable requestKey', async () => {
+		const getList = vi.fn().mockResolvedValue({ items: [] });
+		const pb = makePb({ getList });
+		await getTrustDirections(pb, 'a', 'b');
+
+		expect(getList).toHaveBeenCalledTimes(1);
+		expect(pb.filter).toHaveBeenCalledWith(
+			'(truster={:a} && trustee={:b}) || (truster={:b} && trustee={:a})',
+			{ a: 'a', b: 'b' }
+		);
+		const callArgs = getList.mock.calls[0];
+		expect(callArgs[0]).toBe(1);
+		expect(callArgs[1]).toBe(2);
+		expect(callArgs[2]).toMatchObject({
+			filter: "(truster='a' && trustee='b') || (truster='b' && trustee='a')",
+			fields: 'truster,trustee',
+			requestKey: 'trust-directions',
+		});
 	});
 });

--- a/src/lib/server/trust.test.ts
+++ b/src/lib/server/trust.test.ts
@@ -9,6 +9,7 @@ import {
 	getTrustees,
 	getTrusters,
 	getTrustDirections,
+	NO_TRUST_DIRECTIONS,
 } from './trust';
 
 vi.mock('$lib/server/notifications', () => ({
@@ -41,12 +42,22 @@ describe('isTrusting', () => {
 		const getFirstListItem = vi.fn().mockResolvedValue({ id: 't1' });
 		const pb = makePb({ getFirstListItem });
 		expect(await isTrusting(pb, 'a', 'b')).toBe(true);
-		expect(getFirstListItem).toHaveBeenCalledWith("truster = 'a' && trustee = 'b'", { fields: 'id' });
+		expect(getFirstListItem).toHaveBeenCalledWith("truster = 'a' && trustee = 'b'", {
+			fields: 'id',
+			requestKey: 'is-trusting',
+		});
 	});
 
 	it('is false when no edge exists', async () => {
 		const pb = makePb({ getFirstListItem: vi.fn().mockRejectedValue(new Error('none')) });
 		expect(await isTrusting(pb, 'a', 'b')).toBe(false);
+	});
+
+	it('lets a call site override the requestKey (auto-cancellation guard)', async () => {
+		const getFirstListItem = vi.fn().mockResolvedValue({ id: 't1' });
+		const pb = makePb({ getFirstListItem });
+		await isTrusting(pb, 'a', 'b', 'is-trusting-custom');
+		expect(getFirstListItem.mock.calls[0][1]).toMatchObject({ requestKey: 'is-trusting-custom' });
 	});
 });
 
@@ -248,53 +259,82 @@ describe('getTrustDirections', () => {
 	it('resolves both true when both edges exist', async () => {
 		const getList = vi.fn().mockResolvedValue({
 			items: [
-				{ truster: 'a', trustee: 'b' },
-				{ truster: 'b', trustee: 'a' },
+				{ truster: 'viewer', trustee: 'other' },
+				{ truster: 'other', trustee: 'viewer' },
 			],
 		});
 		const pb = makePb({ getList });
-		expect(await getTrustDirections(pb, 'a', 'b')).toEqual({ aTrustsB: true, bTrustsA: true });
+		expect(await getTrustDirections(pb, 'viewer', 'other')).toEqual({
+			viewerTrustsOther: true,
+			otherTrustsViewer: true,
+		});
 	});
 
-	it('resolves only aTrustsB when just the a→b edge exists', async () => {
-		const getList = vi.fn().mockResolvedValue({ items: [{ truster: 'a', trustee: 'b' }] });
+	it('resolves only viewerTrustsOther when just the viewer→other edge exists', async () => {
+		const getList = vi.fn().mockResolvedValue({ items: [{ truster: 'viewer', trustee: 'other' }] });
 		const pb = makePb({ getList });
-		expect(await getTrustDirections(pb, 'a', 'b')).toEqual({ aTrustsB: true, bTrustsA: false });
+		expect(await getTrustDirections(pb, 'viewer', 'other')).toEqual({
+			viewerTrustsOther: true,
+			otherTrustsViewer: false,
+		});
 	});
 
-	it('resolves only bTrustsA when just the b→a edge exists', async () => {
-		const getList = vi.fn().mockResolvedValue({ items: [{ truster: 'b', trustee: 'a' }] });
+	it('resolves only otherTrustsViewer when just the other→viewer edge exists', async () => {
+		const getList = vi.fn().mockResolvedValue({ items: [{ truster: 'other', trustee: 'viewer' }] });
 		const pb = makePb({ getList });
-		expect(await getTrustDirections(pb, 'a', 'b')).toEqual({ aTrustsB: false, bTrustsA: true });
+		expect(await getTrustDirections(pb, 'viewer', 'other')).toEqual({
+			viewerTrustsOther: false,
+			otherTrustsViewer: true,
+		});
 	});
 
 	it('resolves both false when neither edge exists', async () => {
 		const getList = vi.fn().mockResolvedValue({ items: [] });
 		const pb = makePb({ getList });
-		expect(await getTrustDirections(pb, 'a', 'b')).toEqual({ aTrustsB: false, bTrustsA: false });
+		expect(await getTrustDirections(pb, 'viewer', 'other')).toEqual({
+			viewerTrustsOther: false,
+			otherTrustsViewer: false,
+		});
 	});
 
 	it('fails closed to both false when the query rejects', async () => {
 		const getList = vi.fn().mockRejectedValue(new Error('network error'));
 		const pb = makePb({ getList });
-		expect(await getTrustDirections(pb, 'a', 'b')).toEqual({ aTrustsB: false, bTrustsA: false });
+		expect(await getTrustDirections(pb, 'viewer', 'other')).toEqual({
+			viewerTrustsOther: false,
+			otherTrustsViewer: false,
+		});
+	});
+
+	// The shared fallback is module-global and lives for the whole process: a caller
+	// that mutated it would poison every later request's fail-closed result.
+	it('hands back a frozen NO_TRUST_DIRECTIONS a caller cannot mutate', async () => {
+		const getList = vi.fn().mockRejectedValue(new Error('network error'));
+		const pb = makePb({ getList });
+		const result = await getTrustDirections(pb, 'viewer', 'other');
+
+		expect(Object.isFrozen(result)).toBe(true);
+		expect(() => {
+			(result as { viewerTrustsOther: boolean }).viewerTrustsOther = true;
+		}).toThrow();
+		expect(NO_TRUST_DIRECTIONS.viewerTrustsOther).toBe(false);
 	});
 
 	it('issues exactly one request, built via pb.filter covering both directions, with a stable requestKey', async () => {
 		const getList = vi.fn().mockResolvedValue({ items: [] });
 		const pb = makePb({ getList });
-		await getTrustDirections(pb, 'a', 'b');
+		await getTrustDirections(pb, 'viewer', 'other');
 
 		expect(getList).toHaveBeenCalledTimes(1);
 		expect(pb.filter).toHaveBeenCalledWith(
-			'(truster={:a} && trustee={:b}) || (truster={:b} && trustee={:a})',
-			{ a: 'a', b: 'b' }
+			'(truster={:viewer} && trustee={:other}) || (truster={:other} && trustee={:viewer})',
+			{ viewer: 'viewer', other: 'other' }
 		);
 		const callArgs = getList.mock.calls[0];
 		expect(callArgs[0]).toBe(1);
 		expect(callArgs[1]).toBe(2);
 		expect(callArgs[2]).toMatchObject({
-			filter: "(truster='a' && trustee='b') || (truster='b' && trustee='a')",
+			filter: "(truster='viewer' && trustee='other') || (truster='other' && trustee='viewer')",
 			fields: 'truster,trustee',
 			requestKey: 'trust-directions',
 		});

--- a/src/lib/server/trust.ts
+++ b/src/lib/server/trust.ts
@@ -98,6 +98,65 @@ export async function removeTrust(pb: PocketBase, trusterId: UserId, trusteeId: 
 	}
 }
 
+/** Fail-closed result for `getTrustDirections` — no trust either direction. Shared so
+ *  callers' anonymous-viewer and error fallbacks all point at one literal. */
+export const NO_TRUST_DIRECTIONS = { aTrustsB: false, bTrustsA: false } as const;
+
+/**
+ * Both trust directions between two users in ONE request: whether `a` trusts `b`
+ * and whether `b` trusts `a`.
+ *
+ * Why one query instead of two concurrent `isTrusting()` calls: the PocketBase JS
+ * SDK auto-cancels an in-flight request when a second one hits the same
+ * `method + path` and no distinct `requestKey` is given (see
+ * `pocketbase.es.mjs`: `requestKey || method + path`). Both directions of
+ * `isTrusting` hit the identical `GET /api/collections/trusts/records` path, so a
+ * naive `Promise.all([isTrusting(a,b), isTrusting(b,a)])` makes the SDK abort the
+ * first call — and `isTrusting`'s `catch` swallows that `AbortError` and returns
+ * `false`, silently reporting "no trust" even when the edge exists. Giving each
+ * call a distinct `requestKey` would dodge the cancellation, but still costs two
+ * round-trips; querying both directions in a single `getList` avoids the race
+ * entirely and is cheaper. See also the `getUserPreferences` doc comment for the
+ * same bug class.
+ *
+ * `requestKey` defaults to a stable value but MUST be overridden per concurrent
+ * call site on the same `pb` (mirrors `getUserPreferences`) — two calls sharing a
+ * key would re-trigger exactly the collision this function exists to avoid.
+ */
+export async function getTrustDirections(
+	pb: PocketBase,
+	a: UserId,
+	b: UserId,
+	requestKey = 'trust-directions'
+): Promise<{ aTrustsB: boolean; bTrustsA: boolean }> {
+	try {
+		// Page size 2 is safe because `UNIQUE (truster, trustee)` (docs/data-model.md
+		// → "trusts") guarantees at most one row per direction, so at most 2 rows can
+		// ever match this two-direction filter — a third OR branch here would need a
+		// bigger page or it could silently truncate a row into a wrong `false`.
+		const { items } = await pb.collection('trusts').getList(1, 2, {
+			filter: pb.filter('(truster={:a} && trustee={:b}) || (truster={:b} && trustee={:a})', {
+				a,
+				b,
+			}),
+			fields: 'truster,trustee',
+			requestKey,
+		});
+		let aTrustsB = false;
+		let bTrustsA = false;
+		for (const row of items) {
+			if (row.truster === a && row.trustee === b) aTrustsB = true;
+			if (row.truster === b && row.trustee === a) bTrustsA = true;
+		}
+		return { aTrustsB, bTrustsA };
+	} catch (err) {
+		// Unlike isTrusting()'s catch (which loses only one direction), this loses
+		// both — log so a real failure (vs. "no rows") doesn't vanish silently.
+		console.error('getTrustDirections failed', err instanceof Error ? err.message : err);
+		return NO_TRUST_DIRECTIONS;
+	}
+}
+
 // getTrustees + getTrusters both hit the `trusts` collection and are typically awaited
 // together (e.g. Promise.all on /social). PocketBase auto-cancellation keys concurrent
 // requests by path, so without distinct requestKeys the second would cancel the first —

--- a/src/lib/server/trust.ts
+++ b/src/lib/server/trust.ts
@@ -9,13 +9,28 @@ import { createNotification, sendPushToUser } from '$lib/server/notifications';
 // handles. Keeping every join query here means the visibility model has one place
 // to read on the frontend side.
 
-/** True iff a trust edge {truster, trustee} exists (i.e. truster trusts trustee). */
-export async function isTrusting(pb: PocketBase, trusterId: UserId, trusteeId: UserId): Promise<boolean> {
+/**
+ * True iff a trust edge {truster, trustee} exists (i.e. truster trusts trustee).
+ *
+ * ONE direction only — for both directions use `getTrustDirections`, never two
+ * concurrent `isTrusting` calls on the same `pb`: they share a `method + path`, so
+ * PocketBase auto-cancels the first and the `catch` below reports the abort as a
+ * plain `false` (see `getTrustDirections`' doc comment). `requestKey` exists for the
+ * same reason as on `getTrustees`/`getTrusters` — override it at any call site that
+ * runs concurrently with another `trusts` read.
+ */
+export async function isTrusting(
+	pb: PocketBase,
+	trusterId: UserId,
+	trusteeId: UserId,
+	requestKey = 'is-trusting'
+): Promise<boolean> {
 	try {
 		await pb
 			.collection('trusts')
 			.getFirstListItem(pb.filter('truster = {:tr} && trustee = {:te}', { tr: trusterId, te: trusteeId }), {
 				fields: 'id',
+				requestKey,
 			});
 		return true;
 	} catch {
@@ -98,26 +113,36 @@ export async function removeTrust(pb: PocketBase, trusterId: UserId, trusteeId: 
 	}
 }
 
+/** Both trust directions between a viewer and the other user, named from the viewer's
+ *  perspective so a swapped argument pair can't silently invert the whole display. */
+export type TrustDirections = { viewerTrustsOther: boolean; otherTrustsViewer: boolean };
+
 /** Fail-closed result for `getTrustDirections` — no trust either direction. Shared so
- *  callers' anonymous-viewer and error fallbacks all point at one literal. */
-export const NO_TRUST_DIRECTIONS = { aTrustsB: false, bTrustsA: false } as const;
+ *  callers' anonymous-viewer and error fallbacks all point at one literal. Frozen at
+ *  runtime, not just `as const`: this module-global object is handed to every caller in
+ *  a long-lived Node process, so a single stray write would poison the fallback for all
+ *  subsequent requests. */
+export const NO_TRUST_DIRECTIONS: Readonly<TrustDirections> = Object.freeze({
+	viewerTrustsOther: false,
+	otherTrustsViewer: false,
+});
 
 /**
- * Both trust directions between two users in ONE request: whether `a` trusts `b`
- * and whether `b` trusts `a`.
+ * Both trust directions between two users in ONE request: whether `viewerId` trusts
+ * `otherId` and whether `otherId` trusts `viewerId`.
  *
  * Why one query instead of two concurrent `isTrusting()` calls: the PocketBase JS
  * SDK auto-cancels an in-flight request when a second one hits the same
  * `method + path` and no distinct `requestKey` is given (see
  * `pocketbase.es.mjs`: `requestKey || method + path`). Both directions of
  * `isTrusting` hit the identical `GET /api/collections/trusts/records` path, so a
- * naive `Promise.all([isTrusting(a,b), isTrusting(b,a)])` makes the SDK abort the
- * first call — and `isTrusting`'s `catch` swallows that `AbortError` and returns
- * `false`, silently reporting "no trust" even when the edge exists. Giving each
- * call a distinct `requestKey` would dodge the cancellation, but still costs two
- * round-trips; querying both directions in a single `getList` avoids the race
- * entirely and is cheaper. See also the `getUserPreferences` doc comment for the
- * same bug class.
+ * naive `Promise.all([isTrusting(viewer, other), isTrusting(other, viewer)])` makes
+ * the SDK abort the first call — and `isTrusting`'s `catch` swallows that
+ * `AbortError` and returns `false`, silently reporting "no trust" even when the edge
+ * exists. Giving each call a distinct `requestKey` would dodge the cancellation, but
+ * still costs two round-trips; querying both directions in a single `getList` avoids
+ * the race entirely and is cheaper. See also the `getUserPreferences` doc comment for
+ * the same bug class.
  *
  * `requestKey` defaults to a stable value but MUST be overridden per concurrent
  * call site on the same `pb` (mirrors `getUserPreferences`) — two calls sharing a
@@ -125,30 +150,30 @@ export const NO_TRUST_DIRECTIONS = { aTrustsB: false, bTrustsA: false } as const
  */
 export async function getTrustDirections(
 	pb: PocketBase,
-	a: UserId,
-	b: UserId,
+	viewerId: UserId,
+	otherId: UserId,
 	requestKey = 'trust-directions'
-): Promise<{ aTrustsB: boolean; bTrustsA: boolean }> {
+): Promise<Readonly<TrustDirections>> {
 	try {
 		// Page size 2 is safe because `UNIQUE (truster, trustee)` (docs/data-model.md
 		// → "trusts") guarantees at most one row per direction, so at most 2 rows can
 		// ever match this two-direction filter — a third OR branch here would need a
 		// bigger page or it could silently truncate a row into a wrong `false`.
 		const { items } = await pb.collection('trusts').getList(1, 2, {
-			filter: pb.filter('(truster={:a} && trustee={:b}) || (truster={:b} && trustee={:a})', {
-				a,
-				b,
-			}),
+			filter: pb.filter(
+				'(truster={:viewer} && trustee={:other}) || (truster={:other} && trustee={:viewer})',
+				{ viewer: viewerId, other: otherId }
+			),
 			fields: 'truster,trustee',
 			requestKey,
 		});
-		let aTrustsB = false;
-		let bTrustsA = false;
+		let viewerTrustsOther = false;
+		let otherTrustsViewer = false;
 		for (const row of items) {
-			if (row.truster === a && row.trustee === b) aTrustsB = true;
-			if (row.truster === b && row.trustee === a) bTrustsA = true;
+			if (row.truster === viewerId && row.trustee === otherId) viewerTrustsOther = true;
+			if (row.truster === otherId && row.trustee === viewerId) otherTrustsViewer = true;
 		}
-		return { aTrustsB, bTrustsA };
+		return { viewerTrustsOther, otherTrustsViewer };
 	} catch (err) {
 		// Unlike isTrusting()'s catch (which loses only one direction), this loses
 		// both — log so a real failure (vs. "no rows") doesn't vanish silently.

--- a/src/lib/server/trust.ts
+++ b/src/lib/server/trust.ts
@@ -166,6 +166,9 @@ export async function getTrustDirections(
 			),
 			fields: 'truster,trustee',
 			requestKey,
+			// Only `items` is read below, never `totalItems` — skip the COUNT query PocketBase
+			// would otherwise run on every trust lookup on the item detail and profile pages.
+			skipTotal: true,
 		});
 		let viewerTrustsOther = false;
 		let otherTrustsViewer = false;

--- a/src/routes/items/[id]/+page.server.ts
+++ b/src/routes/items/[id]/+page.server.ts
@@ -1,11 +1,11 @@
 import { PUBLIC_PB_URL } from '../../../hooks.server';
 import { error, fail, redirect } from '@sveltejs/kit';
-import type { ItemPublic } from '$lib/types/models';
+import type { ItemPublic, UnmetRequirement } from '$lib/types/models';
 import type { ClientResponseError } from 'pocketbase';
 import { texts } from '$lib/texts';
 import { hasAcceptedActiveTerms } from '$lib/server/lendingTerms';
 import { evaluateUnmetRequirements } from '$lib/server/lendingRequirements';
-import { isTrusting } from '$lib/server/trust';
+import { getTrustDirections, NO_TRUST_DIRECTIONS } from '$lib/server/trust';
 import { toggleItemStatus } from '$lib/server/items';
 import {
 	findResumableConversation,
@@ -32,22 +32,54 @@ export async function load({ params, locals }) {
 	const currentUserId = locals.user?.id ?? null;
 	const isAuthenticated = locals.pb.authStore.isValid;
 	const isOwnItem = currentUserId === item.userId;
-	// Viewer → Owner direction (does the viewer trust this owner).
-	const viewerTrustsOwner = currentUserId
-		? await isTrusting(locals.pb, currentUserId, item.userId)
-		: false;
 
+	// From here, load() runs in three more stages ("waves"): a wave of five
+	// concurrent, independent lookups right below, then two more stages that each
+	// depend on the previous stage's result and so can't join that wave —
+	// resolveOwnerContact needs isTrustRestricted (derived from the wave below), and
+	// resolveTermsGate/evaluateUnmetRequirements need resolveOwnerContact's result.
+	// `resolveViewerAccess` is the only task in the wave allowed to mutate `item` (in
+	// place); every other task only reads `item.id` / `item.userId`.
+
+	// Both trust directions in one query — see the doc comment on getTrustDirections
+	// in trust.ts for why a Promise.all of two directional lookups would collide.
+	const trustDirectionsTask = currentUserId
+		? getTrustDirections(locals.pb, currentUserId, item.userId, 'trust-directions-item')
+		: NO_TRUST_DIRECTIONS;
+	const viewerAccessTask = resolveViewerAccess(locals.pb, item, currentUserId);
+	const existingConversationTask =
+		currentUserId && !isOwnItem
+			? resolveExistingConversation(locals.pb, currentUserId, item.id)
+			: null;
+	const ownerItemCountTask = item.userId ? countOwnerItems(locals.pb, item.userId) : 0;
+	// Transport mode lives in the user_preferences sidecar (issue #426), not on the
+	// auth record — fetch it directly (only when authenticated) rather than via the
+	// layout's `parent()`, so this already query-heavy load doesn't serialize behind
+	// it. Distinct requestKey from the layout's fetch so the two concurrent reads
+	// don't auto-cancel each other (PB keys by method+path).
+	const preferencesTask = currentUserId
+		? getUserPreferences(locals.pb, currentUserId, 'user-preferences-item')
+		: null;
+
+	const [trustDirections, viewerAccess, existingConversation, ownerItemCount, preferences] =
+		await Promise.all([
+			trustDirectionsTask,
+			viewerAccessTask,
+			existingConversationTask,
+			ownerItemCountTask,
+			preferencesTask,
+		]);
+
+	// Viewer → Owner direction (does the viewer trust this owner).
+	const { aTrustsB: viewerTrustsOwner, bTrustsA: rawOwnerTrustsViewer } = trustDirections;
 	// Whether the item owner trusts the logged-in viewer (Owner → Viewer direction).
 	// Resolved server-side against the `trusts` join so no trust list reaches the client.
-	const ownerTrustsViewer =
-		currentUserId && !isOwnItem ? await isTrusting(locals.pb, item.userId, currentUserId) : false;
+	const ownerTrustsViewer = !isOwnItem && rawOwnerTrustsViewer;
 
-	const { wasMasked, viewerHasFullAccess } = await resolveViewerAccess(
-		locals.pb,
-		item,
-		currentUserId
-	);
+	const { wasMasked, viewerHasFullAccess } = viewerAccess;
 	const isTrustRestricted = wasMasked && isAuthenticated && !viewerHasFullAccess;
+
+	const preferredTransportMode = preferences?.preferredTransportMode || 'bicycle';
 
 	const ownerContact = await resolveOwnerContact(
 		locals.pb,
@@ -56,38 +88,20 @@ export async function load({ params, locals }) {
 		!isOwnItem && !isTrustRestricted
 	);
 
-	const existingConversation =
-		currentUserId && !isOwnItem
-			? await resolveExistingConversation(locals.pb, currentUserId, item.id)
-			: null;
-
 	// Terms + borrower requirements only gate the in-app request flow: viewer must be
 	// logged in, not the owner, and the owner must not handle requests off-platform.
-	const requiresTermsAcceptance =
+	// Neither task depends on the other, so they still run concurrently.
+	const [requiresTermsAcceptance, unmetRequirements] = await Promise.all([
 		currentUserId && !isOwnItem && !ownerContact
-			? await resolveTermsGate(locals.pb, currentUserId, item.userId)
-			: false;
-
-	// Lender-defined borrower requirements (#423/#389): which enabled requirements
-	// does the current viewer NOT yet meet for this owner? UX only — the backend
-	// hook on conversation create is the authoritative gate.
-	const unmetRequirements =
+			? resolveTermsGate(locals.pb, currentUserId, item.userId)
+			: false,
+		// Lender-defined borrower requirements (#423/#389): which enabled requirements
+		// does the current viewer NOT yet meet for this owner? UX only — the backend
+		// hook on conversation create is the authoritative gate.
 		currentUserId && !isOwnItem && !ownerContact && locals.user
-			? await evaluateUnmetRequirements(locals.pb, item.userId, locals.user)
-			: [];
-
-	const ownerItemCount = item.userId ? await countOwnerItems(locals.pb, item.userId) : 0;
-
-	// Transport mode lives in the user_preferences sidecar (issue #426), not on the
-	// auth record — fetch it directly (only when authenticated) rather than via the
-	// layout's `parent()`, so this already query-heavy load doesn't serialize behind it.
-	// Distinct requestKey from the layout's fetch so the two concurrent reads don't
-	// auto-cancel each other (PB keys by method+path).
-	const preferredTransportMode =
-		(currentUserId
-			? (await getUserPreferences(locals.pb, currentUserId, 'user-preferences-item'))
-					?.preferredTransportMode
-			: null) || 'bicycle';
+			? evaluateUnmetRequirements(locals.pb, item.userId, locals.user)
+			: ([] as UnmetRequirement[]),
+	]);
 
 	return {
 		item,

--- a/src/routes/items/[id]/+page.server.ts
+++ b/src/routes/items/[id]/+page.server.ts
@@ -94,17 +94,18 @@ export async function load({ params, locals }) {
 
 	// Terms + borrower requirements only gate the in-app request flow: viewer must be
 	// logged in, not the owner, and the owner must not handle requests off-platform.
+	const canRequestInApp = currentUserId && !isOwnItem && !ownerContact;
+
 	// Neither task depends on the other, so they still run concurrently.
-	const termsGateTask =
-		currentUserId && !isOwnItem && !ownerContact
-			? resolveTermsGate(locals.pb, currentUserId, item.userId)
-			: false;
+	const termsGateTask = canRequestInApp
+		? resolveTermsGate(locals.pb, currentUserId, item.userId)
+		: false;
 	// Lender-defined borrower requirements (#423/#389): which enabled requirements does
 	// the current viewer NOT yet meet for this owner? UX only — the backend hook on
 	// conversation create is the authoritative gate. Distinct requestKey from the terms
 	// gate's reads so the two concurrent tasks can't auto-cancel each other.
 	const unmetRequirementsTask: Promise<UnmetRequirement[]> | UnmetRequirement[] =
-		currentUserId && !isOwnItem && !ownerContact && locals.user
+		canRequestInApp && locals.user
 			? evaluateUnmetRequirements(
 					locals.pb,
 					item.userId,

--- a/src/routes/items/[id]/+page.server.ts
+++ b/src/routes/items/[id]/+page.server.ts
@@ -38,8 +38,8 @@ export async function load({ params, locals }) {
 	// depend on the previous stage's result and so can't join that wave —
 	// resolveOwnerContact needs isTrustRestricted (derived from the wave below), and
 	// resolveTermsGate/evaluateUnmetRequirements need resolveOwnerContact's result.
-	// `resolveViewerAccess` is the only task in the wave allowed to mutate `item` (in
-	// place); every other task only reads `item.id` / `item.userId`.
+	// No task in the wave writes `item`: resolveViewerAccess hands its un-masked fields
+	// back and they are merged in once the whole wave has settled (see below).
 
 	// Both trust directions in one query — see the doc comment on getTrustDirections
 	// in trust.ts for why a Promise.all of two directional lookups would collide.
@@ -71,10 +71,14 @@ export async function load({ params, locals }) {
 		]);
 
 	// Viewer → Owner direction (does the viewer trust this owner).
-	const { aTrustsB: viewerTrustsOwner, bTrustsA: rawOwnerTrustsViewer } = trustDirections;
+	const viewerTrustsOwner = trustDirections.viewerTrustsOther;
 	// Whether the item owner trusts the logged-in viewer (Owner → Viewer direction).
 	// Resolved server-side against the `trusts` join so no trust list reaches the client.
-	const ownerTrustsViewer = !isOwnItem && rawOwnerTrustsViewer;
+	const ownerTrustsViewer = !isOwnItem && trustDirections.otherTrustsViewer;
+
+	// Apply the un-masked fields now that every wave task has settled — no sibling can
+	// observe a partially un-masked item.
+	if (viewerAccess.unmasked) Object.assign(item, viewerAccess.unmasked);
 
 	const { wasMasked, viewerHasFullAccess } = viewerAccess;
 	const isTrustRestricted = wasMasked && isAuthenticated && !viewerHasFullAccess;
@@ -91,16 +95,27 @@ export async function load({ params, locals }) {
 	// Terms + borrower requirements only gate the in-app request flow: viewer must be
 	// logged in, not the owner, and the owner must not handle requests off-platform.
 	// Neither task depends on the other, so they still run concurrently.
-	const [requiresTermsAcceptance, unmetRequirements] = await Promise.all([
+	const termsGateTask =
 		currentUserId && !isOwnItem && !ownerContact
 			? resolveTermsGate(locals.pb, currentUserId, item.userId)
-			: false,
-		// Lender-defined borrower requirements (#423/#389): which enabled requirements
-		// does the current viewer NOT yet meet for this owner? UX only — the backend
-		// hook on conversation create is the authoritative gate.
+			: false;
+	// Lender-defined borrower requirements (#423/#389): which enabled requirements does
+	// the current viewer NOT yet meet for this owner? UX only — the backend hook on
+	// conversation create is the authoritative gate. Distinct requestKey from the terms
+	// gate's reads so the two concurrent tasks can't auto-cancel each other.
+	const unmetRequirementsTask: Promise<UnmetRequirement[]> | UnmetRequirement[] =
 		currentUserId && !isOwnItem && !ownerContact && locals.user
-			? evaluateUnmetRequirements(locals.pb, item.userId, locals.user)
-			: ([] as UnmetRequirement[]),
+			? evaluateUnmetRequirements(
+					locals.pb,
+					item.userId,
+					locals.user,
+					'unmet-requirements-item'
+				)
+			: [];
+
+	const [requiresTermsAcceptance, unmetRequirements] = await Promise.all([
+		termsGateTask,
+		unmetRequirementsTask,
 	]);
 
 	return {

--- a/src/routes/items/[id]/itemDetailQueries.server.test.ts
+++ b/src/routes/items/[id]/itemDetailQueries.server.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ItemPublic } from '$lib/types/models';
 import { makeMockPb } from '$lib/test-utils/pocketbase';
 
-const { getActiveTerms, hasAcceptedActiveTerms } = vi.hoisted(() => ({
+const { getActiveTerms, hasAcceptedTerms } = vi.hoisted(() => ({
 	getActiveTerms: vi.fn(),
-	hasAcceptedActiveTerms: vi.fn(),
+	hasAcceptedTerms: vi.fn(),
 }));
-vi.mock('$lib/server/lendingTerms', () => ({ getActiveTerms, hasAcceptedActiveTerms }));
+vi.mock('$lib/server/lendingTerms', () => ({ getActiveTerms, hasAcceptedTerms }));
 
 import {
 	resolveViewerAccess,
@@ -212,12 +212,12 @@ describe('resolveTermsGate', () => {
 		const result = await resolveTermsGate(pb, VIEWER_ID, OWNER_ID);
 
 		expect(result).toBe(false);
-		expect(hasAcceptedActiveTerms).not.toHaveBeenCalled();
+		expect(hasAcceptedTerms).not.toHaveBeenCalled();
 	});
 
 	it('returns false when active terms exist and the viewer already accepted them', async () => {
 		getActiveTerms.mockResolvedValue({ id: 'terms1' });
-		hasAcceptedActiveTerms.mockResolvedValue(true);
+		hasAcceptedTerms.mockResolvedValue(true);
 
 		const result = await resolveTermsGate(pb, VIEWER_ID, OWNER_ID);
 
@@ -226,11 +226,24 @@ describe('resolveTermsGate', () => {
 
 	it('returns true (gate the request) when active terms exist and the viewer has not accepted them', async () => {
 		getActiveTerms.mockResolvedValue({ id: 'terms1' });
-		hasAcceptedActiveTerms.mockResolvedValue(false);
+		hasAcceptedTerms.mockResolvedValue(false);
 
 		const result = await resolveTermsGate(pb, VIEWER_ID, OWNER_ID);
 
 		expect(result).toBe(true);
+	});
+
+	// The point of #525's terms dedupe: the already-resolved terms are threaded into
+	// the acceptance check, so the gate costs one `getActiveTerms` round-trip, not two.
+	it('fetches the active terms exactly once and threads them into the acceptance check', async () => {
+		const activeTerms = { id: 'terms1' };
+		getActiveTerms.mockResolvedValue(activeTerms);
+		hasAcceptedTerms.mockResolvedValue(true);
+
+		await resolveTermsGate(pb, VIEWER_ID, OWNER_ID);
+
+		expect(getActiveTerms).toHaveBeenCalledTimes(1);
+		expect(hasAcceptedTerms).toHaveBeenCalledWith(pb, VIEWER_ID, activeTerms);
 	});
 });
 

--- a/src/routes/items/[id]/itemDetailQueries.server.test.ts
+++ b/src/routes/items/[id]/itemDetailQueries.server.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ItemPublic } from '$lib/types/models';
 import { makeMockPb } from '$lib/test-utils/pocketbase';
 
-const { getActiveTerms, hasAcceptedTerms } = vi.hoisted(() => ({
+const { getActiveTerms, getAcceptance } = vi.hoisted(() => ({
 	getActiveTerms: vi.fn(),
-	hasAcceptedTerms: vi.fn(),
+	getAcceptance: vi.fn(),
 }));
-vi.mock('$lib/server/lendingTerms', () => ({ getActiveTerms, hasAcceptedTerms }));
+vi.mock('$lib/server/lendingTerms', () => ({ getActiveTerms, getAcceptance }));
 
 import {
 	resolveViewerAccess,
@@ -42,7 +42,7 @@ describe('resolveViewerAccess', () => {
 
 		const result = await resolveViewerAccess(pb, item, VIEWER_ID);
 
-		expect(result).toEqual({ wasMasked: false, viewerHasFullAccess: true });
+		expect(result).toEqual({ wasMasked: false, viewerHasFullAccess: true, unmasked: null });
 		expect(getOne).not.toHaveBeenCalled();
 	});
 
@@ -53,12 +53,12 @@ describe('resolveViewerAccess', () => {
 
 		const result = await resolveViewerAccess(pb, item, null);
 
-		expect(result).toEqual({ wasMasked: true, viewerHasFullAccess: false });
+		expect(result).toEqual({ wasMasked: true, viewerHasFullAccess: false, unmasked: null });
 		expect(getOne).not.toHaveBeenCalled();
 		expect(item.name).toBeNull();
 	});
 
-	it('unmasks the item in place when items_searchable grants access', async () => {
+	it('returns the un-masked fields — without touching the item — when items_searchable grants access', async () => {
 		const getOne = vi.fn().mockResolvedValue({
 			collectionId: 'col1',
 			name: 'Bohrmaschine',
@@ -72,9 +72,22 @@ describe('resolveViewerAccess', () => {
 
 		const result = await resolveViewerAccess(pb, item, VIEWER_ID);
 
-		expect(result).toEqual({ wasMasked: true, viewerHasFullAccess: true });
-		expect(item.name).toBe('Bohrmaschine');
-		expect(item.image).toBe('img.jpg');
+		expect(result).toEqual({
+			wasMasked: true,
+			viewerHasFullAccess: true,
+			unmasked: {
+				collectionId: 'col1',
+				name: 'Bohrmaschine',
+				image: 'img.jpg',
+				externalImgUrl: null,
+				externalUrl: null,
+				description: 'Kraftvoll',
+			},
+		});
+		// The item itself stays untouched: siblings in the same concurrency wave must
+		// never observe a half-un-masked item (the caller merges after the wave).
+		expect(item.name).toBeNull();
+		expect(item.image).toBeNull();
 		expect(getOne).toHaveBeenCalledWith(
 			'item1',
 			expect.objectContaining({ fields: expect.stringContaining('name') })
@@ -88,7 +101,7 @@ describe('resolveViewerAccess', () => {
 
 		const result = await resolveViewerAccess(pb, item, VIEWER_ID);
 
-		expect(result).toEqual({ wasMasked: true, viewerHasFullAccess: false });
+		expect(result).toEqual({ wasMasked: true, viewerHasFullAccess: false, unmasked: null });
 		expect(item.name).toBeNull();
 	});
 });
@@ -212,12 +225,12 @@ describe('resolveTermsGate', () => {
 		const result = await resolveTermsGate(pb, VIEWER_ID, OWNER_ID);
 
 		expect(result).toBe(false);
-		expect(hasAcceptedTerms).not.toHaveBeenCalled();
+		expect(getAcceptance).not.toHaveBeenCalled();
 	});
 
 	it('returns false when active terms exist and the viewer already accepted them', async () => {
 		getActiveTerms.mockResolvedValue({ id: 'terms1' });
-		hasAcceptedTerms.mockResolvedValue(true);
+		getAcceptance.mockResolvedValue({ id: 'acc1' });
 
 		const result = await resolveTermsGate(pb, VIEWER_ID, OWNER_ID);
 
@@ -226,24 +239,40 @@ describe('resolveTermsGate', () => {
 
 	it('returns true (gate the request) when active terms exist and the viewer has not accepted them', async () => {
 		getActiveTerms.mockResolvedValue({ id: 'terms1' });
-		hasAcceptedTerms.mockResolvedValue(false);
+		getAcceptance.mockResolvedValue(null);
 
 		const result = await resolveTermsGate(pb, VIEWER_ID, OWNER_ID);
 
 		expect(result).toBe(true);
 	});
 
-	// The point of #525's terms dedupe: the already-resolved terms are threaded into
-	// the acceptance check, so the gate costs one `getActiveTerms` round-trip, not two.
-	it('fetches the active terms exactly once and threads them into the acceptance check', async () => {
-		const activeTerms = { id: 'terms1' };
-		getActiveTerms.mockResolvedValue(activeTerms);
-		hasAcceptedTerms.mockResolvedValue(true);
+	// The point of #525's terms dedupe: the id of the already-resolved terms goes
+	// straight into the acceptance lookup, so the gate costs one `getActiveTerms`
+	// round-trip, not two (`hasAcceptedActiveTerms` would resolve them again).
+	it('fetches the active terms exactly once and threads their id into the acceptance check', async () => {
+		getActiveTerms.mockResolvedValue({ id: 'terms1' });
+		getAcceptance.mockResolvedValue({ id: 'acc1' });
 
 		await resolveTermsGate(pb, VIEWER_ID, OWNER_ID);
 
 		expect(getActiveTerms).toHaveBeenCalledTimes(1);
-		expect(hasAcceptedTerms).toHaveBeenCalledWith(pb, VIEWER_ID, activeTerms);
+		expect(getAcceptance).toHaveBeenCalledWith(pb, VIEWER_ID, 'terms1', expect.any(String));
+	});
+
+	// Both reads run inside load()'s W4 wave next to evaluateUnmetRequirements, whose
+	// requirement `evaluate`s may read the same collections. Without distinct keys
+	// PocketBase auto-cancels a sibling and the swallowed AbortError opens the gate.
+	it('passes a distinct requestKey to each of its two reads', async () => {
+		getActiveTerms.mockResolvedValue({ id: 'terms1' });
+		getAcceptance.mockResolvedValue(null);
+
+		await resolveTermsGate(pb, VIEWER_ID, OWNER_ID);
+
+		const termsKey = getActiveTerms.mock.calls[0][2];
+		const acceptanceKey = getAcceptance.mock.calls[0][3];
+		expect(termsKey).toBeTruthy();
+		expect(acceptanceKey).toBeTruthy();
+		expect(termsKey).not.toBe(acceptanceKey);
 	});
 });
 

--- a/src/routes/items/[id]/itemDetailQueries.server.test.ts
+++ b/src/routes/items/[id]/itemDetailQueries.server.test.ts
@@ -2,11 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ItemPublic } from '$lib/types/models';
 import { makeMockPb } from '$lib/test-utils/pocketbase';
 
-const { getActiveTerms, getAcceptance } = vi.hoisted(() => ({
-	getActiveTerms: vi.fn(),
-	getAcceptance: vi.fn(),
+const { hasAcceptedActiveTerms } = vi.hoisted(() => ({
+	hasAcceptedActiveTerms: vi.fn(),
 }));
-vi.mock('$lib/server/lendingTerms', () => ({ getActiveTerms, getAcceptance }));
+vi.mock('$lib/server/lendingTerms', () => ({ hasAcceptedActiveTerms }));
 
 import {
 	resolveViewerAccess,
@@ -216,63 +215,41 @@ describe('resolveExistingConversation', () => {
 describe('resolveTermsGate', () => {
 	beforeEach(() => vi.clearAllMocks());
 
-	// `pb` is only forwarded to the mocked lendingTerms helpers, never queried here.
+	// `pb` is only forwarded to the mocked `hasAcceptedActiveTerms`, never queried here.
 	const pb = makeMockPb({});
 
-	it('returns false when the owner has no active terms', async () => {
-		getActiveTerms.mockResolvedValue(null);
-
-		const result = await resolveTermsGate(pb, VIEWER_ID, OWNER_ID);
-
-		expect(result).toBe(false);
-		expect(getAcceptance).not.toHaveBeenCalled();
-	});
-
-	it('returns false when active terms exist and the viewer already accepted them', async () => {
-		getActiveTerms.mockResolvedValue({ id: 'terms1' });
-		getAcceptance.mockResolvedValue({ id: 'acc1' });
+	it('returns false when hasAcceptedActiveTerms reports the terms as satisfied (no active terms, or already accepted)', async () => {
+		hasAcceptedActiveTerms.mockResolvedValue(true);
 
 		const result = await resolveTermsGate(pb, VIEWER_ID, OWNER_ID);
 
 		expect(result).toBe(false);
 	});
 
-	it('returns true (gate the request) when active terms exist and the viewer has not accepted them', async () => {
-		getActiveTerms.mockResolvedValue({ id: 'terms1' });
-		getAcceptance.mockResolvedValue(null);
+	it('returns true (gate the request) when hasAcceptedActiveTerms reports the terms as not accepted', async () => {
+		hasAcceptedActiveTerms.mockResolvedValue(false);
 
 		const result = await resolveTermsGate(pb, VIEWER_ID, OWNER_ID);
 
 		expect(result).toBe(true);
 	});
 
-	// The point of #525's terms dedupe: the id of the already-resolved terms goes
-	// straight into the acceptance lookup, so the gate costs one `getActiveTerms`
-	// round-trip, not two (`hasAcceptedActiveTerms` would resolve them again).
-	it('fetches the active terms exactly once and threads their id into the acceptance check', async () => {
-		getActiveTerms.mockResolvedValue({ id: 'terms1' });
-		getAcceptance.mockResolvedValue({ id: 'acc1' });
+	// The point of #615's dedupe: resolveTermsGate delegates to `hasAcceptedActiveTerms`
+	// instead of re-implementing its getActiveTerms→getAcceptance composition, so the
+	// "no active terms" / "most recent acceptance" rules live in one place and the round
+	// trip cost (2 reads: active terms + acceptance) can't drift from that helper's.
+	// Both request keys still travel through, distinct, so a sibling task in load()'s W4
+	// wave (e.g. evaluateUnmetRequirements) can't auto-cancel either read.
+	it('delegates to hasAcceptedActiveTerms exactly once, with the item-detail request keys', async () => {
+		hasAcceptedActiveTerms.mockResolvedValue(false);
 
 		await resolveTermsGate(pb, VIEWER_ID, OWNER_ID);
 
-		expect(getActiveTerms).toHaveBeenCalledTimes(1);
-		expect(getAcceptance).toHaveBeenCalledWith(pb, VIEWER_ID, 'terms1', expect.any(String));
-	});
-
-	// Both reads run inside load()'s W4 wave next to evaluateUnmetRequirements, whose
-	// requirement `evaluate`s may read the same collections. Without distinct keys
-	// PocketBase auto-cancels a sibling and the swallowed AbortError opens the gate.
-	it('passes a distinct requestKey to each of its two reads', async () => {
-		getActiveTerms.mockResolvedValue({ id: 'terms1' });
-		getAcceptance.mockResolvedValue(null);
-
-		await resolveTermsGate(pb, VIEWER_ID, OWNER_ID);
-
-		const termsKey = getActiveTerms.mock.calls[0][2];
-		const acceptanceKey = getAcceptance.mock.calls[0][3];
-		expect(termsKey).toBeTruthy();
-		expect(acceptanceKey).toBeTruthy();
-		expect(termsKey).not.toBe(acceptanceKey);
+		expect(hasAcceptedActiveTerms).toHaveBeenCalledTimes(1);
+		expect(hasAcceptedActiveTerms).toHaveBeenCalledWith(pb, VIEWER_ID, OWNER_ID, {
+			termsRequestKey: 'terms-gate-item',
+			acceptanceRequestKey: 'terms-acceptance-item',
+		});
 	});
 });
 
@@ -286,10 +263,16 @@ describe('countOwnerItems', () => {
 		const result = await countOwnerItems(pb, OWNER_ID);
 
 		expect(result).toBe(5);
+		// Explicit requestKey (#615 fix 2): getList's default auto-cancellation key is just
+		// `method + path` and ignores the query string, so without this a second concurrent
+		// items_public.getList anywhere in the request would silently cancel this one.
 		expect(getList).toHaveBeenCalledWith(
 			1,
 			1,
-			expect.objectContaining({ filter: expect.stringContaining(`userId = '${OWNER_ID}'`) })
+			expect.objectContaining({
+				filter: expect.stringContaining(`userId = '${OWNER_ID}'`),
+				requestKey: 'owner-item-count-item',
+			})
 		);
 	});
 

--- a/src/routes/items/[id]/itemDetailQueries.server.ts
+++ b/src/routes/items/[id]/itemDetailQueries.server.ts
@@ -1,5 +1,5 @@
 import type { ItemPublic } from '$lib/types/models';
-import { getAcceptance, getActiveTerms } from '$lib/server/lendingTerms';
+import { hasAcceptedActiveTerms } from '$lib/server/lendingTerms';
 import { OPEN_LENDING_STATES, lendingStatusFilter } from '$lib/lending';
 
 export type ViewerAccess = {
@@ -125,26 +125,35 @@ export async function resolveExistingConversation(
 }
 
 // Does this owner publish lending terms, and if so has the viewer NOT accepted them?
-// Composes `getActiveTerms` + `getAcceptance` instead of calling `hasAcceptedActiveTerms`
-// (which re-resolves the active terms itself) — one round-trip per lookup within one
-// load(). Both reads carry a call-site-specific requestKey so a sibling task in the same
-// concurrency wave reading `lending_terms`/`term_acceptances` (e.g. a future requirement's
-// `evaluate`) can't auto-cancel them into a silently open gate.
+// Delegates to `hasAcceptedActiveTerms` (the same helper the `startConversation` POST
+// guard in +page.server.ts uses) so the "no active terms → satisfied" / "acceptance is
+// the most recent row for that exact version" rules live in exactly one place — two
+// copies of that composition could silently drift out of sync. Still exactly 2
+// PocketBase reads (active terms + acceptance): each gets its own call-site-specific
+// requestKey via `opts` so a sibling task in the same concurrency wave reading
+// `lending_terms`/`term_acceptances` (e.g. a future requirement's `evaluate`) can't
+// auto-cancel either into a silently open gate.
 export async function resolveTermsGate(
 	pb: App.Locals['pb'],
 	currentUserId: string,
 	ownerId: string
 ): Promise<boolean> {
-	const activeTerms = await getActiveTerms(pb, ownerId, 'terms-gate-item');
-	if (!activeTerms) return false;
-	return (await getAcceptance(pb, currentUserId, activeTerms.id, 'terms-acceptance-item')) === null;
+	return !(await hasAcceptedActiveTerms(pb, currentUserId, ownerId, {
+		termsRequestKey: 'terms-gate-item',
+		acceptanceRequestKey: 'terms-acceptance-item',
+	}));
 }
 
-// Total items listed by this owner (all statuses); 0 on failure.
+// Total items listed by this owner (all statuses); 0 on failure. Explicit requestKey:
+// unlike getFirstListItem (whose SDK default key already folds in the filter), getList's
+// default auto-cancellation key is just `method + path` and ignores the query string —
+// so a second concurrent items_public.getList anywhere in the same request would
+// silently cancel this one and the count would fall back to 0.
 export async function countOwnerItems(pb: App.Locals['pb'], ownerId: string): Promise<number> {
 	try {
 		const { totalItems } = await pb.collection('items_public').getList(1, 1, {
 			filter: pb.filter('userId = {:userId}', { userId: ownerId }),
+			requestKey: 'owner-item-count-item',
 		});
 		return totalItems;
 	} catch {

--- a/src/routes/items/[id]/itemDetailQueries.server.ts
+++ b/src/routes/items/[id]/itemDetailQueries.server.ts
@@ -1,6 +1,15 @@
 import type { ItemPublic } from '$lib/types/models';
-import { getActiveTerms, hasAcceptedTerms } from '$lib/server/lendingTerms';
+import { getAcceptance, getActiveTerms } from '$lib/server/lendingTerms';
 import { OPEN_LENDING_STATES, lendingStatusFilter } from '$lib/lending';
+
+export type ViewerAccess = {
+	wasMasked: boolean;
+	viewerHasFullAccess: boolean;
+	/** The un-masked fields for the caller to merge into its item, or null if nothing
+	 *  was un-masked. Returned rather than written into `item` so this can run inside a
+	 *  concurrency wave without its siblings observing a half-mutated item. */
+	unmasked: Partial<ItemPublic> | null;
+};
 
 // items_public masks RESTRICTED items (trustees-only OR shared with a group):
 // name/image/description come back NULL. The owner, trusted viewers and members
@@ -11,31 +20,40 @@ import { OPEN_LENDING_STATES, lendingStatusFilter } from '$lib/lending';
 // We read full fields from the trust/group-filtered `items_searchable` view —
 // incl. `collectionId` and the un-masked `image` — so the image file URL resolves
 // (a URL built from the items_public row would 404, since its image is NULL).
-// Un-masks `item` in place; returns whether the viewer may see full details.
+// Reads `item` but never writes it; the un-masked fields come back in `unmasked`
+// for the caller to apply once every concurrent sibling has settled.
 export async function resolveViewerAccess(
 	pb: App.Locals['pb'],
 	item: ItemPublic,
 	currentUserId: string | null
-): Promise<{ wasMasked: boolean; viewerHasFullAccess: boolean }> {
-	const wasMasked = item.name == null;
-	let viewerHasFullAccess = !wasMasked; // unmasked == public == visible to everyone
-	if (wasMasked && currentUserId) {
+): Promise<ViewerAccess> {
+	if (item.name != null) {
+		// not masked == public == visible to everyone, nothing to un-mask
+		return { wasMasked: false, viewerHasFullAccess: true, unmasked: null };
+	}
+	if (currentUserId) {
 		try {
 			const full = await pb.collection('items_searchable').getOne(item.id, {
 				fields: 'collectionId,name,image,externalImgUrl,externalUrl,description',
 			});
-			item.collectionId = full.collectionId;
-			item.name = full.name;
-			item.image = full.image;
-			item.externalImgUrl = full.externalImgUrl;
-			item.externalUrl = full.externalUrl;
-			item.description = full.description;
-			viewerHasFullAccess = true;
+			return {
+				wasMasked: true,
+				viewerHasFullAccess: true,
+				unmasked: {
+					collectionId: full.collectionId,
+					name: full.name,
+					image: full.image,
+					externalImgUrl: full.externalImgUrl,
+					externalUrl: full.externalUrl,
+					description: full.description,
+				},
+			};
 		} catch {
-			// No access (or not logged in) -> details stay masked.
+			// No access -> details stay masked.
 		}
 	}
-	return { wasMasked, viewerHasFullAccess };
+	// Masked and either anonymous or not permitted.
+	return { wasMasked: true, viewerHasFullAccess: false, unmasked: null };
 }
 
 export type OwnerContact =
@@ -106,18 +124,20 @@ export async function resolveExistingConversation(
 	}
 }
 
-// Does this owner publish lending terms, and if so has the viewer accepted them?
-// Threads the already-resolved `activeTerms` into `hasAcceptedTerms` directly
-// instead of calling `hasAcceptedActiveTerms` (which would re-fetch `getActiveTerms`
-// itself) — avoids a duplicated round-trip for the same lookup within one load().
+// Does this owner publish lending terms, and if so has the viewer NOT accepted them?
+// Composes `getActiveTerms` + `getAcceptance` instead of calling `hasAcceptedActiveTerms`
+// (which re-resolves the active terms itself) — one round-trip per lookup within one
+// load(). Both reads carry a call-site-specific requestKey so a sibling task in the same
+// concurrency wave reading `lending_terms`/`term_acceptances` (e.g. a future requirement's
+// `evaluate`) can't auto-cancel them into a silently open gate.
 export async function resolveTermsGate(
 	pb: App.Locals['pb'],
 	currentUserId: string,
 	ownerId: string
 ): Promise<boolean> {
-	const activeTerms = await getActiveTerms(pb, ownerId);
+	const activeTerms = await getActiveTerms(pb, ownerId, 'terms-gate-item');
 	if (!activeTerms) return false;
-	return !(await hasAcceptedTerms(pb, currentUserId, activeTerms));
+	return (await getAcceptance(pb, currentUserId, activeTerms.id, 'terms-acceptance-item')) === null;
 }
 
 // Total items listed by this owner (all statuses); 0 on failure.

--- a/src/routes/items/[id]/itemDetailQueries.server.ts
+++ b/src/routes/items/[id]/itemDetailQueries.server.ts
@@ -1,5 +1,5 @@
 import type { ItemPublic } from '$lib/types/models';
-import { getActiveTerms, hasAcceptedActiveTerms } from '$lib/server/lendingTerms';
+import { getActiveTerms, hasAcceptedTerms } from '$lib/server/lendingTerms';
 import { OPEN_LENDING_STATES, lendingStatusFilter } from '$lib/lending';
 
 // items_public masks RESTRICTED items (trustees-only OR shared with a group):
@@ -107,6 +107,9 @@ export async function resolveExistingConversation(
 }
 
 // Does this owner publish lending terms, and if so has the viewer accepted them?
+// Threads the already-resolved `activeTerms` into `hasAcceptedTerms` directly
+// instead of calling `hasAcceptedActiveTerms` (which would re-fetch `getActiveTerms`
+// itself) — avoids a duplicated round-trip for the same lookup within one load().
 export async function resolveTermsGate(
 	pb: App.Locals['pb'],
 	currentUserId: string,
@@ -114,7 +117,7 @@ export async function resolveTermsGate(
 ): Promise<boolean> {
 	const activeTerms = await getActiveTerms(pb, ownerId);
 	if (!activeTerms) return false;
-	return !(await hasAcceptedActiveTerms(pb, currentUserId, ownerId));
+	return !(await hasAcceptedTerms(pb, currentUserId, activeTerms));
 }
 
 // Total items listed by this owner (all statuses); 0 on failure.

--- a/src/routes/items/[id]/page.server.test.ts
+++ b/src/routes/items/[id]/page.server.test.ts
@@ -10,17 +10,19 @@ vi.mock('$lib/server/notifications.js', () => ({
 	createNotification: vi.fn(),
 	sendPushToUser: vi.fn(),
 }));
-// Lending-flow helpers are exercised by their own suites; stub them here.
-const { getActiveTerms, hasAcceptedTerms, hasAcceptedActiveTerms, evaluateUnmetRequirements } =
+// Lending-flow helpers are exercised by their own suites; stub them here. The terms
+// gate itself is asserted in itemDetailQueries.server.test.ts (resolveTermsGate) — this
+// suite only needs the gate to stay closed so the load path runs.
+const { getActiveTerms, getAcceptance, hasAcceptedActiveTerms, evaluateUnmetRequirements } =
 	vi.hoisted(() => ({
 		getActiveTerms: vi.fn(),
-		hasAcceptedTerms: vi.fn(),
+		getAcceptance: vi.fn(),
 		hasAcceptedActiveTerms: vi.fn(),
 		evaluateUnmetRequirements: vi.fn(),
 	}));
 vi.mock('$lib/server/lendingTerms', () => ({
 	getActiveTerms,
-	hasAcceptedTerms,
+	getAcceptance,
 	hasAcceptedActiveTerms,
 }));
 vi.mock('$lib/server/lendingRequirements', () => ({
@@ -347,7 +349,6 @@ describe('items/[id] load — wave concurrency and the trust auto-cancellation t
 	beforeEach(() => {
 		vi.clearAllMocks();
 		getActiveTerms.mockResolvedValue(null);
-		hasAcceptedTerms.mockResolvedValue(true);
 		hasAcceptedActiveTerms.mockResolvedValue(true);
 		evaluateUnmetRequirements.mockResolvedValue([]);
 	});
@@ -445,22 +446,6 @@ describe('items/[id] load — wave concurrency and the trust auto-cancellation t
 		expect(trustsGetList).toHaveBeenCalledTimes(1);
 		// ownerTrustsViewer stays forced false on your own item, regardless of edges.
 		expect(data.ownerTrustsViewer).toBe(false);
-	});
-
-	it('calls getActiveTerms exactly once per load, threading the resolved terms into hasAcceptedTerms instead of re-fetching via hasAcceptedActiveTerms', async () => {
-		const activeTerms = { id: 'terms1' };
-		getActiveTerms.mockResolvedValue(activeTerms);
-		hasAcceptedTerms.mockResolvedValue(false);
-		const { pb } = makePb({});
-
-		const data = await callLoad(pb);
-
-		expect(getActiveTerms).toHaveBeenCalledTimes(1);
-		expect(hasAcceptedTerms).toHaveBeenCalledWith(pb, VIEWER_ID, activeTerms);
-		// hasAcceptedActiveTerms would re-fetch getActiveTerms internally — the load
-		// path must not use it (the startConversation action still does).
-		expect(hasAcceptedActiveTerms).not.toHaveBeenCalled();
-		expect(data.requiresTermsAcceptance).toBe(true);
 	});
 });
 

--- a/src/routes/items/[id]/page.server.test.ts
+++ b/src/routes/items/[id]/page.server.test.ts
@@ -11,12 +11,18 @@ vi.mock('$lib/server/notifications.js', () => ({
 	sendPushToUser: vi.fn(),
 }));
 // Lending-flow helpers are exercised by their own suites; stub them here.
-const { getActiveTerms, hasAcceptedActiveTerms, evaluateUnmetRequirements } = vi.hoisted(() => ({
-	getActiveTerms: vi.fn(),
-	hasAcceptedActiveTerms: vi.fn(),
-	evaluateUnmetRequirements: vi.fn(),
+const { getActiveTerms, hasAcceptedTerms, hasAcceptedActiveTerms, evaluateUnmetRequirements } =
+	vi.hoisted(() => ({
+		getActiveTerms: vi.fn(),
+		hasAcceptedTerms: vi.fn(),
+		hasAcceptedActiveTerms: vi.fn(),
+		evaluateUnmetRequirements: vi.fn(),
+	}));
+vi.mock('$lib/server/lendingTerms', () => ({
+	getActiveTerms,
+	hasAcceptedTerms,
+	hasAcceptedActiveTerms,
 }));
-vi.mock('$lib/server/lendingTerms', () => ({ getActiveTerms, hasAcceptedActiveTerms }));
 vi.mock('$lib/server/lendingRequirements', () => ({
 	evaluateUnmetRequirements,
 	requirementRegistry: [],
@@ -61,6 +67,12 @@ function makePb(opts: {
 	itemExtra?: Record<string, unknown>;
 	conversationsGetFirstListItem?: ReturnType<typeof vi.fn>;
 	preferredTransportMode?: 'foot' | 'bicycle' | 'car';
+	/** Raw {truster, trustee} rows the mocked `trusts.getList` (getTrustDirections) returns. */
+	trustEdges?: Array<{ truster: string; trustee: string }>;
+	/** Per-collection method overrides, merged over the defaults below — lets a test
+	 *  swap in e.g. deferred-promise mocks for specific methods without hand-building
+	 *  a whole separate pb (and drifting from this factory as collections are added). */
+	overrides?: Partial<Record<string, Record<string, ReturnType<typeof vi.fn>>>>;
 }) {
 	const usersGetOne = vi.fn().mockResolvedValue({
 		contactMethod: opts.contactMethod ?? '',
@@ -77,38 +89,33 @@ function makePb(opts: {
 				preferredTransportMode: opts.preferredTransportMode,
 			})
 		: vi.fn().mockRejectedValue(new Error('none'));
+	// getTrustDirections() probes here in ONE request; default: no trust edge either way.
+	const trustsGetList = vi.fn().mockResolvedValue({ items: opts.trustEdges ?? [] });
 	const base = publicItem(opts.itemExtra);
 	const itemRow = opts.masked ? { ...base, name: null } : base;
+	const collections: Record<string, Record<string, ReturnType<typeof vi.fn>>> = {
+		items_public: {
+			getOne: vi.fn().mockResolvedValue(itemRow),
+			getList: vi.fn().mockResolvedValue({ totalItems: 3 }),
+		},
+		// Unmask attempt: denied for a restricted viewer.
+		items_searchable: { getOne: vi.fn().mockRejectedValue(new Error('no access')) },
+		trusts: { getList: trustsGetList },
+		users: { getOne: usersGetOne },
+		conversations: { getFirstListItem: convGetFirstListItem },
+		user_preferences: { getFirstListItem: prefsGetFirstListItem },
+	};
+	for (const [name, methods] of Object.entries(opts.overrides ?? {})) {
+		collections[name] = { ...collections[name], ...methods };
+	}
 	const pb = {
-		collection: vi.fn((name: string) => {
-			switch (name) {
-				case 'items_public':
-					return {
-						getOne: vi.fn().mockResolvedValue(itemRow),
-						getList: vi.fn().mockResolvedValue({ totalItems: 3 }),
-					};
-				case 'items_searchable':
-					// Unmask attempt: denied for a restricted viewer.
-					return { getOne: vi.fn().mockRejectedValue(new Error('no access')) };
-				case 'trusts':
-					// isTrusting() probes here; default: no trust edge in either direction.
-					return { getFirstListItem: vi.fn().mockRejectedValue(new Error('not trusted')) };
-				case 'users':
-					return { getOne: usersGetOne };
-				case 'conversations':
-					return { getFirstListItem: convGetFirstListItem };
-				case 'user_preferences':
-					return { getFirstListItem: prefsGetFirstListItem };
-				default:
-					return {};
-			}
-		}),
+		collection: vi.fn((name: string) => collections[name] ?? {}),
 		filter: vi.fn(mockFilter),
 		// Real PocketBase: authStore.isValid is false for a guest. Driven per-call in
 		// callLoad() from whether a user is passed, so the anonymous path is faithful.
 		authStore: { isValid: true },
 	};
-	return { pb, usersGetOne, convGetFirstListItem, prefsGetFirstListItem };
+	return { pb, usersGetOne, convGetFirstListItem, prefsGetFirstListItem, trustsGetList };
 }
 
 function callLoad(
@@ -333,6 +340,127 @@ describe('items/[id] load — preferred transport mode (#426, from user_preferen
 		expect(data.preferredTransportMode).toBe('bicycle');
 		// The `currentUserId ? … : null` guard must short-circuit — no query for a guest.
 		expect(prefsGetFirstListItem).not.toHaveBeenCalled();
+	});
+});
+
+describe('items/[id] load — wave concurrency and the trust auto-cancellation trap (#525)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		getActiveTerms.mockResolvedValue(null);
+		hasAcceptedTerms.mockResolvedValue(true);
+		hasAcceptedActiveTerms.mockResolvedValue(true);
+		evaluateUnmetRequirements.mockResolvedValue([]);
+	});
+
+	function createDeferred<T>() {
+		let resolve!: (value: T) => void;
+		let reject!: (reason?: unknown) => void;
+		const promise = new Promise<T>((res, rej) => {
+			resolve = res;
+			reject = rej;
+		});
+		return { promise, resolve, reject };
+	}
+
+	// A macrotask boundary drains every pending microtask, incl. Promise.all's
+	// internal `.then` hops — a bare `await Promise.resolve()` only advances one
+	// tick and can leave those hops unresolved (flaky).
+	async function flushPendingPromises() {
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	}
+
+	it('issues all five W2 requests concurrently — none has resolved before the others start', async () => {
+		const trustsDeferred = createDeferred<{ items: Array<{ truster: string; trustee: string }> }>();
+		const searchableDeferred = createDeferred<Record<string, unknown>>();
+		const convDeferred = createDeferred<never>();
+		const itemsPublicListDeferred = createDeferred<{ totalItems: number }>();
+		const prefsDeferred = createDeferred<never>();
+
+		const trustsGetList = vi.fn().mockReturnValue(trustsDeferred.promise);
+		const searchableGetOne = vi.fn().mockReturnValue(searchableDeferred.promise);
+		const convGetFirstListItem = vi.fn().mockReturnValue(convDeferred.promise);
+		const itemsPublicGetList = vi.fn().mockReturnValue(itemsPublicListDeferred.promise);
+		const prefsGetFirstListItem = vi.fn().mockReturnValue(prefsDeferred.promise);
+
+		// Masked item + authenticated non-owner viewer so every one of the five W2
+		// tasks actually issues its request (viewer-access unmask included).
+		const { pb } = makePb({
+			masked: true,
+			overrides: {
+				trusts: { getList: trustsGetList },
+				items_searchable: { getOne: searchableGetOne },
+				conversations: { getFirstListItem: convGetFirstListItem },
+				items_public: { getList: itemsPublicGetList },
+				user_preferences: { getFirstListItem: prefsGetFirstListItem },
+			},
+		});
+
+		const loadPromise = callLoad(pb);
+
+		await flushPendingPromises();
+
+		// All five W2 collection calls have fired while every one of them is still
+		// pending — if load() ran them sequentially instead, a task after the first
+		// pending one would never have been called at all.
+		expect(trustsGetList).toHaveBeenCalledTimes(1);
+		expect(searchableGetOne).toHaveBeenCalledTimes(1);
+		expect(convGetFirstListItem).toHaveBeenCalledTimes(1);
+		expect(itemsPublicGetList).toHaveBeenCalledTimes(1);
+		expect(prefsGetFirstListItem).toHaveBeenCalledTimes(1);
+
+		trustsDeferred.resolve({ items: [] });
+		searchableDeferred.resolve({
+			collectionId: 'c1',
+			name: 'Bohrmaschine',
+			image: 'img.png',
+			externalImgUrl: '',
+			externalUrl: '',
+			description: 'desc',
+		});
+		convDeferred.reject(new Error('none'));
+		itemsPublicListDeferred.resolve({ totalItems: 3 });
+		prefsDeferred.reject(new Error('none'));
+
+		await loadPromise;
+	});
+
+	it('queries trusts exactly once and still reports viewerTrustsOwner=true from a single directional edge (regression — would catch a naive Promise.all of two isTrusting calls colliding on the same path)', async () => {
+		const { pb, trustsGetList } = makePb({
+			trustEdges: [{ truster: VIEWER_ID, trustee: OWNER_ID }],
+		});
+
+		const data = await callLoad(pb);
+
+		expect(trustsGetList).toHaveBeenCalledTimes(1);
+		expect(data.viewerTrustsOwner).toBe(true);
+		expect(data.ownerTrustsViewer).toBe(false);
+	});
+
+	it('still queries trusts on the viewer\'s own item (request count per persona unchanged)', async () => {
+		const { pb, trustsGetList } = makePb({});
+
+		const data = await callLoad(pb, { id: OWNER_ID });
+
+		expect(data.isOwnItem).toBe(true);
+		expect(trustsGetList).toHaveBeenCalledTimes(1);
+		// ownerTrustsViewer stays forced false on your own item, regardless of edges.
+		expect(data.ownerTrustsViewer).toBe(false);
+	});
+
+	it('calls getActiveTerms exactly once per load, threading the resolved terms into hasAcceptedTerms instead of re-fetching via hasAcceptedActiveTerms', async () => {
+		const activeTerms = { id: 'terms1' };
+		getActiveTerms.mockResolvedValue(activeTerms);
+		hasAcceptedTerms.mockResolvedValue(false);
+		const { pb } = makePb({});
+
+		const data = await callLoad(pb);
+
+		expect(getActiveTerms).toHaveBeenCalledTimes(1);
+		expect(hasAcceptedTerms).toHaveBeenCalledWith(pb, VIEWER_ID, activeTerms);
+		// hasAcceptedActiveTerms would re-fetch getActiveTerms internally — the load
+		// path must not use it (the startConversation action still does).
+		expect(hasAcceptedActiveTerms).not.toHaveBeenCalled();
+		expect(data.requiresTermsAcceptance).toBe(true);
 	});
 });
 

--- a/src/routes/users/[id]/+page.server.ts
+++ b/src/routes/users/[id]/+page.server.ts
@@ -56,9 +56,15 @@ export async function load({ params, locals }) {
 	// trust list ever leaves the server. Both directions in ONE query (see
 	// getTrustDirections in trust.ts) rather than two separate lookups against the
 	// same `trusts` path.
-	const { aTrustsB: viewerTrustsProfile, bTrustsA: profileTrustsViewer } = currentUser
-		? await getTrustDirections(locals.pb, currentUser.id, profileUser.id, 'trust-directions-profile')
-		: NO_TRUST_DIRECTIONS;
+	const { viewerTrustsOther: viewerTrustsProfile, otherTrustsViewer: profileTrustsViewer } =
+		currentUser
+			? await getTrustDirections(
+					locals.pb,
+					currentUser.id,
+					profileUser.id,
+					'trust-directions-profile'
+				)
+			: NO_TRUST_DIRECTIONS;
 
 	// items_public masks RESTRICTED items (trustees-only OR group-shared): their
 	// name comes back NULL. Unmasked rows are public.

--- a/src/routes/users/[id]/+page.server.ts
+++ b/src/routes/users/[id]/+page.server.ts
@@ -3,7 +3,12 @@ import { PUBLIC_PB_URL } from '$env/static/public';
 import type { Item, User } from '$lib/types/models.js';
 import type { ClientResponseError } from 'pocketbase';
 import { texts } from '$lib/texts';
-import { addTrustAndNotify, removeTrust as removeTrustEdge, isTrusting } from '$lib/server/trust';
+import {
+	addTrustAndNotify,
+	removeTrust as removeTrustEdge,
+	getTrustDirections,
+	NO_TRUST_DIRECTIONS,
+} from '$lib/server/trust';
 
 export async function load({ params, locals }) {
 
@@ -48,13 +53,12 @@ export async function load({ params, locals }) {
 	const currentUser = locals.user;
 	const isOwnProfile = currentUser?.id === profileUser.id;
 	// Directional trust, both resolved server-side against the `trusts` join so no
-	// trust list ever leaves the server.
-	const viewerTrustsProfile = currentUser
-		? await isTrusting(locals.pb, currentUser.id, profileUser.id)
-		: false;
-	const profileTrustsViewer = currentUser
-		? await isTrusting(locals.pb, profileUser.id, currentUser.id)
-		: false;
+	// trust list ever leaves the server. Both directions in ONE query (see
+	// getTrustDirections in trust.ts) rather than two separate lookups against the
+	// same `trusts` path.
+	const { aTrustsB: viewerTrustsProfile, bTrustsA: profileTrustsViewer } = currentUser
+		? await getTrustDirections(locals.pb, currentUser.id, profileUser.id, 'trust-directions-profile')
+		: NO_TRUST_DIRECTIONS;
 
 	// items_public masks RESTRICTED items (trustees-only OR group-shared): their
 	// name comes back NULL. Unmasked rows are public.


### PR DESCRIPTION
## What

The item detail page load (`src/routes/items/[id]/+page.server.ts`) issued up to 12 strictly sequential PocketBase requests. This groups the independent lookups into concurrent `Promise.all` waves and removes a duplicated round-trip:

```
W1  items_public.getOne                                        (blocks everything)
W2  Promise.all: trust directions | viewer-access unmask | existing conversation
                 | owner item count | user preferences
W3  owner contact                  (needs W2's isTrustRestricted)
W4  Promise.all: terms gate | unmet requirements    (both need W3's ownerContact)
```

- **`getTrustDirections`** (new, `src/lib/server/trust.ts`) resolves both trust directions between two users in **one** query instead of two `isTrusting()` calls. This isn't just an optimization: the PocketBase JS SDK auto-cancels in-flight requests keyed by `method + path` when no distinct `requestKey` is given, and both directions of `isTrusting` hit the identical `trusts` list endpoint — a naive `Promise.all` of the two would make the SDK abort the first call, and `isTrusting`'s catch swallows that abort into a silent `false`. One combined query avoids the race entirely.
- Also migrates `src/routes/users/[id]/+page.server.ts` (profile page) to the same helper — it had the identical two-lookup-same-path pattern (sequential today, so not a live bug there, but the same trap for the next person to "optimize" it).
- Drops the duplicated `getActiveTerms` round-trip: `resolveTermsGate` now threads the already-fetched terms into a new `hasAcceptedTerms` helper instead of calling `hasAcceptedActiveTerms` (which re-fetched `getActiveTerms` internally). `hasAcceptedActiveTerms` now delegates to the same helper, so there's one definition of "has accepted."
- Every original gate (own-item, anonymous, off-platform-contact, trust-restricted) is preserved exactly — no persona issues a request it didn't issue before, and the data-minimization guarantees the existing tests assert (no `users.getOne` for a restricted/own-item viewer, no `evaluateUnmetRequirements` for off-platform-contact owners) are unchanged.

Closes #525. The `expand` half of the issue's ACs was evaluated and dropped (see issue comment): this route reads `items_public`, a view that already denormalizes the owner as scalar columns, so there's no relation to expand.

## Why

Flagged during an architecture review: SvelteKit's `load()` blocks on all sequential round-trips before the page renders, adding latency to SSR of the most-visited page type. See issue #525 and its evaluation comment for the full request-dependency analysis.

## Test notes

**Automated (all green):**
- `npx vitest run` — 712/712 passed, including new tests: `getTrustDirections` (both/one/neither direction, query failure, single-request assertion), a concurrency test proving all 5 W2 requests fire before any resolve, a regression test asserting `trusts` is queried exactly once per load and `viewerTrustsOwner` reports `true` from a single directional edge (the case a naive `Promise.all` of two `isTrusting` calls would get wrong), and a call-count assertion on `getActiveTerms`.
- `npm run check` — 0 errors (10 pre-existing warnings in untouched files).
- `npm run lint` — clean.
- `npm run build` — succeeds.

**Manual, against a real PocketBase stack** (isolated instance, not mocks — this verifies the combined trust filter is actually permitted by the `trusts` collection's list rule and returns the right rows, which only had mock coverage otherwise):
- Trusted viewer opening a trustees-only item: unmasked correctly, "Diese Person vertraut dir" renders (owner→viewer edge, asymmetric — viewer does not trust owner back). PocketBase log confirms exactly one `trusts` query combining the OR filter with the collection's list rule.
- Same asymmetric edge on the profile page (`users/[id]`): both directions render correctly independently.
- Anonymous viewer on a public item: exactly 2 requests (item + owner-item-count) — anonymous path is unchanged, as expected.
- Authenticated non-owner request sequence in the PocketBase log matches the planned wave structure exactly (W1 → W2's 5 concurrent calls → W3 → W4).
- No console errors on any persona.

Reviewed by all four applicable review roles (`sveltekit-pb-reviewer`, `code-quality-reviewer`, `conventions-reviewer`; `a11y-reviewer` skipped — no markup changed) with a full fix loop before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)