### PR TITLE
docs(data-model): document the deleted-owner clause on the item views (#624)

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -440,7 +440,8 @@ Self-service account deletion (GDPR Art. 17) is **two-phase, anonymize-in-place*
   **cannot** be deleted (`conversations.requestedItem` is a *required* relation) — it is kept
   (set to `unavailable`) so the counterparty's loan history resolves. The `items_public` /
   `items_searchable` views exclude rows whose owner is `deleted`, so a deleted account's
-  listings disappear from search/catalogue while existing conversations still show the item.
+  listings disappear from search/catalogue while existing conversations still show the item —
+  see "Deleted owners" under the views section below for the clause and its consequences.
 - Shared/audit data is **retained**, de-identified to "Gelöschtes Konto": `messages`,
   `conversations` (the counterparty keeps a coherent history; the lending paper trail stays
   intact), and `term_acceptances` (legal-obligation exception, Art. 17(3)).
@@ -516,6 +517,32 @@ reachable). Accepting the current terms clears the lock in the same transaction.
 
 Two read-only PocketBase SQL views expose `items` joined with `users` (and `user_geolocations` for the location flag) as flat, privacy-safe rows. Neither exposes the owner's `trusts` list, and neither includes raw coordinates — they expose only `ownerHasLocation` (0 or 1); travel times are computed in the backend `/api/travel-times` hook, which returns only **bucketed minutes** so coordinates never reach the client.
 
+### Deleted owners
+
+**Both** views end with `WHERE COALESCE(users.deleted, 0) = 0`, so no row of an
+anonymized owner is ever returned. Such rows exist on purpose: account deletion
+hard-deletes the user's items *except* those a conversation still references
+(`conversations.requestedItem` is a required relation) — those are kept as
+`unavailable` so the counterparty's loan history stays coherent (see "Account
+deletion" above). The clause keeps them out of discovery without deleting them.
+`COALESCE` rather than a bare `users.deleted = 0` because both views `LEFT JOIN
+users`: an item with no owner row would otherwise compare against `NULL` and be
+dropped silently.
+
+Consequence: `/items/{id}` reads `items_public` unconditionally, so a deleted
+owner's item detail page **404s for everyone** — including the ex-borrower —
+which matches how `/users/{id}` shows a tombstone. The conversation itself is
+unaffected: it resolves the item from the base `items` collection via `expand`,
+which carries no such filter.
+
+The clause is appended to the view query, not part of any `SELECT`, so **any**
+migration that replaces a `viewQuery` wholesale must carry it over. Four did not
+after `1781900042` introduced it: `1781900045` dropped it from
+`items_searchable`, `1781900049` dropped it from `items_public`, and
+`1782750000` + `1783800001` rewrote the already clause-less `items_public` query
+again — which is issue #624. The guard is
+`allerleih-backend/tests/deleted-owner-items.test.mjs`.
+
 ### `items_public` — public, content-masked
 
 Fully public (`listRule`/`viewRule` are open). For any **restricted** item — i.e.
@@ -573,8 +600,8 @@ conversation access never leaks an item into search/profile/sitemap.
 > first; see that repo's README ("Writing migrations").
 Free-text search (`buildSearchFilter`) matches the owner `username` in addition to item
 `name` and `description`, so an account or institution can be found by name. Deleted-owner
-rows are excluded from the view (see the deleted-owner `WHERE` clause), so this never
-surfaces an anonymized account name.
+rows are excluded from the view (see "Deleted owners" above for the `WHERE` clause), so this
+never surfaces an anonymized account name.
 
 ### Base `items` trust rule
 


### PR DESCRIPTION
## What & why

`docs/data-model.md` asserted in two places that `items_public` and `items_searchable` exclude
rows whose owner is `deleted`:

- the account-deletion bullet — "The `items_public` / `items_searchable` views exclude rows whose
  owner is `deleted`, so a deleted account's listings disappear from search/catalogue …"
- the free-text-search paragraph — "Deleted-owner rows are excluded from the view (see the
  deleted-owner `WHERE` clause), so this never surfaces an anonymized account name."

Both were true when written and had silently stopped being true. Four backend migrations that
reassigned `viewQuery` dropped the clause (`1781900045` on `items_searchable`, `1781900049` on
`items_public`, then `1782750000` + `1783800001` rebuilding an already clause-less query), so an
anonymized account's conversation-retained items were back in the public catalogue and in search.
That is #624; the fix lives in the backend.

Notice also that the second claim points at "the deleted-owner `WHERE` clause" as if the document
explained it somewhere. It never did — the clause only ever existed in a migration's string append,
which is precisely how it went missing without anyone noticing.

## What this adds

A `### Deleted owners` paragraph under the views section, before `### items_public`, carrying:

- the literal `WHERE COALESCE(users.deleted, 0) = 0`, on **both** views;
- why such rows exist at all (`conversations.requestedItem` is a required relation, so a
  conversation-referenced item survives account deletion as `unavailable`);
- why `COALESCE` rather than a bare `users.deleted = 0` (both views `LEFT JOIN users`, so an item
  with no owner row would compare against `NULL` and be dropped silently);
- the consequence that `/items/{id}` 404s for such items — including for the ex-borrower — while
  the conversation still resolves the item from the base `items` collection;
- the rule that **any** migration replacing a `viewQuery` must carry the clause over, and where the
  guard lives.

The two existing claims now point at it instead of at nothing.

## Scope

Docs only — no code. The clause adds no column, so `src/lib/types/models.ts` is unaffected and the
`ItemPublic` type stays correct. The consumers of these views (`/search`, `/sitemap.xml`,
`/user/groups/[id]`, `/items/[id]`, `/users/[id]`) need no change: they lose those rows, which is
the point. `/users/[id]` is unaffected either way — its tombstone branch returns before any item
query.

## Test notes

Preflight: `npm run lint` clean · `npm run check` 0 errors (8 pre-existing
`state_referenced_locally` warnings in untouched components) · `npx vitest run` 785/785 ·
`npm run build` ✔.

Beyond the preflight, the backend change was verified end to end against the `account-deletion`
seed in a real browser, and the e2e specs covering the consumers of these views (`search`,
`misc`/sitemap, `item-upload`) pass 22/22. Reviewer only needs to read the prose — but it is worth
checking that the `### Deleted owners` paragraph reads correctly *next to* the masking explanation
below it, since one removes rows and the other nulls columns.

## Companion PR

Backend fix (migration + guard test + the skill/rule/README corrections that stop this recurring):
share-open-sharing-infrastructure/allerleih-backend#54

Closes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)