### PR TITLE
fix(profile): bind editable fields so hydration can't clobber input (#558)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -78,7 +78,9 @@ use a gitignored `CLAUDE.local.md` at the repo root — it loads alongside this 
 These prevent the most common bugs/security issues here — follow them without being asked.
 
 - **Never destructure the `data` prop.** Access `data.x` directly in markup; assigning
-  `let x = data.x` detaches `use:enhance` reactivity. → `docs/best-practices.md`
+  `let x = data.x` detaches `use:enhance` reactivity — and a *user-editable* field seeded from
+  `data.x`/a prop needs a seed-once `$state` + `bind:value`, never one-way `value=`, or hydration
+  clobbers it (issue #558). → `docs/best-practices.md`
 - **Always build PocketBase filters with `pb.filter(raw, {params})`** — never template-literal
   interpolation. Applies to *every* value, including IDs from `locals.user.id` / route params
   (filter injection). Use `locals.pb.filter(...)` in routes, `pb.filter(...)` in `$lib/server/*`.

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -54,6 +54,73 @@ The important part here is that we **do not destructure the data object**. For e
 
 However, this detaches the Svelte-internal reactivity from database updates, and hence deactivates the "use:enhance" functionality. Therefore, if a UI component should react to form actions, it needs to be getting its data directly from the "data"-prop.
 
+### Editable fields: seed-once + `bind:`, never one-way `value=`
+
+**Rule:** once a form field is user-editable, its DOM value must come from `bind:value` (or
+`bind:checked`, …) backed by a local `$state` that is **seeded once** from the loaded value —
+never a one-way `value={…}` fed by a prop or by `data`. Seed it once and don't re-sync it
+afterwards:
+
+```svelte
+<script lang="ts">
+	let { bio }: { bio: string } = $props();
+
+	// Seed once from the loaded value; bind: takes over from here.
+	// svelte-ignore state_referenced_locally
+	let bioValue = $state(bio);
+</script>
+
+<textarea name="bio" bind:value={bioValue}></textarea>
+```
+
+**Why:** a one-way `value={…}` compiles to a `set_value()` call with no memory of what the DOM
+already holds. On an ordinary re-render this is harmless — `set_value` caches the last value it
+wrote and skips a redundant write. But its very **first** pass, at hydration, has no cache yet:
+it writes the loaded value over the DOM **unconditionally**, clobbering anything the user already
+typed into the server-rendered input before the JS bundle finished loading (real on slower
+connections/devices — issue #558, where text typed during that window was silently discarded and
+an empty value saved instead, behind a success toast). `bind:value` compiles to `bind_value`,
+which carries a hydration guard: it **adopts** the DOM's existing value instead of overwriting
+it, so pre-hydration input survives. The server-rendered HTML is identical either way — this is
+a hydration-safety fix, not a no-JS regression.
+
+Reference implementation: the `src/routes/user/profile/` section components —
+`ExternalLendingInfoSection.svelte`, `ProfileBasicsSection.svelte` and `ContactSection.svelte`
+keep the prop's own name and suffix the local `$state` with `Value` (`bio` → `bioValue`);
+`MessengerField.svelte` instead renames the *prop* to `initialValue` and keeps the local named
+`value` — see the escape hatch below for why. The `// svelte-ignore state_referenced_locally`
+comment is required immediately above the seeding `$state(...)` line — the compiler warns
+whenever a `$state` initializer reads another reactive value (a prop, here) — but only where the
+warning actually fires; `svelte/no-unused-svelte-ignore` is an error-level lint rule, so don't add
+the comment speculatively.
+
+**Escape hatch — when the prop is already named `value`:** `let { value } = $props()` followed by
+`let value = $state(value)` is a duplicate `let value` declaration in the same scope — a
+compile-time parse error, not shadowing (shadowing needs two distinct scopes) — so one of the two
+names must change. Rename the *prop* to `initialValue` (not the local) and keep the local `$state`
+named `value`, so the input can use the bare `bind:value` shorthand and the seed-once contract
+stays visible at the call site. See `MessengerField.svelte`.
+
+**Two anti-patterns that look like fixes but reintroduce the bug in a different shape:**
+
+- **A writable `$derived` (e.g. `$lib/stores/realtimeSynced.svelte.ts`) that re-seeds the field
+  whenever its source changes.** The root layout (`src/routes/+layout.svelte`) invalidates
+  `NOTIFICATIONS_DEP` after every navigation and on every realtime reconnect. A field wired
+  through a primitive that re-syncs on invalidation doesn't just clobber at hydration — it
+  discards unsaved input on the next navigation or reconnect, too. (`realtimeSynced` is the
+  right tool when re-sync-on-invalidate is the actual goal, e.g. realtime conversation state —
+  just not for a plain editable field.)
+- **A sync `$effect` that re-seeds the local `$state` from the prop.** Same discard-on-invalidate
+  problem as above, and `svelte/prefer-writable-derived` is an error-level lint rule that
+  specifically flags this shape — treat that as a correct rejection of the pattern here, not a
+  style nit to suppress.
+
+This doesn't change the "never destructure the `data` prop" rule above: the page's `data` prop
+itself stays one-way and un-destructured. That rule is about not *detaching* reactivity from
+`data`; this one is about not letting that reactivity *clobber* in-progress input on a field the
+user can type into. Seeding a local `$state` from `data.x` once, at initialization, reads `data.x`
+exactly once and does not detach anything.
+
 ### The submit action
 
 Submit actions are defined in the server-side `+page.server.ts` file like so:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -36,6 +36,18 @@ npm run test:e2e:ui       # interactive UI mode
 npm run test:e2e:report   # open the last HTML report
 ```
 
+### Repeating a spec (flake / hydration-race hunting)
+
+To confirm a fix isn't timing-dependent (e.g. #558's hydration-clobber regression), repeat a
+spec file several times with `--repeat-each`. Force `--workers=1` for any spec that saves a
+shared seed user — e.g. `profile.spec.ts` writes to `e2e_stranger_seed` — otherwise the
+repeated copies run in parallel workers that race to save/reload the _same_ row, and a
+"reload and find my bio" assertion stops holding by construction:
+
+```bash
+npx playwright test e2e/tests/profile.spec.ts --repeat-each=3 --workers=1
+```
+
 ### Environment variables
 
 | Var                     | Default                 | Purpose                                                                |

--- a/e2e/fixtures/users.ts
+++ b/e2e/fixtures/users.ts
@@ -22,7 +22,11 @@ export const THIRD = {
 	password: SEED_PASSWORD,
 };
 
-/** A stably-untrusted bystander: no test mutates it, so parallel tests can rely on it. */
+/**
+ * A bystander whose trust/group state no test mutates, so parallel tests can rely on it for
+ * untrusted-state assertions. profile.spec.ts does save its bio/contact/requirements/
+ * preferences fields, but no other spec asserts on those.
+ */
 export const STRANGER = {
 	username: 'e2e_stranger_seed',
 	email: 'e2e_stranger_seed@seed.test',

--- a/e2e/tests/profile.spec.ts
+++ b/e2e/tests/profile.spec.ts
@@ -2,12 +2,19 @@ import { test, expect } from '@playwright/test';
 import { STRANGER_STORAGE_STATE } from '../fixtures/users';
 
 /**
- * Profile — saveProfile persists a changed bio. Uses the stranger (owns nothing, not
- * referenced by other tests' assertions) so a concurrent run can't be disturbed. Only the
- * bio is changed; the pre-filled username is submitted unchanged. Runs in `multiuser`.
+ * Profile — saveProfile persists a changed bio, and a bio typed before hydration survives it
+ * (regression for #558). Uses the stranger (owns nothing, not referenced by other tests'
+ * assertions) so a concurrent run can't be disturbed. Only the bio is changed; the pre-filled
+ * username is submitted unchanged. Runs in `multiuser`.
  *
  * Locators are page-level: the profile fields and the sticky "Speichern" save bar are not
  * all inside one <form> element, so scoping to the form would miss them.
+ *
+ * Self-parallelism: this file saves the *same* seed user (e2e_stranger_seed) in the first
+ * test below, so `--repeat-each=N` spreads the copies across workers that would all write
+ * (and then race to reload) that one row — "reload and find *my* bio" cannot hold by
+ * construction under `fullyParallel`. Repeat runs of this file need `--workers=1`
+ * (see e2e/README.md).
  */
 
 test.describe('profile', () => {
@@ -18,14 +25,19 @@ test.describe('profile', () => {
 			const bio = `E2E Bio ${Date.now()}`;
 			await page.goto('/user/profile');
 
-			// Retry the fill until it sticks — under load, hydration can reset a too-early
-			// input. Once it holds, the form is hydrated, so Speichern runs through use:enhance
-			// (a fetch, not a native navigation that would race the reload below).
+			// Hydration gate: this control is client-rendered only (NotificationSettings
+			// resolves the browser permission in onMount — the section is absent from the SSR
+			// HTML until then, since it's gated on `pushSupported`/`emailPrefsLoaded`, both
+			// false until onMount runs), so once it's visible the page's JS has run — Svelte's
+			// initial value pass is done and use:enhance is armed. Filling earlier is exactly
+			// #558; a fixed wait or `networkidle` would be flaky against the dev server.
+			await expect(
+				page.getByRole('checkbox', { name: 'Push auf diesem Gerät' })
+			).toBeVisible({ timeout: 15_000 });
+
 			const bioField = page.locator('textarea[name="bio"]');
-			await expect(async () => {
-				await bioField.fill(bio);
-				await expect(bioField).toHaveValue(bio, { timeout: 500 });
-			}).toPass({ timeout: 15_000 });
+			await bioField.fill(bio);
+			await expect(bioField).toHaveValue(bio);
 
 			await page.getByRole('button', { name: 'Speichern' }).first().click();
 			// Wait for the save to complete (success toast) before navigating away.
@@ -36,6 +48,30 @@ test.describe('profile', () => {
 			// Reload and confirm the value stuck.
 			await page.goto('/user/profile');
 			await expect(page.locator('textarea[name="bio"]')).toHaveValue(bio);
+		} finally {
+			await ctx.close();
+		}
+	});
+
+	test('text typed before hydration survives it (#558 regression)', async ({ browser }) => {
+		// Regression for #558: text typed before the page hydrates must survive hydration.
+		// `waitUntil: 'commit'` returns as soon as the SSR HTML starts arriving, so the fill
+		// lands in the (large, in dev) window before the client modules run. Before the fix,
+		// Svelte's first `set_value` pass reset the textarea to the loaded value ('' for the
+		// seeded user) and the following save persisted an empty bio behind a success toast.
+		// If hydration wins the race the test is trivially green — it can never be falsely red.
+		const ctx = await browser.newContext({ storageState: STRANGER_STORAGE_STATE });
+		const page = await ctx.newPage();
+		try {
+			const bio = `E2E Pre-Hydration Bio ${Date.now()}`;
+			await page.goto('/user/profile', { waitUntil: 'commit' });
+
+			const bioField = page.locator('textarea[name="bio"]');
+			await bioField.fill(bio);
+			await expect(bioField).toHaveValue(bio);
+
+			// No save here: this test performs no DB write, so it can't collide with the
+			// save-and-reload test above under `fullyParallel`.
 		} finally {
 			await ctx.close();
 		}

--- a/scripts/seed/scenarios/e2e.js
+++ b/scripts/seed/scenarios/e2e.js
@@ -9,9 +9,11 @@
  *  - e2e_viewer_seed — borrower/viewer. Trusted by the owner; member of the private group.
  *  - e2e_third_seed  — a third party. NOT trusted and not a group member (used to drive
  *                      "grant trust" and "join via invite token" flows from a clean slate).
- *  - e2e_stranger_seed — a pure bystander that NO test ever mutates. Used for assertions
- *                      that require a stably-untrusted user under `fullyParallel` (so a
- *                      concurrent trust test can't transiently flip the state).
+ *  - e2e_stranger_seed — a bystander whose trust/group state NO test mutates. Used for
+ *                      assertions that require a stably-untrusted user under `fullyParallel`
+ *                      (so a concurrent trust test can't transiently flip the state).
+ *                      profile.spec.ts does save its bio/contact/requirements/preferences —
+ *                      no other spec asserts on those fields, so that's still safe here.
  *
  * "E2E Bohrmaschine" is reserved for lending.spec, which drives a fresh request against it.
  * Login for all: password from lib.js (`password123`), email `<username>@seed.test`.

--- a/src/lib/server/contacts.test.ts
+++ b/src/lib/server/contacts.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeMockPb } from '$lib/test-utils/pocketbase';
+import { getOwnContact, upsertOwnContact, type UserContact } from './contacts';
+
+// Wiring regression for issue #558's failure mode 2 (non-atomic upsertOwnContact). The
+// create-race guard itself already lives in — and is already covered by —
+// upsertSingletonRow (src/lib/server/singletonRow.ts, src/lib/server/singletonRow.test.ts,
+// landed in #586); these tests just pin that upsertOwnContact still delegates to it with the
+// right find/createData/patch, modeled on singletonRow.test.ts's own cases.
+
+const USER_ID = 'u1';
+
+const CONTACT: UserContact = {
+	telegramUsername: 'someone',
+	signalLink: 'https://signal.me/#p/+491234567',
+	telegramVisibleToTrustedOnly: true,
+	signalVisibleToTrustedOnly: false,
+};
+
+describe('upsertOwnContact', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('updates the existing contact row (find resolves ⇒ update, no create)', async () => {
+		const getFirstListItem = vi.fn().mockResolvedValue({ id: 'row1' });
+		const update = vi.fn().mockResolvedValue({ id: 'row1' });
+		const create = vi.fn();
+		const pb = makeMockPb({
+			user_contacts: { getFirstListItem, update, create },
+		});
+
+		await upsertOwnContact(pb, USER_ID, CONTACT);
+
+		expect(update).toHaveBeenCalledWith('row1', CONTACT);
+		expect(create).not.toHaveBeenCalled();
+	});
+
+	it('creates the row on first save (find rejects ⇒ create)', async () => {
+		const getFirstListItem = vi.fn().mockRejectedValue(new Error('not found'));
+		const create = vi.fn().mockResolvedValue({ id: 'new' });
+		const update = vi.fn();
+		const pb = makeMockPb({
+			user_contacts: { getFirstListItem, update, create },
+		});
+
+		await upsertOwnContact(pb, USER_ID, CONTACT);
+
+		expect(create).toHaveBeenCalledWith({ user: USER_ID, ...CONTACT });
+		expect(update).not.toHaveBeenCalled();
+	});
+
+	it('survives a lost create race (#558): find rejects, then resolves; create rejects ⇒ falls back to update instead of throwing', async () => {
+		// findOwnContactRow's try/catch converts the first (rejecting) getFirstListItem call
+		// into `null` — "no row yet". The second call is upsertSingletonRow's retry after the
+		// failed create, resolving to the row the concurrent writer just created.
+		const getFirstListItem = vi
+			.fn()
+			.mockRejectedValueOnce(new Error('not found'))
+			.mockResolvedValueOnce({ id: 'row1' });
+		const create = vi.fn().mockRejectedValue(new Error('unique constraint'));
+		const update = vi.fn().mockResolvedValue({ id: 'row1' });
+		const pb = makeMockPb({
+			user_contacts: { getFirstListItem, update, create },
+		});
+
+		await expect(
+			upsertOwnContact(pb, USER_ID, CONTACT)
+		).resolves.toBeUndefined();
+		expect(update).toHaveBeenCalledWith('row1', CONTACT);
+	});
+});
+
+describe('getOwnContact', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('builds its lookup filter via pb.filter, not raw string interpolation', async () => {
+		const getFirstListItem = vi.fn().mockResolvedValue({
+			telegramUsername: 'someone',
+			signalLink: '',
+			telegramVisibleToTrustedOnly: false,
+			signalVisibleToTrustedOnly: true,
+		});
+		const pb = makeMockPb({ user_contacts: { getFirstListItem } });
+
+		await getOwnContact(pb, USER_ID);
+
+		expect(pb.filter).toHaveBeenCalledWith('user = {:u}', { u: USER_ID });
+		expect(getFirstListItem).toHaveBeenCalledWith("user = 'u1'");
+	});
+
+	it('returns {} when no contact row exists yet, instead of throwing', async () => {
+		const getFirstListItem = vi.fn().mockRejectedValue(new Error('not found'));
+		const pb = makeMockPb({ user_contacts: { getFirstListItem } });
+
+		await expect(getOwnContact(pb, USER_ID)).resolves.toEqual({});
+	});
+});

--- a/src/routes/user/profile/+page.svelte
+++ b/src/routes/user/profile/+page.svelte
@@ -189,7 +189,7 @@
 								fieldName="telegramUsername"
 								label={texts.messenger.telegramUsername}
 								placeholder={texts.messenger.telegramUsernamePlaceholder}
-								value={data.contact.telegramUsername ?? ''}
+								initialValue={data.contact.telegramUsername ?? ''}
 								visibilityToggleName="telegramVisibleToTrustedOnly"
 								visibilityToggleChecked={data.contact
 									.telegramVisibleToTrustedOnly ?? true}
@@ -201,7 +201,7 @@
 								fieldName="signalLink"
 								label={texts.messenger.signalLink}
 								placeholder={texts.messenger.signalLinkPlaceholder}
-								value={data.contact.signalLink ?? ''}
+								initialValue={data.contact.signalLink ?? ''}
 								visibilityToggleName="signalVisibleToTrustedOnly"
 								visibilityToggleChecked={data.contact
 									.signalVisibleToTrustedOnly ?? true}

--- a/src/routes/user/profile/ContactSection.svelte
+++ b/src/routes/user/profile/ContactSection.svelte
@@ -3,8 +3,9 @@
 	import { Toggle } from 'flowbite-svelte';
 
 	// Issue #438: opt into an off-platform contact channel. Fields submit with the
-	// surrounding ?/saveProfile form. Both inputs are always rendered so their values are
-	// preserved across saves even while another method is selected.
+	// surrounding ?/saveProfile form. Both contactEmail/contactUrl are always rendered — one
+	// visible, one hidden — so the field name is always present in the FormData; see the
+	// seed-once comment below for what actually happens to that value on save.
 	let {
 		contactMethod = '',
 		contactEmail = '',
@@ -17,8 +18,27 @@
 		contactPublic?: boolean;
 	} = $props();
 
+	// Pre-existing (not #558): svelte-check reports state_referenced_locally here too, since
+	// `method`/`isPublic` are also seeded once from a prop and never re-synced. Ignored for
+	// the same reason as the #558 seeds below.
+	// svelte-ignore state_referenced_locally
 	let method = $state<'' | 'email' | 'link'>(contactMethod);
+	// svelte-ignore state_referenced_locally
 	let isPublic = $state(contactPublic);
+
+	// Issue #558: seed once from the loaded value and bind: from then on — never a one-way
+	// value={…}, which hydration would clobber (see docs/best-practices.md → "Editable
+	// fields: seed-once + bind:, never one-way value="). The hidden fallback inputs below
+	// (still one-way — they're never user-edited) now read these local values instead of the
+	// original props. This is a client-side-only improvement: switching the contact method
+	// away and back re-mounts the visible input from the edited local state instead of
+	// reverting to the originally-loaded prop value. It does NOT change what gets persisted —
+	// parseOffPlatformContact ($lib/server/profileForm.ts) unconditionally zeroes whichever
+	// method isn't the active one, regardless of what either input carries.
+	// svelte-ignore state_referenced_locally
+	let contactEmailValue = $state(contactEmail);
+	// svelte-ignore state_referenced_locally
+	let contactUrlValue = $state(contactUrl);
 </script>
 
 <div class="border-t pt-6 space-y-4">
@@ -64,7 +84,7 @@
 					type="email"
 					name="contactEmail"
 					id="contactEmail"
-					value={contactEmail}
+					bind:value={contactEmailValue}
 					required
 					placeholder={texts.contactOptions.emailPlaceholder}
 					class="w-full px-3 py-2 bg-gray-50 border border-gray-300 rounded-lg text-gray-900 focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
@@ -75,8 +95,12 @@
 			</div>
 		</div>
 	{:else}
-		<!-- Always submit the email so an existing address is preserved while 'link' is selected. -->
-		<input type="hidden" name="contactEmail" value={contactEmail} />
+		<!-- Client-side only (see the seed-once comment above): keeps the edited value ready
+		     in case the user switches back to 'email' within this page view. This does NOT
+		     preserve an existing address in the database — parseOffPlatformContact discards
+		     this field's submitted value whenever contactMethod isn't 'email', regardless of
+		     what it carries. -->
+		<input type="hidden" name="contactEmail" value={contactEmailValue} />
 	{/if}
 
 	{#if method === 'link'}
@@ -92,7 +116,7 @@
 					type="url"
 					name="contactUrl"
 					id="contactUrl"
-					value={contactUrl}
+					bind:value={contactUrlValue}
 					required
 					placeholder={texts.contactOptions.urlPlaceholder}
 					class="w-full px-3 py-2 bg-gray-50 border border-gray-300 rounded-lg text-gray-900 focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
@@ -103,7 +127,10 @@
 			</div>
 		</div>
 	{:else}
-		<input type="hidden" name="contactUrl" value={contactUrl} />
+		<!-- Client-side only, same reasoning as the contactEmail fallback above: the server
+		     discards this field's submitted value whenever contactMethod isn't 'link',
+		     regardless of what it carries. -->
+		<input type="hidden" name="contactUrl" value={contactUrlValue} />
 	{/if}
 
 	{#if method !== ''}

--- a/src/routes/user/profile/MessengerField.svelte
+++ b/src/routes/user/profile/MessengerField.svelte
@@ -7,7 +7,7 @@
 		fieldName,
 		label,
 		placeholder,
-		value,
+		initialValue,
 		visibilityToggleName,
 		visibilityToggleChecked,
 		tooltipId,
@@ -17,7 +17,14 @@
 		fieldName: string;
 		label: string;
 		placeholder: string;
-		value: string;
+		/** Named `initialValue`, not `value`: the seed-once `$state` below is named `value`
+		 *  (so the input can use the bare `bind:value` shorthand), and a prop also named
+		 *  `value` would make `let value = $state(value)` a duplicate `let value`
+		 *  declaration in the same scope — a compile-time parse error, not shadowing
+		 *  (which needs two distinct scopes). Renaming the prop instead of the local also
+		 *  makes the seed-once contract visible at the call site (precedent: AddressInput's
+		 *  `initialValue`) — see docs/best-practices.md → "Editable fields" → escape hatch. */
+		initialValue: string;
 		visibilityToggleName: string;
 		visibilityToggleChecked: boolean;
 		/** Unique DOM id linking the tooltip trigger button to its Popover. */
@@ -25,12 +32,20 @@
 		tooltipTitle: string;
 		tooltipText: string;
 	} = $props();
+
+	// Issue #558: seed once from initialValue and bind: from then on — never a one-way
+	// value={…}, which hydration would clobber (see docs/best-practices.md → "Editable
+	// fields: seed-once + bind:, never one-way value=").
+	// svelte-ignore state_referenced_locally
+	let value = $state(initialValue);
 </script>
 
 <div>
 	<div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4">
-		<Label class="sm:w-36 sm:shrink-0 flex items-center">
-			<span class="text-sm font-medium text-tinte-900 dark:text-white">{label}</span>
+		<Label for={fieldName} class="sm:w-36 sm:shrink-0 flex items-center">
+			<span class="text-sm font-medium text-tinte-900 dark:text-white"
+				>{label}</span
+			>
 			<button type="button" id={tooltipId}>
 				<QuestionCircleSolid class="ml-1 h-5 w-5" />
 				<span class="sr-only">{texts.ui.explainThis}</span>
@@ -41,7 +56,7 @@
 			name={fieldName}
 			id={fieldName}
 			{placeholder}
-			{value}
+			bind:value
 			class="w-full sm:flex-1 px-3 py-2 bg-papier border border-tinte-300 rounded-lg text-tinte-900 focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:bg-tinte-700 dark:border-tinte-600 dark:text-white"
 			autocomplete="off"
 		/>
@@ -49,6 +64,10 @@
 	<!-- On desktop, indent to align with the input column (sm:w-36 + sm:gap-4 = sm:pl-40) -->
 	<div class="sm:pl-40 mt-2">
 		<Label class="flex">
+			<!-- One-way checked= is intentional, not an #558 miss: Flowbite's Toggle declares
+			     `checked = $bindable()` and binds its own underlying checkbox internally, so
+			     bind_checked's hydration guard already adopts a pre-hydration click — no
+			     seed-once $state needed here. -->
 			<Toggle classes={{ span: 'bg-primary-300 peer-checked:bg-safety' }} name={visibilityToggleName} checked={visibilityToggleChecked}>
 				{texts.messenger.visibleToTrustedOnly}
 			</Toggle>

--- a/src/routes/user/profile/ProfileBasicsSection.svelte
+++ b/src/routes/user/profile/ProfileBasicsSection.svelte
@@ -15,6 +15,14 @@
 	}
 
 	let { username, bio, profileImageUrl, ondirty }: Props = $props();
+
+	// Issue #558: seed once, then bind: — never one-way value=, or hydration clobbers
+	// pre-hydration input; see docs/best-practices.md → "Editable fields: seed-once + bind:,
+	// never one-way value=".
+	// svelte-ignore state_referenced_locally
+	let usernameValue = $state(username);
+	// svelte-ignore state_referenced_locally
+	let bioValue = $state(bio);
 </script>
 
 <div class="mt-4 space-y-4">
@@ -29,7 +37,7 @@
 			type="text"
 			name="username"
 			id="username"
-			value={username}
+			bind:value={usernameValue}
 			class="w-full px-3 py-2 bg-gray-50 border border-gray-300 rounded-lg text-gray-900 focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
 			required
 		/>
@@ -58,7 +66,7 @@
 			name="bio"
 			id="bio"
 			rows="4"
-			value={bio}
+			bind:value={bioValue}
 			class="w-full px-3 py-2 bg-gray-50 border border-gray-300 rounded-lg text-gray-900 focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white resize-y"
 			placeholder={texts.pages.profile.bioPlaceholder}
 		></textarea>

--- a/src/routes/user/profile/page.server.test.ts
+++ b/src/routes/user/profile/page.server.test.ts
@@ -314,3 +314,29 @@ describe('profile saveProfile — external-item lending info (#368)', () => {
 		expect(sent.get('externalLendingInfo')).toBeNull();
 	});
 });
+
+describe('profile saveProfile — bio field semantics (#558)', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	// The server can't tell "the user deliberately cleared their bio" apart from "hydration
+	// clobbered the textarea before the user typed anything" — both submit an empty string.
+	// That ambiguity is exactly why the #558 fix lives client-side (seed-once $state +
+	// bind:value in ProfileBasicsSection.svelte), not here. These two tests just pin the
+	// server's existing, intentional semantics so nobody "fixes" them on this side later.
+
+	it('writes an empty bio when the field is submitted empty (clearing is intended)', async () => {
+		const { result, update } = callSave({ bio: '' });
+
+		expect(await result).toMatchObject({ success: true });
+		const sent = (update.mock.calls[0] as unknown[])[1] as FormData;
+		expect(sent.get('bio')).toBe('');
+	});
+
+	it('leaves bio untouched when the field is absent from the submission', async () => {
+		const { result, update } = callSave({});
+
+		expect(await result).toMatchObject({ success: true });
+		const sent = (update.mock.calls[0] as unknown[])[1] as FormData;
+		expect(sent.has('bio')).toBe(false);
+	});
+});


### PR DESCRIPTION
## What & why

`e2e/tests/profile.spec.ts › saving a new bio persists it` was flaky (1 pass / 2 fail at `--repeat-each=3`). Root cause, verified against the compiled output: the profile form rendered its editable fields with a one-way `value={…}` fed from the loaded data, which compiles to a `set_value()` call. `set_value` caches the last value it wrote, so ordinary re-renders are harmless — but its **first** pass, at hydration, has no cache yet and unconditionally overwrites whatever the user already typed into the server-rendered input before the client bundle finished loading. The seeded user has an empty bio, so the test submitted and persisted `''` behind a green success toast.

Note this is **not** "a re-render clobbers the input", as the issue hypothesised — a re-render with an unchanged server value is a no-op. It is specifically the hydration pass, which also makes it real for users on slow connections or devices, not just for Playwright.

Fix: seed a local `$state` once from the prop and let the element own the value via `bind:value`. `bind_value` carries a hydration guard that *adopts* the existing DOM value instead of overwriting it, and the SSR output is byte-identical — this is a hydration-safety fix, not a no-JS regression.

Covers `username`, `bio`, both messenger handles and the off-platform contact email/URL. The visibility `Toggle`s keep their one-way `checked=`: Flowbite declares `checked = $bindable()` and binds the underlying checkbox internally, so `bind_checked`'s hydration guard already applies (verified against the installed runtime *and* in the browser against the DB, since this one is privacy-relevant).

**Deliberate trade-off:** the fields no longer re-sync from the server after a successful save, so a server-side normalisation (`bio.trim()`) becomes visible only on the next load. That is consistent with the form's existing `update({ reset: false })`. Re-syncing was explicitly rejected: the root layout invalidates the page data on every navigation and every realtime reconnect, so a writable `$derived` / `realtimeSynced` / sync-`$effect` shape would discard unsaved input on each of those — worse than the status quo, and the same shape #546 rejected.

### The issue's second failure mode was already fixed

The non-atomic `user_contacts` upsert (`ClientResponseError 400: Failed to create record` under parallel saves) was fixed by #586, which routed all four sidecar upserts through `upsertSingletonRow` and its create-race guard. Rather than re-fix it, this PR pins it at the call site with a new `src/lib/server/contacts.test.ts`.

## Also in here

- **e2e:** replaced the flaky fill-retry loop with a real hydration gate (waits for a control that only exists after `onMount`), and added a `waitUntil: 'commit'` regression test that types *before* hydration on purpose. Documented in `e2e/README.md` why repeat runs of this spec need `--workers=1` — it saves the shared `e2e_stranger_seed` row, so parallel copies race by construction.
- **Docs:** new `docs/best-practices.md` section "Editable fields: seed-once + `bind:`, never one-way `value=`", including the two anti-patterns that look like fixes, and the escape hatch for a prop already named `value`. One clause added to the corresponding `.claude/CLAUDE.md` guardrail.
- **a11y:** added the missing `for={fieldName}` to `MessengerField`'s `<Label>` — the messenger inputs had no programmatic label and fell back to their placeholder.
- **Comment accuracy:** corrected three comments claiming the hidden contact inputs preserve a value across saves. `src/lib/server/profileForm.ts:83-84` zeroes whichever method is not selected, regardless of what the hidden input carries; the benefit of the rewiring is client-side only (switching method away and back keeps the typed value in the UI).
- Tightened two seed comments that claimed `e2e_stranger_seed` is mutated by no test — `profile.spec.ts` does write its bio/contact/preferences.

Two out-of-scope findings surfaced during the analysis and were filed separately: #612 (`upsertUserGeolocation`'s clear path is an unguarded `find`+`delete`) and #613 (the same one-way-`value=` class in group settings, onboarding and `AddressInput`).

## Test notes

Preflight: `npm run lint` (clean) · `npm run check` (2 pre-existing errors in `src/lib/server/superuser.ts` from a local `.env` without `PB_SUPERUSER_*`; green in CI) · `npx vitest run` (748/748) · `npm run build`.

- **Acceptance criterion — the issue's own repro:** `npx playwright test e2e/tests/profile.spec.ts --repeat-each=3 --workers=1` → **13/13 green**, where it was 1 pass / 2 fail.
- Affected specs `profile.spec.ts` + `authenticated.spec.ts` → 12/12 green.
- Without `--workers=1`, one copy still fails — on the "reload and find *my* bio" assertion against a sibling worker's write 1 ms apart, **not** on a 400. That is the documented self-parallelism limit of a spec that saves a shared seed user, hence the `e2e/README.md` note.
- Browser-verified on the changed flow: pre-hydration input survives (injected at the earliest possible moment via an `initScript` poll, which is more adversarial than typing), the ordinary save/reload path, the trim-visible-after-reload trade-off, the new label→input focus association (and that the nested tooltip button still opens its Popover), the privacy toggle after a pre-hydration click cross-checked directly against `user_contacts`, and the contact-method round-trip in both halves (typed email survives the UI switch, but is correctly *not* persisted while "link" is the active method). No console errors, no failed requests.

Reviewer: the trade-off in bold above is the one thing worth an explicit opinion — everything else is mechanical.

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)
