### PR TITLE
fix(push): only suppress notifications for the focused target window

### DIFF
--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -81,23 +81,24 @@ self.addEventListener('fetch', (event) => {
 self.addEventListener('push', (event) => {
 	if (!event.data) return;
 
-	const payload = event.data.json() as { title: string; body: string; url?: string };
+	const notificationPayload = event.data.json() as { title: string; body: string; url?: string };
 
 	event.waitUntil(
 		self.clients
 			.matchAll({ type: 'window', includeUncontrolled: true })
 			.then((clientList) => {
 				// Suppress the push if the user already has the target page open
-				if (payload.url) {
-					const alreadyViewing = clientList.some((c) => c.url.endsWith(payload.url!));
+				const targetUrl = notificationPayload.url;
+				if (targetUrl) {
+					const alreadyViewing = clientList.some((client) => client.url.endsWith(targetUrl));
 					if (alreadyViewing) return;
 				}
 
-				return self.registration.showNotification(payload.title, {
-					body: payload.body,
+				return self.registration.showNotification(notificationPayload.title, {
+					body: notificationPayload.body,
 					icon: '/icon-192x192.png',
 					badge: '/icon-192x192.png',
-					data: { url: payload.url ?? '/notifications' },
+					data: { url: targetUrl ?? '/notifications' },
 				});
 			})
 	);

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -83,22 +83,35 @@ self.addEventListener('push', (event) => {
 
 	const notificationPayload = event.data.json() as { title: string; body: string; url?: string };
 
+	const targetPath = notificationPayload.url ?? '/notifications';
+	// Resolve to an absolute URL once, exactly as notificationclick below does, so
+	// both handlers match open windows by the same rule. A substring check would
+	// miss a client carrying a query string or hash, and could match an unrelated
+	// route that merely ends with this path.
+	const target = new URL(targetPath, self.location.origin).href;
+
 	event.waitUntil(
 		self.clients
 			.matchAll({ type: 'window', includeUncontrolled: true })
 			.then((clientList) => {
-				// Suppress the push if the user already has the target page open
-				const targetUrl = notificationPayload.url;
-				if (targetUrl) {
-					const alreadyViewing = clientList.some((client) => client.url.endsWith(targetUrl));
-					if (alreadyViewing) return;
-				}
+				// Suppress the push only when the target page is open AND in front of the
+				// user — there the realtime subscription has already updated the UI, so an
+				// OS notification is just noise. matchAll() also returns background and
+				// minimised windows; suppressing on those would silently drop the
+				// notification, and showing nothing at all makes the browser enforce our
+				// userVisibleOnly subscription itself (Chrome substitutes a generic "site
+				// updated in the background" notification; Firefox eventually drops the
+				// subscription).
+				const alreadyViewing = clientList.some(
+					(client) => client.focused && client.url === target
+				);
+				if (alreadyViewing) return;
 
 				return self.registration.showNotification(notificationPayload.title, {
 					body: notificationPayload.body,
 					icon: '/icon-192x192.png',
 					badge: '/icon-192x192.png',
-					data: { url: targetUrl ?? '/notifications' },
+					data: { url: targetPath },
 				});
 			})
 	);


### PR DESCRIPTION
## What

Tightens the `push` handler in `src/service-worker.ts`, which decides whether an incoming push should become a visible notification.

Previously it suppressed the notification whenever **any** open window's URL ended with the push target:

```ts
clientList.some((client) => client.url.endsWith(targetUrl))
```

Two problems with that predicate:

**1. It ignores whether the window is actually in front of the user.** `clients.matchAll()` returns background and minimised windows too, so a tab left open on the target page hours ago silently swallowed the notification — the user never learned about the new message.

Showing nothing is also not free: the subscription is created with `userVisibleOnly: true` (`src/lib/utils/pushSubscription.ts`), and browsers enforce that contract. Chrome substitutes its own generic *"This site has been updated in the background"* notification; Firefox keeps a per-subscription quota of pushes that produced no notification and eventually drops the subscription.

**2. `endsWith()` is a substring test.** An unrelated route that merely ends with the target path matched — a window on `/user/groups/<id>` matched a target of `/groups/<id>`. Not reachable from today's call sites (pushes only ever target `/conversations/<id>`, `/users/<id>` or `/user/groups/<id>`), so this is latent rather than a live bug, but it breaks the moment one route path becomes a suffix of another.

## How

- Suppress only when a **focused** window sits on the target — that's the case the check was actually aiming at, since the realtime subscription has already updated the UI there.
- Resolve the target to an absolute URL once, up front, using the same expression `notificationclick` already uses, and compare exactly. Both handlers now share one definition of "the target page" instead of each carrying its own matching rule.
- `data: { url }` reuses the same defaulted path rather than re-deriving it.

Minor behaviour change worth flagging: a payload with no `url` now participates in suppression (previously the `if (targetUrl)` guard skipped the check entirely). Unreachable in practice — `sendPushToUser` takes `url` as a required parameter — and it's the coherent reading, since such a notification points at `/notifications`.

## Test notes

**Local preflight was skipped at the requester's instruction** — `npx vitest run` and `npm run build` were *not* run locally. CI covers both. What was run:

- `npm run check` — 0 errors (also confirms `client.focused` typechecks without a cast: `matchAll`'s overload narrows to `WindowClient` off the literal `type: 'window'`).
- `npx eslint src/service-worker.ts` — clean.

`src/service-worker.ts` has no unit-test coverage and isn't importable by Vitest, so it was verified against the running app instead (real dev server + PocketBase with the `e2e` seed). A real Web Push can't reach a Playwright-launched Chromium — there's no push-service connection — so pushes were synthesised with CDP `ServiceWorker.deliverPushMessage`, which dispatches a genuine trusted `PushEvent` into the live registration. Each case also recorded what the handler saw (`clients.matchAll` output incl. `focused`) and compared the outcome against what the old predicate would have produced:

| Case | Window state | Push target | Old | New | Actual |
|---|---|---|---|---|---|
| A | focused, on `/notifications` | `/notifications` | suppressed | suppressed | suppressed ✅ |
| B | **backgrounded**, on `/notifications` | `/notifications` | suppressed | shown | shown ✅ |
| C | focused, on `/notifications` | `/conversations/abc123` | shown | shown | shown ✅ |
| D | focused, on `/user/groups/<id>` | `/groups/<id>` | suppressed | shown | shown ✅ |

B is the live bug, reproduced and fixed. A is the important non-regression — the fix doesn't simply disable suppression. D is a synthetic pairing demonstrating the latent substring failure.

**Not covered:** the `notificationclick` navigation path itself (untouched; only the `data` payload it receives was verified), real end-to-end delivery through FCM, and installed-PWA window semantics (tested as browser tabs).

## Notes for the reviewer

- The branch name (`random-code-review`) predates this work and doesn't describe it; happy to rename if you'd rather.
- `213fbe7 "Minor fix"` is the other commit on this branch — it hoists `payload.url` into a local so TypeScript's narrowing survives into the `matchAll` callback, removing a non-null assertion. Same file, same theme; its message could be reworded before merge if you want the history cleaner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
