### PR TITLE
fix(user-items): keep typed search text through the notifications invalidate (#619)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -80,7 +80,9 @@ These prevent the most common bugs/security issues here — follow them without 
 - **Never destructure the `data` prop.** Access `data.x` directly in markup; assigning
   `let x = data.x` detaches `use:enhance` reactivity — and a *user-editable* field seeded from
   `data.x`/a prop needs a seed-once `$state` + `bind:value`, never one-way `value=`, or hydration
-  clobbers it (issue #558). → `docs/best-practices.md`
+  clobbers it (issue #558). A field that must keep *following* an external value (a URL-synced
+  filter box) needs the absorbing-derived variant of the same rule instead of seed-once —
+  issue #619. → `docs/best-practices.md`
 - **Always build PocketBase filters with `pb.filter(raw, {params})`** — never template-literal
   interpolation. Applies to *every* value, including IDs from `locals.user.id` / route params
   (filter injection). Use `locals.pb.filter(...)` in routes, `pb.filter(...)` in `$lib/server/*`.

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -121,6 +121,27 @@ itself stays one-way and un-destructured. That rule is about not *detaching* rea
 user can type into. Seeding a local `$state` from `data.x` once, at initialization, reads `data.x`
 exactly once and does not detach anything.
 
+**A wrapper that binds internally does not make an outer one-way `value=` safe** (issue #613).
+Flowbite's `Input`/`Textarea` declare `value = $bindable()` and bind the underlying element
+internally, so `bind_value`'s hydration guard already applies *inside* them — but without `bind:`
+from the outside the child's prop is a plain writable derived, and every recompute restores what
+the parent passed. `+layout.svelte` fires `invalidate(NOTIFICATIONS_DEP)` from `afterNavigate`
+even on first load, so the layout load re-runs right after hydration, SvelteKit rebuilds `data`
+for every node below it, and the adopted text is discarded. Seed once and `bind:` from the
+outside too.
+
+**Sweep criterion — "is the field in the server-rendered HTML?"** Only fields a user can reach
+*before* hydration are in this bug class. Fields behind an `{#if}` (modal bodies, wizard steps
+such as `src/routes/onboarding/`) are not, and there re-seeding on remount is usually the
+*desired* behaviour — see `src/routes/user/items/ItemModal.svelte`.
+
+**Open case — URL-synced fields** (tracked as issue #619). `/user/items`' search box syncs from the URL
+(`$derived(data.search)`) so back/forward and a filter reset win, which rules seed-once out. But
+`bind:value` on that writable `$derived` does not fix #613 either: measured in a hydrated browser
+reproduction, the binding *does* adopt the pre-hydration text, and the `afterNavigate` invalidate
+above then recomputes the derived and overwrites it a few ms later. Neither shape is correct
+today — don't "fix" such a field with either one without solving the re-sync trigger first.
+
 ### The submit action
 
 Submit actions are defined in the server-side `+page.server.ts` file like so:

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -109,7 +109,9 @@ stays visible at the call site. See `MessengerField.svelte`.
   through a primitive that re-syncs on invalidation doesn't just clobber at hydration — it
   discards unsaved input on the next navigation or reconnect, too. (`realtimeSynced` is the
   right tool when re-sync-on-invalidate is the actual goal, e.g. realtime conversation state —
-  just not for a plain editable field.)
+  just not for a plain editable field. This is exactly the shape "URL-synced fields" below
+  rejected for `/user/items`' search box — a writable `$derived` sitting directly over the
+  churning source, with no absorber in between.)
 - **A sync `$effect` that re-seeds the local `$state` from the prop.** Same discard-on-invalidate
   problem as above, and `svelte/prefer-writable-derived` is an error-level lint rule that
   specifically flags this shape — treat that as a correct rejection of the pattern here, not a
@@ -133,14 +135,52 @@ outside too.
 **Sweep criterion — "is the field in the server-rendered HTML?"** Only fields a user can reach
 *before* hydration are in this bug class. Fields behind an `{#if}` (modal bodies, wizard steps
 such as `src/routes/onboarding/`) are not, and there re-seeding on remount is usually the
-*desired* behaviour — see `src/routes/user/items/ItemModal.svelte`.
+*desired* behaviour — see `src/routes/user/items/ItemModal.svelte`. Also excluded: controls whose
+pre-hydration interaction did nothing without JS in the first place —
+`TrustNetworkTable.svelte:148-153`, the status `<select>` on `/user/items`, and
+`search/Pagination.svelte`'s page-size select; a "rescued" value there would claim a filter that
+was never actually applied.
 
-**Open case — URL-synced fields** (tracked as issue #619). `/user/items`' search box syncs from the URL
-(`$derived(data.search)`) so back/forward and a filter reset win, which rules seed-once out. But
-`bind:value` on that writable `$derived` does not fix #613 either: measured in a hydrated browser
-reproduction, the binding *does* adopt the pre-hydration text, and the `afterNavigate` invalidate
-above then recomputes the derived and overwrites it a few ms later. Neither shape is correct
-today — don't "fix" such a field with either one without solving the re-sync trigger first.
+**URL-synced fields — absorb the invalidate, keep the re-sync** (issue #619). Some editable fields
+have to keep following an external value: `/user/items`' search box mirrors `?search=`, so
+back/forward and a filter reset must win — which rules seed-once out. Both obvious shapes fail,
+and for the same reason: a writable `$derived` off `data.search` *or* off `page.url.searchParams`
+adopts the pre-hydration text and then loses it milliseconds later. `invalidate(NOTIFICATIONS_DEP)`
+makes SvelteKit rebuild the page props **and** hand out a fresh `URL` instance (`client.js`:
+`url: new URL(url)` as soon as any node's data changed), so both sources change identity even
+though the search string didn't; the derived recomputes, and a recompute always overwrites an
+override. Measured directly (not inferred from state alone): the box really does go empty for a
+moment and recovers again shortly after — comfortably within the time a web-first assertion would
+keep polling — so a test that only checks the end state (`toHaveValue`, which retries until it
+matches) cannot tell "never went empty" apart from "went empty, then recovered" and passes either
+way; see `e2e/tests/user-items-search.spec.ts`'s core-regression test for a timed, single-snapshot
+assertion that actually catches the gap.
+
+Put a read-only derived in between, so the churn is absorbed by Svelte's own rule that
+*downstream updates are skipped when a derived's new value is referentially identical to its
+previous one*:
+
+```svelte
+// Recomputes on every invalidate — but to the same string, so nothing downstream reruns.
+const loadedSearch = $derived(data.search);
+// The input owns this one via bind:. It only re-syncs when loadedSearch actually changes.
+let searchValue = $derived(loadedSearch);
+```
+```svelte
+<input type="search" bind:value={searchValue} oninput={onSearchInput} />
+```
+
+Both halves are load-bearing: collapsing them into one `$derived(data.search)` *is* the bug, and
+swapping `bind:` for `value=` is #558. The equality rule protects the writable derived only for as
+long as it is never marked dirty — once it does recompute, it compares the fresh value against
+the current, *overridden* one and discards the override. A seed-once `$state` plus a guarded sync
+`$effect` gets the same result and is **not** flagged by `svelte/prefer-writable-derived` (that
+rule only matches a bare single-statement assignment), but it needs its own "did the string
+actually change?" bookkeeping and is the shape #469 moved away from.
+
+Known limit, unrelated to hydration: characters typed *while* the box's own debounced `goto` is
+still in flight are still lost, because the URL then lands one keystroke behind. That predates
+this fix.
 
 ### The submit action
 

--- a/e2e/fixtures/preHydration.ts
+++ b/e2e/fixtures/preHydration.ts
@@ -1,0 +1,44 @@
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * Assert that text typed into server-rendered form fields *before* the page hydrates survives
+ * hydration — the #558/#613 bug class (docs/best-practices.md → "Editable fields: seed-once +
+ * `bind:`, never one-way `value=`"), where the client's first value pass wrote the loaded value
+ * over whatever the user had already typed into the SSR HTML.
+ *
+ * `waitUntil: 'commit'` returns as soon as the SSR HTML starts arriving, so the fills land in the
+ * window before the client modules run — large in dev, where a route also compiles on first hit.
+ *
+ * **The caveat, stated once for every caller:** this is a ratchet, not a proof. If hydration wins
+ * the race the assertion passes trivially, because a correctly-hydrated field holds the typed text
+ * either way. So it can never be *falsely* red — it fails only if the regression is genuinely
+ * back — but a green run is not evidence that the pre-hydration window was actually hit.
+ *
+ * Submits nothing, so it writes nothing to the database and cannot collide with a test running
+ * concurrently under `fullyParallel` (including one that saves the same seed record).
+ *
+ * All fields are filled before any is asserted, so a multi-field page spends as little time as
+ * possible in the pre-hydration window.
+ *
+ * @param page   a page in a context already carrying the right storage state
+ * @param path   app-relative path to open, e.g. `/user/profile`
+ * @param fields CSS selector → text to type. Selectors rather than the repo's usual role/label
+ *               locators because the bug is specifically about the field's `name` attribute
+ *               surviving into the hydrated DOM.
+ */
+export async function expectFieldsSurvivePreHydration(
+	page: Page,
+	path: string,
+	fields: Record<string, string>
+): Promise<void> {
+	const entries = Object.entries(fields);
+
+	await page.goto(path, { waitUntil: 'commit' });
+
+	for (const [selector, value] of entries) {
+		await page.locator(selector).fill(value);
+	}
+	for (const [selector, value] of entries) {
+		await expect(page.locator(selector)).toHaveValue(value);
+	}
+}

--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { STORAGE_STATE, THIRD_STORAGE_STATE, VIEWER } from '../fixtures/users';
+import { expectFieldsSurvivePreHydration } from '../fixtures/preHydration';
 
 /**
  * Groups — the owner-managed lifecycle and the invite-token join.
@@ -78,6 +79,34 @@ test.describe('groups', () => {
 			await page.getByRole('button', { name: 'Gruppe löschen' }).click();
 			await expect(page).toHaveURL(/\/user\/groups$/);
 			await expect(page.getByRole('link', { name: groupName })).toHaveCount(0);
+		} finally {
+			await ctx.close();
+		}
+	});
+
+	test('group name and description typed before hydration survive it (#613 regression)', async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext({ storageState: STORAGE_STATE });
+		const page = await ctx.newPage();
+		try {
+			// The seeded group's id isn't stable across seed runs, so look it up by name
+			// instead of hard-coding it.
+			await page.goto('/user/groups');
+			const card = page.getByRole('link', { name: PRIVATE_GROUP });
+			await expect(card).toBeVisible();
+			const groupId = (await card.getAttribute('href'))?.split('/').pop();
+			expect(groupId).toBeTruthy();
+
+			// Regression for #613: both fields passed a one-way `value=` into Flowbite's
+			// Input/Textarea, which the root layout's afterNavigate invalidate then clobbered
+			// right after hydration (docs/best-practices.md → "Editable fields: seed-once +
+			// bind:, never one-way value="). The helper never saves, so this cannot rename the
+			// shared seed group out from under the join test below under `fullyParallel`.
+			await expectFieldsSurvivePreHydration(page, `/user/groups/${groupId}/settings`, {
+				'input[name="name"]': `E2E Vor-Hydration ${Date.now()}`,
+				'textarea[name="description"]': `E2E Beschreibung ${Date.now()}`,
+			});
 		} finally {
 			await ctx.close();
 		}

--- a/e2e/tests/profile.spec.ts
+++ b/e2e/tests/profile.spec.ts
@@ -1,9 +1,11 @@
 import { test, expect } from '@playwright/test';
 import { STRANGER_STORAGE_STATE } from '../fixtures/users';
+import { expectFieldsSurvivePreHydration } from '../fixtures/preHydration';
 
 /**
  * Profile — saveProfile persists a changed bio, and a bio typed before hydration survives it
- * (regression for #558). Uses the stranger (owns nothing, not referenced by other tests'
+ * (regression for #558), as does a city typed into AddressInput (the same bug class, #613).
+ * Uses the stranger (owns nothing, not referenced by other tests'
  * assertions) so a concurrent run can't be disturbed. Only the bio is changed; the pre-filled
  * username is submitted unchanged. Runs in `multiuser`.
  *
@@ -54,24 +56,31 @@ test.describe('profile', () => {
 	});
 
 	test('text typed before hydration survives it (#558 regression)', async ({ browser }) => {
-		// Regression for #558: text typed before the page hydrates must survive hydration.
-		// `waitUntil: 'commit'` returns as soon as the SSR HTML starts arriving, so the fill
-		// lands in the (large, in dev) window before the client modules run. Before the fix,
-		// Svelte's first `set_value` pass reset the textarea to the loaded value ('' for the
-		// seeded user) and the following save persisted an empty bio behind a success toast.
-		// If hydration wins the race the test is trivially green — it can never be falsely red.
+		// Before the fix, Svelte's first `set_value` pass reset the textarea to the loaded value
+		// ('' for the seeded user) and the following save persisted an empty bio behind a success
+		// toast — which is what made this worth a browser test at all.
 		const ctx = await browser.newContext({ storageState: STRANGER_STORAGE_STATE });
 		const page = await ctx.newPage();
 		try {
-			const bio = `E2E Pre-Hydration Bio ${Date.now()}`;
-			await page.goto('/user/profile', { waitUntil: 'commit' });
+			await expectFieldsSurvivePreHydration(page, '/user/profile', {
+				'textarea[name="bio"]': `E2E Pre-Hydration Bio ${Date.now()}`,
+			});
+		} finally {
+			await ctx.close();
+		}
+	});
 
-			const bioField = page.locator('textarea[name="bio"]');
-			await bioField.fill(bio);
-			await expect(bioField).toHaveValue(bio);
-
-			// No save here: this test performs no DB write, so it can't collide with the
-			// save-and-reload test above under `fullyParallel`.
+	test('a city typed before hydration survives it (#613 regression)', async ({ browser }) => {
+		// Same bug class as #558, different component: AddressInput's city field is SSR-rendered
+		// on /user/profile and was fed a one-way `value={cityText}`. Every seed user has an empty
+		// city (scripts/seed/lib.js sets none), so the assertion is sharp — anything the field
+		// holds afterwards can only have come from the fill.
+		const ctx = await browser.newContext({ storageState: STRANGER_STORAGE_STATE });
+		const page = await ctx.newPage();
+		try {
+			await expectFieldsSurvivePreHydration(page, '/user/profile', {
+				'input[name="city"]': 'E2E Teststraße 1',
+			});
 		} finally {
 			await ctx.close();
 		}

--- a/e2e/tests/search.spec.ts
+++ b/e2e/tests/search.spec.ts
@@ -10,7 +10,7 @@ import { VIEWER_STORAGE_STATE, STRANGER_STORAGE_STATE } from '../fixtures/users'
  */
 
 const SECRET_ITEM = 'E2E Geheimwerkzeug'; // trustees-only, owned by e2e_owner_seed
-const PUBLIC_ITEM = 'E2E Campingzelt'; // public, not touched by any other spec
+const PUBLIC_ITEM = 'E2E Campingzelt'; // public; no other spec writes to it (user-items-search.spec.ts also reads it)
 
 async function searchAs(browser: Browser, storageState: string, query: string) {
 	const ctx = await browser.newContext({ storageState });

--- a/e2e/tests/user-items-search.spec.ts
+++ b/e2e/tests/user-items-search.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect, type Page } from '@playwright/test';
+import { expectFieldsSurvivePreHydration } from '../fixtures/preHydration';
+
+/**
+ * /user/items' search box mirrors `?search=` in the URL (#619, see docs/best-practices.md →
+ * "URL-synced fields"). Runs in the `authenticated` project (owner storageState) — the seeded
+ * owner owns "E2E Campingzelt", "E2E Bohrmaschine", "E2E Kochbuch", "E2E Beamer". No test writes
+ * to the DB, so this file is fullyParallel-safe.
+ */
+
+const PUBLIC_ITEM = 'E2E Campingzelt';
+const OTHER_ITEM = 'E2E Bohrmaschine';
+
+/**
+ * Navigates and waits past hydration before returning. Without this, `.fill()` right after a
+ * plain `page.goto()` reliably lands in the *same* pre-hydration window the first test below
+ * targets on purpose (in dev, Playwright's next command outruns module execution): bind_value
+ * would adopt the fill as an "override", and #619's onMount replay (+page.svelte) would then
+ * fire its own (correct, but different) navigation — not the plain debounced one these tests
+ * mean to exercise. Waiting for the root layout's post-load `__data.json` request reliably means
+ * onMount has already run (and, for the core-regression test below, already had its one-shot
+ * replay be a no-op).
+ */
+async function gotoHydrated(page: Page, path: string) {
+	const dataJsonPromise = page.waitForResponse('**/__data.json*');
+	await page.goto(path);
+	await dataJsonPromise;
+}
+
+function searchBox(page: Page) {
+	return page.getByRole('searchbox', { name: 'Suchen...' });
+}
+
+test.describe('user items search box (#619)', () => {
+	test('text typed before hydration survives it (ratchet, see preHydration.ts)', async ({
+		page,
+	}) => {
+		// Honest caveat (documented once for every caller in preHydration.ts): if hydration wins
+		// the race this passes trivially, since a correctly-hydrated field holds the typed text
+		// either way. It can never be *falsely* red — only red if the regression is genuinely back.
+		await expectFieldsSurvivePreHydration(page, '/user/items', {
+			'input[type="search"]': PUBLIC_ITEM,
+		});
+	});
+
+	test('a spurious invalidate that leaves the search term unchanged does not overwrite typed text (core regression)', async ({
+		page,
+	}) => {
+		// Fully hydrated first: onMount's replay (+page.svelte) already had its one shot — the
+		// box was still empty when it ran, so it was a no-op — and it cannot fire a second time,
+		// so it cannot heal a clobber that happens below.
+		await gotoHydrated(page, '/user/items');
+		const box = searchBox(page);
+		// The status filter — the only combobox on /user/items today. If a second one ever lands
+		// here (sorting, category filter), this needs a name to stay unambiguous.
+		const statusSelect = page.getByRole('combobox');
+
+		// The box's own debounced navigation (300ms after fill, see the test below) also hits
+		// `__data.json` and — being a *real* `?search=` change — would correctly re-sync
+		// `loadedSearch` and heal a clobber if it landed here. Block it forever by URL so it can
+		// never interfere with this test, however slow a CI run is; every other `__data.json`
+		// request (there is exactly one below) goes through untouched. Deliberately *not*
+		// `route.abort()`: a failed `__data.json` fetch trips SvelteKit's hard-navigation
+		// fallback, i.e. an uncontrolled page reload mid-test, instead of the navigation simply
+		// never landing.
+		await page.route('**/__data.json*', async (route) => {
+			if (route.request().url().includes('search=')) return; // never resolves — by design
+			await route.continue();
+		});
+
+		await box.fill(PUBLIC_ITEM);
+		await expect(box).toHaveValue(PUBLIC_ITEM);
+
+		// Change the status filter — any navigation re-runs the root layout's load, which
+		// `afterNavigate` unconditionally invalidates (src/routes/+layout.svelte:28-35, the same
+		// call that fires after the very first page load too). The resulting `data` is a fresh
+		// object even though `data.search` is still '' — the URL never carried `search=` — which
+		// is exactly the "identity churn, unchanged value" shape #619 is about. Driving it via
+		// the status filter, rather than racing the first-load invalidate against hydration,
+		// makes the repro deterministic instead of depending on exactly when hydration lands
+		// relative to the fill.
+		const invalidated = page.waitForResponse(
+			(r) => r.url().includes('__data.json') && !r.url().includes('search=')
+		);
+		await statusSelect.selectOption('available');
+		await invalidated;
+
+		// A polling `toHaveValue` here would NOT prove anything: without the absorber the box
+		// does go empty the instant the invalidate above is processed — measured directly, not
+		// inferred — but Svelte's own reactivity heals it again within roughly a frame or two (a
+		// side effect of `bind:value`'s input-event handling, not #619's onMount replay, and not
+		// something this test relies on). A web-first assertion polls until it matches, so it
+		// would just wait out that recovery and pass regardless of the intervening clobber — it
+		// cannot tell "never went empty" apart from "went empty, then recovered". Read the value
+		// with a single, non-retrying snapshot instead, timed to land inside that window: wait
+		// one settle point past the invalidate (two animation frames —
+		// comfortably longer than Svelte's own effect flush, comfortably shorter than the 300ms
+		// debounce that would otherwise heal it again) and check exactly that snapshot.
+		await page.evaluate(
+			() =>
+				new Promise((resolve) =>
+					requestAnimationFrame(() => requestAnimationFrame(resolve))
+				)
+		);
+		expect(await box.inputValue()).toBe(PUBLIC_ITEM); // #619
+	});
+
+	test("the box's own debounced navigation is idempotent and keeps focus", async ({
+		page,
+	}) => {
+		await gotoHydrated(page, '/user/items');
+		const box = searchBox(page);
+
+		await box.fill(PUBLIC_ITEM);
+		await expect(page).toHaveURL(/[?&]search=E2E\+Campingzelt/); // web-first, outlasts the debounce
+		await expect(box).toHaveValue(PUBLIC_ITEM);
+		await expect(box).toBeFocused(); // keepFocus
+		await expect(page.getByRole('link', { name: PUBLIC_ITEM })).toBeVisible();
+		await expect(page.getByRole('link', { name: OTHER_ITEM })).toBeHidden();
+	});
+
+	test('back/forward re-syncs the box from the URL', async ({ page }) => {
+		await gotoHydrated(page, '/user/items');
+		const box = searchBox(page);
+
+		await box.fill(PUBLIC_ITEM);
+		await expect(page).toHaveURL(/[?&]search=E2E\+Campingzelt/);
+		await expect(page.getByRole('link', { name: OTHER_ITEM })).toBeHidden();
+
+		await page.goBack();
+		await expect(box).toHaveValue('');
+		await expect(page.getByRole('link', { name: OTHER_ITEM })).toBeVisible();
+
+		await page.goForward();
+		await expect(box).toHaveValue(PUBLIC_ITEM);
+	});
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -62,6 +62,7 @@ export default defineConfig({
 				'tests/trust.spec.ts',
 				'tests/feedback.spec.ts',
 				'tests/toast-over-modal.spec.ts',
+				'tests/user-items-search.spec.ts',
 			],
 		},
 		{

--- a/src/lib/components/AddressInput.svelte
+++ b/src/lib/components/AddressInput.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import debounce from 'debounce';
+	import { texts } from '$lib/texts';
 
 	interface Props {
 		initialValue?: string;
@@ -26,7 +28,7 @@
 		if (isValidSelection) {
 			validationInputEl.setCustomValidity('');
 		} else {
-			validationInputEl.setCustomValidity('Bitte nutze die Suche, um eine gültige Adresse auszuwählen.');
+			validationInputEl.setCustomValidity(texts.errors.addressNotSelected);
 		}
 	});
 
@@ -48,14 +50,25 @@
 		isLoadingGeo = false;
 	}, 1000);
 
-	function handleCityInput(e: Event) {
-		cityText = (e.target as HTMLInputElement).value;
+	/**
+	 * The city field holds free text that was *not* picked from the suggestion list: it carries
+	 * no coordinates, so it has to fail the "choose an address from the search" guard. An empty
+	 * field stays valid — the address is optional, `required` only means "if you type something,
+	 * it has to resolve".
+	 */
+	function markAsFreeText() {
 		selectedGeo = null;
-		if (cityText.length === 0) {
-			isValidSelection = true;
-		} else {
-			isValidSelection = false;
-		}
+		isValidSelection = cityText.length === 0;
+	}
+
+	function handleCityInput(e: Event) {
+		// Redundant today, kept deliberately: `bind:value` compiles to `bind_value`, which
+		// attaches a *direct* listener on the input (target phase), while this `oninput` is
+		// delegated to the mount root (bubble phase) — so `cityText` is already current here.
+		// Reading the value off the event keeps the handler self-contained instead of resting on
+		// that ordering, which is a Svelte-internal detail, not a documented guarantee.
+		cityText = (e.target as HTMLInputElement).value;
+		markAsFreeText();
 		if (cityText.length > 3) {
 			isLoadingGeo = true;
 			showSuggestions = false;
@@ -69,7 +82,36 @@
 		isValidSelection = true;
 		showSuggestions = false;
 		suggestions = [];
+		// Emptying `suggestions` unmounts the <ul> — including the button a keyboard user just
+		// activated. Without this, focus would fall back to <body> and strand them at the top of
+		// the document. Deliberately synchronous rather than after a tick(): Svelte flushes the
+		// unmount later, so focus has already left the button by the time it disappears and there
+		// is never a frame with focus on a detached node. Pure no-op on the pointer path, where
+		// onmousedown's preventDefault() kept focus on #city all along. Focusing fires no `input`
+		// event and touches no state, so neither fetchSuggestions() nor the dropdown is retriggered.
+		cityInputEl?.focus();
 	}
+
+	// Issue #613: bind:value's hydration guard adopts text the user typed into the SSR-rendered
+	// input before the bundle ran, but those keystrokes fired no input event we could hear, so
+	// handleCityInput never ran for them and `selectedGeo`/`isValidSelection` still hold their
+	// seeded values. Replay that bookkeeping once, after the hydration flush (onMount runs after
+	// bind_value has adopted the value), so pre-hydration text is judged exactly as it would have
+	// been had it arrived a moment later. Deliberately no fetchSuggestions() here — an unprompted
+	// dropdown on page load would be surprising; the user's next keystroke opens it.
+	// No-op when the component is mounted client-side (onboarding's StepLocation) or untouched.
+	onMount(() => {
+		if (cityText === initialValue) return;
+		markAsFreeText();
+	});
+
+	// Single source of truth for "the address is unusable and the user needs to be told": drives
+	// the visible warning *and* `aria-invalid`, so the screen-reader state can never disagree
+	// with what is on screen. Held back while a lookup runs or the dropdown is open — the user is
+	// mid-selection there, and flagging every keystroke as an error would be pure noise.
+	let showCityWarning = $derived(
+		cityText.length > 0 && !isValidSelection && !isLoadingGeo && !showSuggestions
+	);
 
 	function handleWindowMousedown(e: MouseEvent) {
 		if (
@@ -90,9 +132,11 @@
 		id="city"
 		placeholder="z.B. Kleine Bäckerstraße"
 		bind:this={cityInputEl}
-		value={cityText}
+		bind:value={cityText}
 		oninput={handleCityInput}
 		autocomplete="off"
+		aria-invalid={showCityWarning}
+		aria-describedby="city-error"
 		class="w-full px-3 py-2 bg-papier border border-tinte-300 rounded-lg text-tinte-900 focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:bg-tinte-700 dark:border-tinte-600 dark:text-white pr-8"
 	/>
 	{#if isLoadingGeo}
@@ -110,10 +154,19 @@
 		>
 			{#each suggestions as s (suggestions.indexOf(s))}
 				<li>
+					<!-- Both handlers on purpose: keyboard activation fires `click`, never
+					     `mousedown`, so without onclick a keyboard user could never pick a
+					     suggestion — the only route back to a valid selection. onmousedown stays
+					     for its preventDefault (keeps focus in the input on a pointer pick). A
+					     mouse click does not run both: selectSuggestion() empties `suggestions`,
+					     so the button is gone before `click` would be dispatched — and even if a
+					     browser did dispatch it, selectSuggestion() is idempotent (same
+					     assignments, no fetch, no submit). -->
 					<button
 						type="button"
 						class="w-full text-left px-3 py-2 text-sm text-tinte-800 dark:text-tinte-200 hover:bg-tinte-100 dark:hover:bg-tinte-700"
 						onmousedown={(e) => { e.preventDefault(); selectSuggestion(s); }}
+						onclick={() => selectSuggestion(s)}
 					>
 						{s.label}
 					</button>
@@ -126,16 +179,45 @@
 		<input type="hidden" name="geolocation_lat" value={selectedGeo.lat} />
 	{/if}
 	{#if required}
+		<!-- Submit blocker: its setCustomValidity() message is what stops the form, while the
+		     *semantics* of the invalid state sit on #city (aria-invalid + aria-describedby), which
+		     is where a screen reader lands during normal browsing. This control therefore only
+		     needs to speak in one single moment — the blocked submit, where the browser's native
+		     constraint validation *focuses it* to anchor its bubble — so its exposure follows
+		     exactly the flag that decides whether that moment can happen at all: `isValidSelection`,
+		     the same one the $effect above feeds to setCustomValidity(). Valid ⇒ the browser will
+		     never focus it, so it leaves the accessibility tree instead of sitting in every
+		     rotor/browse-mode pass announcing an error while its own value reads "valid";
+		     tabindex={-1} drops it from sequential Tab order but not from that tree, which is why
+		     hiding it has to be conditional rather than static. Invalid ⇒ it is exposed and named
+		     (aria-label = the visible warning, verbatim) *before* the focus arrives. Deliberately
+		     NOT `showCityWarning`: that tracks whether the user should be *told*, and is held back
+		     mid-lookup, so it goes false while the blocker is still armed — it would re-hide the
+		     very element the browser is about to focus, and could even flip while focus already
+		     sits here, once a debounced lookup resolves. No race the other way either: getting back
+		     to a valid address means typing in #city or picking a suggestion, so focus has always
+		     left this input before `isValidSelection` can flip to true. `aria-hidden` is not a
+		     boolean attribute, so the invalid state renders an explicit `aria-hidden="false"`
+		     (= not hidden), under SSR and after hydration alike. -->
 		<input
 			bind:this={validationInputEl}
 			type="text"
 			value={isValidSelection ? 'valid' : ''}
 			class="sr-only"
 			tabindex={-1}
-			aria-hidden="true"
+			aria-hidden={isValidSelection}
+			aria-label={texts.errors.addressNotSelected}
 		/>
 	{/if}
-	{#if cityText.length > 0 && !isValidSelection && !isLoadingGeo && !showSuggestions}
-		<p class="mt-1 text-xs text-amber-600 dark:text-amber-400">Bitte nutze die Suche, um eine gültige Adresse auszuwählen.</p>
-	{/if}
+	<!-- Rendered unconditionally so the live region is already in the accessibility tree when it
+	     gets content — a region inserted together with its text is frequently not announced.
+	     Polite (role="status"), not alert: #613's onMount can flip the field to invalid with no
+	     user action at all, but interrupting mid-keystroke would be worse than waiting. aria-live
+	     is spelled out alongside the implicit role value for the same reason as /search's status
+	     line: some older screen-reader/browser pairs don't apply it. -->
+	<div id="city-error" role="status" aria-live="polite">
+		{#if showCityWarning}
+			<p class="mt-1 text-xs text-amber-600 dark:text-amber-400">{texts.errors.addressNotSelected}</p>
+		{/if}
+	</div>
 </div>

--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -130,6 +130,12 @@ export const texts = {
 		invalidContactUrl: 'Bitte gib einen gültigen Link an (muss mit https:// beginnen).',
 		contactOffPlatformOnly:
 			'Dieser Anbieter wickelt Anfragen außerhalb der Plattform ab. Bitte nutze den „Anfragen"-Button auf der Gegenstandsseite.',
+		// AddressInput: freier Text im Adressfeld, der nicht aus der Vorschlagsliste stammt und
+		// daher keine Koordinaten trägt. Steht an drei Stellen derselben Komponente (sichtbare
+		// Warnung, setCustomValidity(), aria-label des Validity-Inputs) und muss überall gleich
+		// lauten – die Warnung ist der zugängliche Name des Feldes, auf dem die Browser-Validierung
+		// landet.
+		addressNotSelected: 'Bitte nutze die Suche, um eine gültige Adresse auszuwählen.',
 		feedbackFailed: 'Feedback konnte nicht gesendet werden.',
 		userConsentRequired: 'Bitte stimme der Datenschutzerklärung und den AGB zu, um fortzufahren.',
 		itemNotFound: 'Gegenstand nicht gefunden.',

--- a/src/routes/onboarding/StepContact.svelte
+++ b/src/routes/onboarding/StepContact.svelte
@@ -22,6 +22,18 @@
 	let showTrustInfo = $state(false);
 
 	let errorMessage = $state<string | undefined>(undefined);
+
+	// Issue #613, prophylactic: seed once, then bind: — docs/best-practices.md → "Editable
+	// fields: seed-once + bind:, never one-way value=". No bug to reproduce and hence no
+	// regression test: the wizard is a client-only stepper ({#if}-gated steps) and this is step 7,
+	// so these inputs are never in the SSR HTML today. Fixed anyway so the step stays correct if
+	// the wizard ever becomes resumable (e.g. a `?step=` deep link that server-renders it).
+	// svelte-ignore state_referenced_locally
+	let telegramValue = $state(
+		currentUser?.telegramUsername ? `@${currentUser.telegramUsername}` : ''
+	);
+	// svelte-ignore state_referenced_locally
+	let signalValue = $state(currentUser?.signalLink ?? '');
 </script>
 
 <div class="space-y-4">
@@ -65,7 +77,7 @@
 				type="text"
 				name="telegramUsername"
 				id="telegramUsername"
-				value={currentUser?.telegramUsername ? `@${currentUser.telegramUsername}` : ''}
+				bind:value={telegramValue}
 				placeholder={texts.messenger.telegramUsernamePlaceholder}
 				autocomplete="off"
 				class="w-full px-3 py-2 bg-papier border border-tinte-300 rounded-lg text-sm text-tinte-900 focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:bg-tinte-700 dark:border-tinte-600 dark:text-white"
@@ -115,7 +127,7 @@
 				type="text"
 				name="signalLink"
 				id="signalLink"
-				value={currentUser?.signalLink ?? ''}
+				bind:value={signalValue}
 				placeholder={texts.messenger.signalLinkPlaceholder}
 				autocomplete="off"
 				class="w-full px-3 py-2 bg-papier border border-tinte-300 rounded-lg text-sm text-tinte-900 focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:bg-tinte-700 dark:border-tinte-600 dark:text-white"

--- a/src/routes/user/groups/[id]/settings/+page.svelte
+++ b/src/routes/user/groups/[id]/settings/+page.svelte
@@ -12,7 +12,25 @@
 	let { data, form }: { data: PageData; form: ActionData } = $props();
 
 	// Track the public toggle so we can warn only when newly enabling it.
+	// (Pre-existing, not #613: seeded once from `data` and never re-synced, so
+	// state_referenced_locally fires here too — ignored for the same reason as the seeds below.)
+	// svelte-ignore state_referenced_locally
 	let makePublic = $state(data.group.isPublic);
+
+	// Issue #613: seed once from the loaded value, then let the field own it via bind: — never a
+	// one-way value= on an editable field. Flowbite's Input/Textarea binding internally does not
+	// make the outer one-way prop safe; the un-bound prop is a writable derived that the root
+	// layout's afterNavigate invalidate recomputes right after hydration, discarding what the
+	// user typed. Full mechanism: docs/best-practices.md → "Editable fields: seed-once + bind:,
+	// never one-way value=".
+	//
+	// Trade-off (same as #558/`bio`): ?/updateGroup runs update({ reset: false }) → invalidateAll(),
+	// so after a save these fields keep the value the user typed rather than the server-trimmed one.
+	// The page's <h1> still reads data.group.name, so the heading shows the stored value.
+	// svelte-ignore state_referenced_locally
+	let nameValue = $state(data.group.name);
+	// svelte-ignore state_referenced_locally
+	let descriptionValue = $state(data.group.description);
 
 	// Separate copy-feedback per target so the public-link and invite-link
 	// buttons don't both flip to "kopiert!" at once.
@@ -74,7 +92,7 @@
 				<Input
 					type="text"
 					name="name"
-					value={data.group.name}
+					bind:value={nameValue}
 					required
 					oninvalid={requireName}
 					oninput={clearValidity}
@@ -82,7 +100,7 @@
 			</Label>
 			<Label class="space-y-2 block w-full">
 				<span>{texts.groups.descriptionLabel}</span>
-				<Textarea name="description" class="h-24 w-full" value={data.group.description} />
+				<Textarea name="description" class="h-24 w-full" bind:value={descriptionValue} />
 			</Label>
 			<div class="space-y-1">
 				<Toggle name="isPublic" bind:checked={makePublic}>{texts.groups.publicToggle}</Toggle>

--- a/src/routes/user/groups/[id]/settings/page.server.test.ts
+++ b/src/routes/user/groups/[id]/settings/page.server.test.ts
@@ -76,6 +76,26 @@ describe('settings — updateGroup', () => {
 		const res = await actions.updateGroup({ locals, params, request: req({ name: 'Neu' }) } as never);
 		expect(r(res).data).toMatchObject({ message: texts.errors.somethingWentWrong });
 	});
+
+	// Pre-existing, intentional server semantics, pinned here so nobody "fixes" them later:
+	// `description` uses a `?? ''` fallback, so an absent field clears the stored description
+	// just like an explicitly emptied one (unlike profile's `bio`, which is left untouched when
+	// absent). The server therefore cannot tell a deliberate clear from a field that hydration
+	// blanked before the user typed — which is precisely why #613's fix has to live client-side
+	// (seed-once $state + bind:value in +page.svelte). Its regression coverage is the Playwright
+	// spec, not this file.
+	it.each([
+		['submitted empty', { name: 'Neu', description: '' }],
+		['absent entirely', { name: 'Neu' }],
+	])('clears the stored description when the field is %s', async (_case, body) => {
+		const update = vi.fn().mockResolvedValue({ id: 'g1' });
+		const locals = makeLocals({ groups: { update } });
+
+		const res = await actions.updateGroup({ locals, params, request: req(body) } as never);
+
+		expect(res).toMatchObject({ success: true });
+		expect(update).toHaveBeenCalledWith('g1', { name: 'Neu', description: '', isPublic: false });
+	});
 });
 
 describe('settings — createInvite', () => {

--- a/src/routes/user/items/+page.svelte
+++ b/src/routes/user/items/+page.svelte
@@ -2,6 +2,7 @@
 	import { enhance } from '$app/forms';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
+	import { onMount } from 'svelte';
 	import { SvelteSet, SvelteURLSearchParams } from 'svelte/reactivity';
 	import { texts } from '$lib/texts';
 	import Button from '$lib/components/ui/Button.svelte';
@@ -13,29 +14,62 @@
 	let { data, form } = $props();
 
 	let showAddModal = $state(false);
-	let searchValue = $derived(data.search);
+	// #619 — two deriveds, on purpose, do NOT collapse them into one.
+	// The root layout fires invalidate(NOTIFICATIONS_DEP) from afterNavigate (even on the
+	// first load) and on every realtime reconnect. SvelteKit rebuilds every node's props when
+	// that happens — `data` is a fresh object even though `search` is unchanged (and so is
+	// `page.url`: client.js hands out `url: new URL(url)` as soon as any node has new data —
+	// so deriving from the URL instead doesn't help either).
+	// `loadedSearch` does recompute, but to the same string, and Svelte doesn't propagate a
+	// recompute whose result is referentially identical to the previous one. That keeps
+	// `searchValue` from being marked dirty, so it keeps whatever the user typed.
+	// A real ?search= change (back/forward, our own debounced navigation) changes the string
+	// and re-syncs the box. A single $derived here is exactly #619.
+	const loadedSearch = $derived(data.search);
+	let searchValue = $derived(loadedSearch);
 	let debounceTimer: ReturnType<typeof setTimeout>;
 	const selectedIds = new SvelteSet<string>();
 
+	// Absorber like above: the effect should run on real list changes (navigation, filter,
+	// page, delete), not on every invalidate(NOTIFICATIONS_DEP), which only repackages `data`
+	// — otherwise the bulk selection would disappear the moment a notification arrives or
+	// realtime reconnects.
+	const itemIdsKey = $derived(data.items.map((item) => item.id).join(','));
 	$effect(() => {
-		// Reading the current item ids registers this effect as a dependency of
-		// data.items, so the bulk selection is cleared on every list change
-		// (navigation, filter, page, delete).
-		data.items.map((item) => item.id);
+		void itemIdsKey;
 		selectedIds.clear();
 	});
 
-	function onSearchInput(e: Event) {
-		const value = (e.currentTarget as HTMLInputElement).value;
-		searchValue = value;
+	function scheduleSearchNavigation(value: string, replace = false) {
 		clearTimeout(debounceTimer);
 		debounceTimer = setTimeout(() => {
 			const params = new SvelteURLSearchParams(window.location.search);
 			params.set('search', value);
 			params.set('page', '1');
-			goto(resolve(`/user/items?${params.toString()}`), { keepFocus: true });
+			goto(resolve(`/user/items?${params.toString()}`), {
+				keepFocus: true,
+				replaceState: replace,
+			});
 		}, 300);
 	}
+
+	function onSearchInput(e: Event) {
+		const value = (e.currentTarget as HTMLInputElement).value;
+		// Redundant with bind:value today — bind_value attaches its own direct listener, this
+		// oninput is delegated — but kept so the handler doesn't depend on a Svelte-internal
+		// listener-ordering detail (see AddressInput.svelte, PR #620).
+		searchValue = value;
+		scheduleSearchNavigation(value);
+	}
+
+	onMount(() => {
+		// #619: bind_value adopts text typed before hydration, but onSearchInput never ran for
+		// those keystrokes — the list is still on the old filter. Replay the same debounce so a
+		// user who keeps typing overwrites this navigation instead of navigating on half a word.
+		// replaceState because the user never triggered this navigation themselves. No-op if
+		// nothing was adopted.
+		if (searchValue !== loadedSearch) scheduleSearchNavigation(searchValue, true);
+	});
 
 	function onStatusChange(e: Event) {
 		const value = (e.currentTarget as HTMLSelectElement).value;
@@ -68,7 +102,14 @@
 		<h2 class="text-2xl tracking-tight font-extrabold text-tinte-900 dark:text-white">
 			{texts.pages.items.title}
 		</h2>
-		<div>
+		<!-- Live region: this text already changes on every search/filter navigation, including
+		     #619's onMount replay, which the user never triggered themselves — and that replay's
+		     goto(..., { keepFocus: true }) skips SvelteKit's own reset_focus announcement, so this
+		     is the only announcement a screen reader gets. Unlike ItemsSection.svelte /
+		     GroupItemsSection.svelte (whose visible per-category badges are terse numbers unfit to
+		     read aloud, so they carry a separate sr-only `texts.ui.resultsFound` line), this text
+		     is already a full sentence — no need for a second, duplicate node/string. -->
+		<div aria-live="polite">
 			{#if data.totalItems > 0}
 				<span class="text-accent">{texts.pages.items.countSome(data.totalItems)}</span>
 			{:else}
@@ -97,8 +138,9 @@
 		<div class="flex flex-col sm:flex-row gap-3 mb-4">
 			<input
 				type="search"
-				value={searchValue}
+				bind:value={searchValue}
 				oninput={onSearchInput}
+				aria-label={texts.pages.items.search}
 				placeholder={texts.pages.items.search}
 				class="flex-1 rounded-full border border-tinte-300 bg-papier px-4 py-2 text-sm text-tinte-900 placeholder-tinte-400 focus:border-primary focus:ring-primary dark:border-tinte-600 dark:bg-tinte-700 dark:text-white"
 			/>

--- a/src/routes/user/items/page.server.test.ts
+++ b/src/routes/user/items/page.server.test.ts
@@ -20,8 +20,9 @@ vi.mock('$lib/server/groups', () => ({ getAttachableGroups: getAttachableGroupsM
 // hooks.server.ts (re-exported by +page.server) reads PUBLIC_PB_URL from here.
 vi.mock('$env/static/public', () => ({ PUBLIC_PB_URL: 'http://localhost', PUBLIC_VAPID_PUBLIC_KEY: 'x' }));
 
-import { actions } from './+page.server';
+import { actions, load } from './+page.server';
 import { texts } from '$lib/texts';
+import { makeMockPb } from '$lib/test-utils/pocketbase';
 
 // The actions return a union of fail() shapes (validation vs. save-error), so narrow the
 // data to a permissive shape for assertions instead of indexing the union directly.
@@ -42,6 +43,59 @@ function callDelete(itemId?: string) {
 		request: { formData: vi.fn().mockResolvedValue(fd) },
 	} as unknown as DeleteEvent);
 }
+
+type LoadEvent = Parameters<typeof load>[0];
+
+function buildLoadPb(getListImpl?: ReturnType<typeof vi.fn>) {
+	const getList =
+		getListImpl ?? vi.fn().mockResolvedValue({ items: [], totalItems: 0, totalPages: 0 });
+	const loadPb = makeMockPb({
+		users: { getOne: vi.fn().mockResolvedValue({ id: 'u1' }) },
+		items: { getList },
+	});
+	getAttachableGroupsMock.mockResolvedValue([]);
+	return { pb: loadPb, getList };
+}
+
+function callLoad(loadPb: unknown, search: string) {
+	return load({
+		locals: { pb: loadPb, user: { id: 'u1' } },
+		url: new URL(`http://localhost/user/items${search}`),
+	} as unknown as LoadEvent);
+}
+
+describe('user items: load', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('passes the ?search= query param through as data.search', async () => {
+		const { pb: loadPb } = buildLoadPb();
+
+		const result = await callLoad(loadPb, '?search=Bohrmaschine');
+
+		expect(result.search).toBe('Bohrmaschine');
+	});
+
+	it('defaults data.search to an empty string when no ?search= param is present', async () => {
+		const { pb: loadPb } = buildLoadPb();
+
+		const result = await callLoad(loadPb, '');
+
+		expect(result.search).toBe('');
+	});
+
+	it('builds the name filter via pb.filter with a name ~ {:search} placeholder', async () => {
+		const { pb: loadPb, getList } = buildLoadPb();
+
+		await callLoad(loadPb, '?search=Bohrmaschine');
+
+		expect(loadPb.filter).toHaveBeenCalledWith('name ~ {:search}', { search: 'Bohrmaschine' });
+		expect(getList).toHaveBeenCalledWith(
+			1,
+			25,
+			expect.objectContaining({ filter: expect.stringContaining("name ~ 'Bohrmaschine'") })
+		);
+	});
+});
 
 describe('user items: delete action', () => {
 	beforeEach(() => vi.clearAllMocks());


### PR DESCRIPTION
Closes #619.

> **Stacked on #620** (base is `fix/613-one-way-value-hydration`, not `main`). It reuses that PR's `e2e/fixtures/preHydration.ts` and rewrites the "Open case" paragraph that PR added to `docs/best-practices.md`. Merge #620 first; GitHub will retarget this one to `main` automatically.

## The problem

`/user/items`' search box is SSR-rendered, editable, and was fed a one-way `value={searchValue}`, so text typed before hydration was discarded — the same bug class as #558/#613. It was split out of #613 because neither known fix shape appeared to work: the box has to keep following `?search=` (back/forward, filter reset), which rules seed-once out, and `bind:value` on the writable `$derived` was reported to adopt the text and then lose it again.

## Why `bind:value` alone isn't enough

The root layout fires `invalidate(NOTIFICATIONS_DEP)` from `afterNavigate` — **even on the first load** — and again on every realtime reconnect. SvelteKit then rebuilds every node's props (`client.js`: `data_changed` is a per-node reference check, and the whole `page` object including a fresh `URL` instance is handed out as soon as *any* node's data changed). The writable derived recomputes, and a recompute compares the fresh value against the *overridden* one and discards the override.

## The fix

A read-only derived between the churning source and the bound one:

```svelte
const loadedSearch = $derived(data.search);   // recomputes on every invalidate — to the same string
let searchValue = $derived(loadedSearch);     // the input owns this via bind:
```

`loadedSearch` recomputes but returns a referentially identical string, so Svelte skips downstream propagation; `searchValue` is never marked dirty and keeps what the user typed. A real `?search=` change still moves the string and re-syncs the box.

## Correcting the issue's own proposal

The issue sketches deriving from `page.url.searchParams` instead of `data`, on the theory that `invalidate()` doesn't touch the URL. **Measured, that is not a fix** — it behaves exactly like the bug, because `client.js` sets `url: new URL(url)` whenever any node's data changed. The absorbing derived is what matters, not the source.

## Also in this PR

- **`onMount` replay** — `bind:value` adopts the pre-hydration text, but `onSearchInput` never ran for those keystrokes, so the list was still on the old filter. Replays the same 300 ms debounce with `replaceState`.
- **`selectedIds` fix** — that effect depended on the `data` object, so the bulk selection was cleared on every notification and every realtime reconnect. Now keyed on the item ids.
- **`aria-live` on the result count** — `goto(..., { keepFocus: true })` skips SvelteKit's `reset_focus`, so nothing announced the list change to screen readers (SC 4.1.3), and the new replay navigates without the user asking.
- **`aria-label` on the search input** — it had no accessible name at all. Reuses the existing `texts.pages.items.search` key.
- **Docs** — the "Open case" paragraph becomes the documented idiom; the sweep criterion now also excludes controls whose pre-hydration interaction did nothing without JS.

## A note on the regression test

The first version of the e2e test raced the first-load invalidate and asserted with `toHaveValue`. It was **green even with the fix removed**: the clobber really happens, but the `onMount` replay heals it ~300 ms later and a web-first assertion just polls until it matches. Confirmed with a temporary in-component probe:

```
data identity changed: true | data.search = ""      <- mount
searchValue recomputed -> "E2E Campingzelt"         <- bind_value adopts the typed text
data identity changed: true | data.search = ""      <- the invalidate
searchValue recomputed -> ""                        <- override discarded (the bug)
data identity changed: true | data.search = "E2E …" <- the replay navigates
searchValue recomputed -> "E2E Campingzelt"         <- healed
```

The test now drives the invalidate deterministically via the status filter (after hydration, so the one-shot replay can't heal anything), blocks the box's own debounced navigation by URL, and reads the value with a single non-retrying snapshot two animation frames after the invalidate resolves — long enough for Svelte's effect flush, short enough to land inside the window. A polling assertion cannot tell "never went empty" apart from "went empty, then recovered"; this one can.

## Test notes

- `npx playwright test e2e/tests/user-items-search.spec.ts --repeat-each=5 --workers=1` → **27/27**, no flakes.
- Same command with the absorbing derived removed → **5/5 red**, so the test genuinely guards the fix.
- Full `npm run test:e2e` → 62/62. `npx vitest run` → 790/790. `npm run lint` clean. `npm run build` green.
- `npm run check` reports 2 errors in `src/lib/server/superuser.ts` — pre-existing, caused by `PB_SUPERUSER_*` missing from the local `.env`; green in CI.
- Manually verified in the browser: throttled pre-hydration typing, no blank flash, text surviving an offline/online realtime reconnect, bulk selection surviving a notification, back/forward, and the no-JS render.

## Known, deliberately out of scope

- `src/routes/search/SearchBar.svelte` has the same bug class in a different shape: its focus-guard `$effect` runs at mount while focus is still on `<body>` and overwrites the adopted text. Separate risk surface (autofocus, two e2e specs, 1200 ms debounce) — worth its own issue, and it must **not** be "fixed" by pattern-matching the idiom from this PR without accounting for the focus guard.
- The status `<select>` next to the search box still has no accessible name. Pre-existing, outside this diff.
- Typing *while* the box's own debounced `goto` is in flight still loses the last keystroke. Predates this change; documented as a known limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
