### PR TITLE
fix(profile): make clearing the address idempotent (#612)

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -114,6 +114,38 @@ must stay green *unchanged*), and the bulk flow got a characterization test writ
 refactor. Any deliberate behavior change (here: the MIME whitelist now also applies to bulk rows)
 is called out in a test comment.
 
+### Sidecar singleton rows (`$lib/server/singletonRow.ts`)
+
+Several collections hold **at most one row per user** alongside the `users` record —
+`user_preferences`, `user_contacts`, `user_geolocations`, `lending_requirements`. Writing them is
+always a find-then-write, which is not atomic: a double-submit (or two tabs) makes two requests
+race over the same row, and the loser fails on a row that is already in the state it wanted.
+
+Never hand-roll that write. Route it through the two helpers, which carry the guard once:
+
+- `upsertSingletonRow({ pb, collection, find, createData, patch })` — update if the row exists,
+  otherwise create. A lost create race (unique index on the owning relation) is retried as an
+  update instead of surfacing as a failed save.
+- `deleteSingletonRow({ pb, collection, find })` — the clear path. Deletes if a row exists, no-ops
+  if not, and tolerates a lost delete race (someone else already removed the row).
+
+Both guards settle "did I lose the race?" by **re-reading the state**, never by trusting the status
+code: PocketBase answers 404 both for "already gone" and for "a rule or hook refused this delete",
+so the delete guard only swallows the 404 once `find` confirms the row really is gone. Everything
+else throws — a write that genuinely failed must never be reported as done.
+
+The same reasoning applies to the `find` callback itself: resolve "no row" from a **404 only** and
+rethrow the rest. A blanket `catch { return null }` turns a 500 into "the user has no row", which
+on the clear path skips the delete and still reports success — the data stays stored (#612). That
+is load-bearing wherever `deleteSingletonRow` is used. The upsert-only sidecars
+(`user_preferences`, `lending_requirements`) still use a blanket catch, which survives there
+because a swallowed error resurfaces on the create that follows.
+
+Both helpers take the same `find`, so a module like `$lib/server/geolocation.ts` defines the lookup
+once and reuses it for both directions. Keeping the guards here rather than at the call sites is
+deliberate: they were each fixed one call site at a time before being centralised (#586 for the
+create race, #612 for the delete race), and the next sidecar collection should get them for free.
+
 ### Data (Re-)Loading
 
 The load function passes the data to the UI component:

--- a/src/lib/server/geolocation.test.ts
+++ b/src/lib/server/geolocation.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { makeMockPb } from '$lib/test-utils/pocketbase';
+import { upsertUserGeolocation } from './geolocation';
+
+const COLLECTION = 'user_geolocations';
+
+/** A PocketBase-shaped rejection: what matters to the guards is the `status` field. */
+function pbError(status: number, message = `status ${status}`) {
+	return Object.assign(new Error(message), { status });
+}
+
+/** `getFirstListItem` answers "no match" with a 404 — that's how the row lookup sees "none". */
+const NO_ROW = pbError(404, 'no rows');
+
+function makePb(getFirstListItem: ReturnType<typeof vi.fn>, del = vi.fn().mockResolvedValue(true)) {
+	return { pb: makeMockPb({ [COLLECTION]: { getFirstListItem, delete: del } }), del };
+}
+
+describe('upsertUserGeolocation — clear path (geo === null)', () => {
+	it('deletes the stored row when the user empties the address', async () => {
+		const { pb, del } = makePb(vi.fn().mockResolvedValue({ id: 'geo1' }));
+		await upsertUserGeolocation(pb, 'u1', null);
+		expect(del).toHaveBeenCalledWith('geo1');
+	});
+
+	it('no-ops when the user never stored a location', async () => {
+		const { pb, del } = makePb(vi.fn().mockRejectedValue(NO_ROW));
+		await expect(upsertUserGeolocation(pb, 'u1', null)).resolves.toBeUndefined();
+		expect(del).not.toHaveBeenCalled();
+	});
+
+	it('does not throw when a concurrent clear already removed the row (#612)', async () => {
+		// Two ?/saveProfile submits with an empty address resolve the same row id; the
+		// loser's delete 404s even though "no geolocation row" is the desired end state.
+		const { pb } = makePb(
+			vi.fn().mockResolvedValueOnce({ id: 'geo1' }).mockRejectedValueOnce(NO_ROW),
+			vi.fn().mockRejectedValue(pbError(404, 'Not Found'))
+		);
+		await expect(upsertUserGeolocation(pb, 'u1', null)).resolves.toBeUndefined();
+	});
+
+	it('surfaces a failed row lookup instead of silently skipping the delete', async () => {
+		// A 500 must not read as "no location stored" — that would report a successful
+		// clear while the coordinates stay in the database.
+		const { pb, del } = makePb(vi.fn().mockRejectedValue(pbError(500, 'Server Error')));
+		await expect(upsertUserGeolocation(pb, 'u1', null)).rejects.toThrow('Server Error');
+		expect(del).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/server/geolocation.ts
+++ b/src/lib/server/geolocation.ts
@@ -1,5 +1,6 @@
 import type PocketBase from 'pocketbase';
-import { upsertSingletonRow } from '$lib/server/singletonRow';
+import type { ClientResponseError } from 'pocketbase';
+import { deleteSingletonRow, upsertSingletonRow } from '$lib/server/singletonRow';
 
 export type GeoPoint = { lon: number; lat: number };
 
@@ -9,8 +10,12 @@ async function findGeolocationRow(pb: PocketBase, userId: string): Promise<{ id:
 		return await pb
 			.collection('user_geolocations')
 			.getFirstListItem(pb.filter('user = {:u}', { u: userId }), { fields: 'id' });
-	} catch {
-		return null;
+	} catch (err) {
+		// PocketBase reports "no match" as a 404. Anything else (500, network, expired
+		// token) must not be read as "the user has no location": on the clear path that
+		// would skip the delete and still report success, leaving the coordinates stored.
+		if ((err as Partial<ClientResponseError>)?.status === 404) return null;
+		throw err;
 	}
 }
 
@@ -23,6 +28,9 @@ export async function getUserGeolocation(pb: PocketBase, userId: string): Promis
 		const geo = rec.geolocation as GeoPoint | undefined;
 		return geo && !(geo.lon === 0 && geo.lat === 0) ? geo : null;
 	} catch {
+		// Read path, so the blanket catch is deliberate here (unlike findGeolocationRow
+		// above): nothing writes based on this value — a failed read just renders the form
+		// as "no location", and the clear is driven by the emptied city field, not by this.
 		return null;
 	}
 }
@@ -33,15 +41,16 @@ export async function upsertUserGeolocation(
 	userId: string,
 	geo: GeoPoint | null
 ): Promise<void> {
+	const find = () => findGeolocationRow(pb, userId);
+
 	if (!geo) {
-		const existing = await findGeolocationRow(pb, userId);
-		if (existing) await pb.collection('user_geolocations').delete(existing.id);
+		await deleteSingletonRow({ pb, collection: 'user_geolocations', find });
 		return;
 	}
 	await upsertSingletonRow({
 		pb,
 		collection: 'user_geolocations',
-		find: () => findGeolocationRow(pb, userId),
+		find,
 		createData: { user: userId, geolocation: geo },
 		patch: { geolocation: geo },
 	});

--- a/src/lib/server/singletonRow.test.ts
+++ b/src/lib/server/singletonRow.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { makeMockPb } from '$lib/test-utils/pocketbase';
-import { upsertSingletonRow } from './singletonRow';
+import { deleteSingletonRow, upsertSingletonRow } from './singletonRow';
 
 const COLLECTION = 'user_things';
 
@@ -54,5 +54,61 @@ describe('upsertSingletonRow', () => {
 		const { promise, update } = run({ find, create });
 		await expect(promise).rejects.toThrow('boom');
 		expect(update).not.toHaveBeenCalled();
+	});
+});
+
+/** A PocketBase-shaped rejection: what matters to the guard is the `status` field. */
+function pbError(status: number, message = `status ${status}`) {
+	return Object.assign(new Error(message), { status });
+}
+
+function runDelete(opts: { find: ReturnType<typeof vi.fn>; del?: ReturnType<typeof vi.fn> }) {
+	const del = opts.del ?? vi.fn().mockResolvedValue(true);
+	const pb = makeMockPb({ [COLLECTION]: { delete: del } });
+	const promise = deleteSingletonRow({
+		pb,
+		collection: COLLECTION,
+		find: opts.find as () => Promise<{ id: string } | null>,
+	});
+	return { promise, del };
+}
+
+describe('deleteSingletonRow', () => {
+	it('deletes the existing row', async () => {
+		const find = vi.fn().mockResolvedValue({ id: 'row1' });
+		const { promise, del } = runDelete({ find });
+		await promise;
+		expect(del).toHaveBeenCalledWith('row1');
+	});
+
+	it('no-ops when there is no row to delete', async () => {
+		const find = vi.fn().mockResolvedValue(null);
+		const { promise, del } = runDelete({ find });
+		await expect(promise).resolves.toBeUndefined();
+		expect(del).not.toHaveBeenCalled();
+	});
+
+	it('swallows a 404 from a lost delete race once the row is confirmed gone', async () => {
+		// find: the row up front, then nothing — the concurrent writer already removed it.
+		const find = vi.fn().mockResolvedValueOnce({ id: 'row1' }).mockResolvedValueOnce(null);
+		const del = vi.fn().mockRejectedValue(pbError(404, 'Not Found'));
+		const { promise } = runDelete({ find, del });
+		await expect(promise).resolves.toBeUndefined();
+		expect(find).toHaveBeenCalledTimes(2);
+	});
+
+	it('rethrows a 404 when the row survived (a rule or hook refused the delete)', async () => {
+		const find = vi.fn().mockResolvedValue({ id: 'row1' });
+		const del = vi.fn().mockRejectedValue(pbError(404, 'Not Found'));
+		const { promise } = runDelete({ find, del });
+		await expect(promise).rejects.toThrow('Not Found');
+	});
+
+	it('rethrows a non-404 delete error so a real failure stays visible', async () => {
+		const find = vi.fn().mockResolvedValue({ id: 'row1' });
+		const del = vi.fn().mockRejectedValue(pbError(403, 'Forbidden'));
+		const { promise } = runDelete({ find, del });
+		await expect(promise).rejects.toThrow('Forbidden');
+		expect(find).toHaveBeenCalledTimes(1); // no pointless re-read on a non-race error
 	});
 });

--- a/src/lib/server/singletonRow.ts
+++ b/src/lib/server/singletonRow.ts
@@ -1,4 +1,5 @@
 import type PocketBase from 'pocketbase';
+import type { ClientResponseError } from 'pocketbase';
 
 /**
  * Upsert for "one row per user/owner" sidecar collections (user_preferences,
@@ -36,5 +37,41 @@ export async function upsertSingletonRow(opts: {
 		const row = await find();
 		if (row) await pb.collection(collection).update(row.id, patch);
 		else throw err;
+	}
+}
+
+/**
+ * Clears the same "one row per user/owner" sidecar row: deletes it if one exists,
+ * no-ops if there is nothing to delete.
+ *
+ * Counterpart to {@link upsertSingletonRow}, with the matching race guard on the way
+ * out: two concurrent clears both resolve the same row id and both delete it, so the
+ * loser gets a 404 for a row that is already in exactly the state it wanted. Like the
+ * create guard, that race is settled by re-reading the state: a 404 is only swallowed
+ * once `find` confirms the row is gone. Every other error throws.
+ */
+export async function deleteSingletonRow(opts: {
+	pb: PocketBase;
+	collection: string;
+	/**
+	 * Resolves the user's existing row, or null when there is nothing to delete. Called
+	 * again after a 404 to confirm the row is really gone, so it must return null **only**
+	 * for a genuine 404 and rethrow everything else — a `find` with a blanket
+	 * `catch { return null }` would let a refused delete pass as done (#612).
+	 */
+	find: () => Promise<{ id: string } | null>;
+}): Promise<void> {
+	const { pb, collection, find } = opts;
+
+	const existing = await find();
+	if (!existing) return;
+
+	try {
+		await pb.collection(collection).delete(existing.id);
+	} catch (err) {
+		if ((err as Partial<ClientResponseError>)?.status !== 404) throw err;
+		// Lost a delete race — but only if the row really is gone. If it survived, the
+		// 404 came from a rule or hook refusing the delete, and that must not pass as done.
+		if (await find()) throw err;
 	}
 }


### PR DESCRIPTION
## What & why

`upsertUserGeolocation`'s **clear** path (`geo === null` — the user emptied the address field) was a non-atomic `find` + `delete`:

```ts
const existing = await findGeolocationRow(pb, userId);
if (existing) await pb.collection('user_geolocations').delete(existing.id);
```

Two concurrent `?/saveProfile` submits from the same user resolve the same row id and both delete it. The loser gets a `404` from PocketBase, which propagates out of `saveProfile` and surfaces as a **failed save** — even though the desired end state ("no geolocation row") was reached. The write path was already guarded via `upsertSingletonRow` (#586); the clear path bypassed that helper entirely and never got the guard.

Closes #612.

## Changes

**`deleteSingletonRow` (new, `$lib/server/singletonRow.ts`)** — the counterpart to `upsertSingletonRow`, so the module owns the full sidecar-row lifecycle and the next collection gets the guard for free. `geolocation.ts`'s clear path now delegates to it.

Both guards settle *"did I lose the race?"* the **same** way — by re-reading the state, not by trusting the status code. This matters: PocketBase also answers `404` when a rule or an `onRecordDelete` hook **refuses** a delete. A purely status-based guard would report success for a refused clear while the row survives — precisely the failure mode the helper claims to exclude. So the 404 is only swallowed once `find` confirms the row is actually gone; everything else throws.

**Narrowed `findGeolocationRow`'s blanket catch** — beyond the issue's scope, but the review made it untenable to leave: the `catch { return null }` ran *before* the guard, so a 500 during the lookup was read as "the user has no location", skipping the delete while still reporting success and leaving the coordinates stored. That is a confirmed-but-not-executed deletion of location data, and it made the new helper's contract untrue. Now: `404` → `null`, everything else rethrows. Both call sites (`user/profile`, `onboarding`) already wrap the call in try/catch, so a genuine failure surfaces as an error message rather than an uncaught 500.

`getUserGeolocation` deliberately keeps its blanket catch — it is a read, nothing writes based on the result, and the clear is driven by the emptied *city* field rather than by this value. Marked as such in a comment so the asymmetry doesn't read as an oversight.

## Test notes

- **New regression test verified to fail without the fix**, with exactly the 404 from the issue.
- `npx vitest run` — 74 files, **787 passed** (8 new: 5 for `deleteSingletonRow`, 4 for the geolocation clear path incl. the lookup-failure case).
- `npm run lint` clean · `npm run build` clean · `npm run check` clean apart from the two pre-existing `superuser.ts` env errors.
- Playwright e2e — **55/55 passed**.
- **Browser-verified** against a live stack: set address → save → clear → save → clear again (no-op). All 200, row confirmed deleted via the PocketBase API, console clean.
- **The race was reproduced for real**, not just unit-tested: two concurrent `?/saveProfile` requests with an empty address against the running server both returned `success: true`, and the row was deleted exactly once. On `main` the loser returns an error.
- **Regression check on the path the narrowed catch could break:** a user with no geolocation row completing the onboarding location step with an empty field — advances normally, no error.

### Reviewer note
Formatting follows the surrounding code (~100 cols), not `.prettierrc`'s `printWidth: 80` — 149 of 189 `src/**/*.ts` diverge from it today, so matching the config here would make these files the outliers. Out of scope for this PR, but probably worth settling repo-wide at some point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)