### PR TITLE
feat(assetlinks): add assetlinks.json for Android app URL handling (#509)

### DIFF
--- a/static/.well-known/assetlinks.json
+++ b/static/.well-known/assetlinks.json
@@ -3,6 +3,6 @@
   "target": {
     "namespace": "android_app",
     "package_name": "org.allerleih.app",
-    "sha256_cert_fingerprints": ["PLACEHOLDER_REPLACE_AFTER_PLAY_CONSOLE_UPLOAD"]
+    "sha256_cert_fingerprints": ["86:80:72:82:E0:9B:90:D9:CE:5B:B7:02:78:4F:E5:16:0F:9C:22:34:F0:4F:28:7E:E9:D1:AC:CA:AC:2B:16:3B"]
   }
 }]

--- a/static/.well-known/assetlinks.json
+++ b/static/.well-known/assetlinks.json
@@ -1,0 +1,8 @@
+[{
+  "relation": ["delegate_permission/common.handle_all_urls"],
+  "target": {
+    "namespace": "android_app",
+    "package_name": "org.allerleih.app",
+    "sha256_cert_fingerprints": ["PLACEHOLDER_REPLACE_AFTER_PLAY_CONSOLE_UPLOAD"]
+  }
+}]


### PR DESCRIPTION
## What

- Creates `static/.well-known/assetlinks.json` with package name `org.allerleih.app` —
  the Digital Asset Link file that, once the real signing-certificate fingerprint is filled
  in, removes the Chrome URL bar from the installed TWA
- For #509 

## Why

Without `assetlinks.json` on the server, Android cannot verify that the TWA shell and the
website are controlled by the same party, so Chrome shows an address bar inside the
installed app. This file is the server-side half of that trust declaration.

## Fingerprint

`sha256_cert_fingerprints` is the fingerprint from the AAB upload to the Play Console in Christians account.

## Package name

`org.allerleih.app` follows reverse-domain-notation for `allerleih.org`

## Test notes

- Changes are purely to static JSON files — no TypeScript, no Svelte components affected
- Not tested (hope it is fine for this one static file)