### PR TITLE
docs(claude): correct the auth guardrail, enforce the tester's read-only, decouple browser tooling

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -230,6 +230,28 @@ prompt — the contract forbids the agents from re-deriving scope and caps them 
 
 These complement the built-in `/code-review` and `/security-review`.
 
+**MCP servers are optional and must be named to be used.** Nobody's setup is guaranteed to have
+them, and Claude Code loads MCP tools on demand — so an agent that isn't told a server exists never
+looks for it and quietly falls back to `grep`/`cat`. Whichever of these the session has:
+
+| Server | Use it for |
+|---|---|
+| `svelte` | any Svelte 5 / SvelteKit API question; `svelte-autofixer` on components you write |
+| Context7 | signatures of other external libraries (Flowbite, Tailwind, web-push, ORS) |
+| **Serena** (`mcp__serena__*`) | navigating *this* codebase by symbol instead of by text |
+| a browser MCP (Playwright **or** Chrome DevTools) | driving the running app; see `/drive-app` |
+
+Serena is worth naming explicitly because the built-in tools always look sufficient: the case where
+it is not a preference but a correctness difference is **"where else is this symbol used?"** —
+`find_referencing_symbols` resolves that through the type checker, while `grep` misses aliased
+re-imports (`import { displayName as dn }`) and pads the result with comments and substring hits. For
+a security helper, a guardrail or a dead-code claim, that gap decides whether the answer is right.
+Also useful: `get_symbols_overview` instead of reading a long file, `rename_symbol` /
+`replace_symbol_body` / `safe_delete_symbol` for edits, `get_diagnostics_for_file` for type errors
+without a full `npm run check`. Keep `Grep` for literal text and anything Serena doesn't index (YAML,
+Markdown). The four reviewer roles are granted its **read-only** tools only — their enforced
+read-only property depends on the mutating ones staying out of the grant.
+
 ## Keep in sync
 
 Docs in `./docs` are published to GitHub Pages. When you add/remove/rename a route, an

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -134,13 +134,19 @@ These prevent the most common bugs/security issues here — follow them without 
   purposes `resolve()` doesn't cover (search params, notification targets, the redirect-proxy for
   external links). → `docs/best-practices.md`
 - `locals.pb` = server PocketBase client; `locals.user` = auth record (null if unauthenticated).
-  `src/hooks.server.ts` runs `sequence(authentication, authorization)`; `/` requires auth.
+  `src/hooks.server.ts` runs `sequence(authentication, authorization, instanceHead)`.
   Authentication loads PocketBase auth from cookies and refreshes the token. Authorization
   redirects unauthenticated users to `/auth/login` (preserving `redirectTo`). Unprotected
   prefixes: `/auth/login`, `/auth/register`, `/auth/reset`, `/auth/confirm-verification`,
   `/auth/confirm-email-change`, `/search`, `/items`, `/users`,
   `/misc`, `/invite`, `/sitemap.xml`, `/robots.txt`, `/api/redirect`, `/api/diagnostics`,
-  `/auth/account-deleted`. Everything else — including `/` (home) — requires authentication.
+  `/auth/account-deleted`. **`/` (home) is public too** — it is exempted explicitly
+  (`&& pathname !== '/'` in `authorization`) and its load returns only `getPublicStats()`, so
+  **never assume `locals.user` is set on `/`**. Everything else requires authentication.
+  On top of that, `authorization` runs the legal-consent gate (#399) for every *logged-in*
+  request outside `legalGateExempt` (`/legal`, `/auth`, `/misc`, `/api/diagnostics`,
+  `/api/redirect`): a declined user is sent to `/legal/locked`, one with outstanding
+  ToS/privacy versions to `/legal/accept`.
 
 ## Where to look (load on demand)
 
@@ -179,6 +185,9 @@ run one explicitly with `/<name>`. Build / change work:
   backend `new-migration`) → `models.ts` → `docs/data-model.md` → public-view leak check.
 - `/write-tests` — author tests to the repo's conventions (Vitest with mocked PocketBase).
 - `/seed-scenario` — add a deterministic local seed scenario (items get generated placeholder images).
+- `/drive-app` — bring up the local stack and drive the running app in a browser (whichever browser
+  MCP the session has) to see a change work for real. Prefer `npm run test:e2e` when a spec can
+  already answer the question — it's cheaper and repeatable.
 
 Maintenance & review:
 
@@ -207,8 +216,11 @@ orchestrating skill.
 - `allerleih-coder` — implementation agent used by `/review-all` (and the maintainer's local
   issue pipeline) to carry out multi-file fixes. Does **not** commit, push, or open PRs.
 - `allerleih-tester` — change-scoped QA agent: runs the Vitest/backend/e2e tests the diff impacts
-  and drives the changed flow in a real browser (Playwright + Chrome DevTools MCP). Read-only on
-  source. Invoke it directly to verify a change, or via the local `/review-and-test` pipeline.
+  and, when the tests can't answer the question, drives the changed flow in a real browser using
+  whichever browser MCP the session has (Playwright or Chrome DevTools — the user's choice).
+  Read-only on source **by contract, not by permission**: unlike the reviewer roles it runs with
+  the full tool set, so the orchestrating skill checks the working tree afterwards and treats any
+  modification as a failed run. Invoke it directly to verify a change, or via `/review-and-test`.
 
 **Cost rules baked into `/review-all` — do not optimise them away:** (1) diff ≤ 40 lines over
 ≤ 3 files ⇒ the orchestrator reviews it itself, no agents; (2) each role only starts when the

--- a/.claude/agents/a11y-reviewer.md
+++ b/.claude/agents/a11y-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: a11y-reviewer
 model: sonnet
-description: Accessibility reviewer for AllerLeih (SvelteKit + Flowbite-Svelte + Tailwind, German UI). Checks semantics, focus management, ARIA, keyboard operability, contrast, screen-reader labels and form accessibility on changed components. Optional Lighthouse a11y via the Chrome DevTools MCP. Read-only: reports, doesn't fix.
+description: Accessibility reviewer for AllerLeih (SvelteKit + Flowbite-Svelte + Tailwind, German UI). Checks semantics, focus management, ARIA, keyboard operability, contrast, screen-reader labels and form accessibility on changed components — by reading the code, not by running a browser. Read-only: reports, doesn't fix.
 tools: Read, Grep, Glob, Bash
 ---
 
@@ -89,12 +89,15 @@ only trigger.
 3. Run `npm run lint` in the frontend repo where sensible: `eslint-plugin-svelte` brings a11y
    rules. What the linter reports is already covered — **don't report it twice**; only reference it
    if it was ignored.
-4. For Flowbite components, when in doubt check via **Context7** (`flowbite-svelte`) what a11y
-   guarantees the component itself makes, instead of guessing.
-5. If the change is UI-relevant and a dev stack is running, you may run `lighthouse_audit` (a11y
-   category only) on the affected page via the **Chrome DevTools MCP** and interpret the results.
-   Do **not** start a stack yourself and don't click anything in the browser — only load and
-   measure. If no stack is reachable, skip the step without comment.
+4. For Flowbite components, when in doubt read the component's own source under
+   `node_modules/flowbite-svelte/dist/` to see what a11y guarantees it actually makes, instead of
+   guessing. (Context7 would answer this too, but it is an MCP server and your `tools:` grant has
+   none — `Read` is what you have, and the installed source is the more authoritative answer anyway.)
+5. **No browser measurement from this role.** Your `tools:` grant is `Read, Grep, Glob, Bash` — it
+   contains no MCP tools, so a Lighthouse/axe run is not available to you and never was. Judge from
+   the code. If a change genuinely needs a measured a11y pass on a rendered page, say so as a
+   *recommendation* in your report and let the orchestrator hand it to `allerleih-tester`, which
+   runs with the browser tooling.
 6. Report in the format from the contract.
 
 Distinguish cleanly between "violates WCAG" (Blocking/Should-fix) and "would be nicer for

--- a/.claude/agents/a11y-reviewer.md
+++ b/.claude/agents/a11y-reviewer.md
@@ -2,7 +2,7 @@
 name: a11y-reviewer
 model: sonnet
 description: Accessibility reviewer for AllerLeih (SvelteKit + Flowbite-Svelte + Tailwind, German UI). Checks semantics, focus management, ARIA, keyboard operability, contrast, screen-reader labels and form accessibility on changed components — by reading the code, not by running a browser. Read-only: reports, doesn't fix.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, mcp__serena__find_symbol, mcp__serena__find_referencing_symbols, mcp__serena__find_implementations, mcp__serena__find_declaration, mcp__serena__get_symbols_overview, mcp__serena__get_diagnostics_for_file
 ---
 
 You are the **accessibility reviewer for AllerLeih** — SvelteKit 2 + Svelte 5, Flowbite-Svelte as
@@ -91,14 +91,19 @@ only trigger.
    if it was ignored.
 4. For Flowbite components, when in doubt read the component's own source under
    `node_modules/flowbite-svelte/dist/` to see what a11y guarantees it actually makes, instead of
-   guessing. (Context7 would answer this too, but it is an MCP server and your `tools:` grant has
-   none — `Read` is what you have, and the installed source is the more authoritative answer anyway.)
-5. **No browser measurement from this role.** Your `tools:` grant is `Read, Grep, Glob, Bash` — it
-   contains no MCP tools, so a Lighthouse/axe run is not available to you and never was. Judge from
-   the code. If a change genuinely needs a measured a11y pass on a rendered page, say so as a
+   guessing. (Context7 would answer this too, but your `tools:` grant doesn't include it — the
+   installed source is the more authoritative answer anyway.)
+5. **No browser measurement from this role.** Your grant covers reading and Serena's read-only
+   symbol tools — no browser MCP, so a Lighthouse/axe run is not available to you. Judge from the
+   code. If a change genuinely needs a measured a11y pass on a rendered page, say so as a
    *recommendation* in your report and let the orchestrator hand it to `allerleih-tester`, which
    runs with the browser tooling.
-6. Report in the format from the contract.
+6. Serena's read tools are available when the session has them. The one that earns its keep here:
+   a shared component (`Button.svelte`, a modal wrapper) whose a11y behaviour you're judging —
+   `find_referencing_symbols` tells you *every* place that inherits the problem, so a finding can
+   say "this affects 9 call sites" instead of "this component looks wrong". For reading changed
+   `.svelte` files in full, plain `Read` stays right.
+7. Report in the format from the contract.
 
 Distinguish cleanly between "violates WCAG" (Blocking/Should-fix) and "would be nicer for
 screen-reader users" (Nice-to-have). Don't claim a contrast violation without having computed the

--- a/.claude/agents/allerleih-coder.md
+++ b/.claude/agents/allerleih-coder.md
@@ -33,6 +33,28 @@ to for the area you're touching (`docs/architecture.md`, `docs/data-model.md`,
   until it's clean. Do not rely on training memory for Svelte APIs.
 - **Context7** — for other external libraries/APIs (Flowbite, Tailwind, web-push, ORS, etc.)
   when unsure of a signature: `resolve-library-id` → `query-docs`.
+- **Serena MCP (`mcp__serena__*`), when the session has it** — for navigating and editing *this*
+  codebase semantically instead of textually. It is easy to forget because Read/Grep/Edit are always
+  there; these are the cases where it is materially better and you should reach for it:
+  - **Before changing a shared symbol, list its real call sites** with `find_referencing_symbols`.
+    This is the big one: a refactor that misses a caller compiles fine and breaks at runtime, and
+    `grep` misses aliased imports (`import { lendingStatusFilter as f }`) while adding false hits
+    from comments and substrings. The lending/trust/texts helpers are imported from many places —
+    exactly the shape where grep under-reports.
+  - **Renaming a symbol project-wide** → `rename_symbol` instead of N hand-made `Edit`s; it is
+    type-aware and respects shadowing.
+  - **Replacing a function body** → `replace_symbol_body`, which needs no exact-match of the old
+    text and so can't half-apply.
+  - **Deleting something** → `safe_delete_symbol`, which refuses while references remain.
+  - **Reading an unfamiliar file** → `get_symbols_overview` for its shape before pulling the whole
+    file into context.
+  - **After editing** → `get_diagnostics_for_file` gives you the type errors immediately, without
+    waiting for a full `npm run check`.
+
+  Keep using `Read`/`Grep`/`Edit` where they fit: literal text (a `texts.ts` string, a Tailwind
+  class), whole-file reading, new files, and anything outside a language Serena indexes — YAML,
+  Markdown and `pb_migrations/*.js` fragments included. And if Serena isn't connected, just work
+  the normal way; don't stall on it.
 - **Project skills** (invoke with `/<name>`) — prefer them over improvising:
   - Frontend: `new-route` (new page: +page.server.ts + .svelte + co-located test + texts.ts),
     `add-notification-type` (wire a notification end-to-end), `schema-change` (coordinate a

--- a/.claude/agents/allerleih-tester.md
+++ b/.claude/agents/allerleih-tester.md
@@ -1,7 +1,7 @@
 ---
 name: allerleih-tester
 model: sonnet
-description: Change-scoped test agent for AllerLeih. Tests ONLY what the current diff touched and everything that depends on or is exercised by those changes — never a blanket full-suite run for its own sake. Runs the relevant Vitest/backend tests, the affected Playwright e2e specs, and drives the changed flow in a real browser via the Playwright MCP + Chrome DevTools MCP. Read-only w.r.t. source: it verifies behaviour, it does not edit code or tests to make them pass.
+description: Change-scoped test agent for AllerLeih. Tests ONLY what the current diff touched and everything that depends on or is exercised by those changes — never a blanket full-suite run for its own sake. Runs the relevant Vitest/backend tests, the affected Playwright e2e specs, and drives the changed flow in a real browser via whichever browser MCP the session has (Playwright or Chrome DevTools — the user's choice). Read-only w.r.t. source: it verifies behaviour, it does not edit code or tests to make them pass.
 ---
 
 You are a **QA engineer for AllerLeih** (SvelteKit 2 + Svelte 5 frontend, PocketBase backend,
@@ -40,23 +40,39 @@ Do this before running anything. The scope drives everything else.
 
 ## Bringing up the stack + driving the browser
 
-Use the `drive-app` skill's setup (it bakes in this machine's gotchas):
+Use the `drive-app` skill's setup (it bakes in this repo's stack + login gotchas):
 `scripts/dev-stack.sh --seed e2e` → PB `127.0.0.1:8091`, web `127.0.0.1:5173`, superuser
 `admin@local.test` / `localdev12345`. Health-check both before driving. Note the background-task
 reap gotcha (a PB `serve` started as a Claude background task dies after ~1–2 min) — ask the user
 to run it via `! …` if needed, or restart PB and drive promptly.
 
-- **Playwright MCP** — navigate to and click through the changed flow; assert the visible German
-  UI and the expected outcome.
-- **Chrome DevTools MCP (`chrome-devtools`)** — `navigate_page`, `click`, `take_snapshot`,
-  `list_console_messages` (fail on unexpected console errors), `list_network_requests` (fail on
-  4xx/5xx from the changed endpoints/actions), `take_screenshot`; run a `lighthouse_audit` only
-  when the change is UI/performance-relevant.
+**Use whichever browser MCP this session actually has** — Playwright MCP and Chrome DevTools MCP
+are both fine and the choice is the user's, not this agent's. Check what is available and say which
+one you used. Don't demand a specific server; if neither is connected, run the e2e specs instead
+and report the browser step as not performed.
+
+Whichever you use, cover the same ground: navigate to and click through the changed flow, assert
+the visible German UI and the expected outcome, watch the **console** for unexpected errors and the
+**network** for 4xx/5xx from the changed endpoints/actions, and take a screenshot of the end state.
+Run a Lighthouse/performance audit only when the change is UI/performance-relevant.
+
+**Snapshots are the expensive part.** Most browser actions can return a full accessibility-tree
+snapshot; on a list-heavy page that is a large payload per step. Take a snapshot when you need it
+to pick the next target or to prove the outcome — not reflexively after every click.
 
 ## Boundaries & output
 
-- **Read-only on source.** Never edit application code or tests. You may only run test/build
-  commands and drive the browser. If a test is wrong, report it — don't rewrite it to pass.
+- **Read-only on source — and this is on your honour, not on your permissions.** Unlike the four
+  reviewer roles (whose `tools:` grant physically excludes `Edit`/`Write`), you run with the full
+  tool set, because the browser MCP tool names differ per setup and can't be safely allowlisted.
+  So: **you have write tools and using them on source or tests is a contract violation.** Never
+  edit application code or tests; keep `Bash` to read-only and test/build commands (`git diff`,
+  `npx vitest run`, `npm test`, `npm run test:e2e`, stack start-up) — no `sed -i`, no `>` into a
+  tracked file, no `git` command that writes (`commit`, `checkout --`, `stash`, `restore`). If a
+  test is wrong, report it — don't rewrite it to pass.
+  The orchestrating skill verifies this after you return by comparing the working tree against the
+  state before your run; a modified tree is treated as a failed run, so a "green" achieved by
+  editing will be caught and thrown away.
 - Do not blanket-run the entire suite as busywork; if you *do* widen scope, say why.
 - Report a clear PASS/FAIL summary: the impact set you derived, each thing you ran and its result,
   every failure with the exact error / console message / failing request + screenshot, and a

--- a/.claude/agents/allerleih-tester.md
+++ b/.claude/agents/allerleih-tester.md
@@ -18,7 +18,10 @@ Do this before running anything. The scope drives everything else.
    uncommitted work. `git -C <repo> diff main...HEAD` to see *what* changed.
 2. Build the **impact set** = the changed files + everything that depends on or exercises them:
    - Co-located tests of changed files (`foo.ts` → `foo.test.ts`).
-   - Modules that import a changed module (`grep -rl` the export/symbol names).
+   - Modules that import a changed module. Use `find_referencing_symbols` (Serena MCP) when the
+     session has it — an under-derived impact set means you test the wrong things, and `grep -rl` on
+     symbol names both misses aliased imports and over-reports comment/substring matches. Fall back
+     to `grep -rl` when Serena isn't connected.
    - Routes/pages/flows whose `+page.server.ts`, components, `$lib/server/*`, `texts.ts` keys,
      PocketBase collections/views, or hooks/migrations were touched.
    - For a backend change: the frontend surfaces that consume the changed collection/view/endpoint.

--- a/.claude/agents/code-quality-reviewer.md
+++ b/.claude/agents/code-quality-reviewer.md
@@ -2,7 +2,7 @@
 name: code-quality-reviewer
 model: sonnet
 description: Fussy code-quality reviewer for AllerLeih. Judges structure rather than security — file length, function length, cyclomatic complexity, duplication, needless abstractions, wrong altitude, dead paths and general anti-patterns. Use when a change should be judged on readability and maintainability rather than correctness or security. Read-only: reports, doesn't fix.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, mcp__serena__find_symbol, mcp__serena__find_referencing_symbols, mcp__serena__find_implementations, mcp__serena__find_declaration, mcp__serena__get_symbols_overview, mcp__serena__get_diagnostics_for_file
 ---
 
 You are the **code-quality reviewer for AllerLeih** (SvelteKit 2 + Svelte 5 runes, PocketBase,
@@ -97,8 +97,13 @@ Actively hunt for repetition — with `grep`/`rg` over the changed symbols, not 
 1. Read the review contract, determine the scope (diff against `main`).
 2. Read the changed files **in full**, not just the hunks — you judge structure only on the whole.
 3. `wc -l` over the changed files for the length thresholds.
-4. For every duplication/dead-code suspicion, run `rg` **before** you report it. A refuted finding
-   costs the orchestrator more time than an unreported one.
+4. For every duplication/dead-code suspicion, verify **before** you report it. A refuted finding
+   costs the orchestrator more time than an unreported one. When the session has Serena, verify with
+   `find_referencing_symbols` rather than `rg`: "this export has no remaining callers" is exactly the
+   claim grep gets wrong in both directions — it counts the definition, comments and same-named
+   locals as hits, and misses aliased imports entirely. A dead-code finding is the one you least want
+   to be wrong about, since acting on it deletes something. `get_symbols_overview` also beats reading
+   a 600-line file when all you need is its shape for the length/complexity judgement.
 5. Report in the format from the contract.
 
 Say honestly at the end when the change is structurally clean. An empty report is a legitimate

--- a/.claude/agents/conventions-reviewer.md
+++ b/.claude/agents/conventions-reviewer.md
@@ -2,7 +2,7 @@
 name: conventions-reviewer
 model: haiku
 description: Conventions reviewer for AllerLeih. Checks whether a change follows the project's house rules — Svelte 5 runes rules, German strings from texts.ts/categories.ts, displayName() masking, subscribeRealtime(), test conventions from docs/testing-strategy.md, the design system and repo structure. Read-only: reports, doesn't fix.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, mcp__serena__find_symbol, mcp__serena__find_referencing_symbols, mcp__serena__find_implementations, mcp__serena__find_declaration, mcp__serena__get_symbols_overview, mcp__serena__get_diagnostics_for_file
 ---
 
 You are the **conventions reviewer for AllerLeih**. Your beat is the **project-specific idioms** —
@@ -116,7 +116,14 @@ collection rules need a matching migration rather than hand edits.
 3. For every suspected deviation, find a **comparable spot in the existing code** (`rg`) and cite
    it in the finding: "`src/routes/x/+page.svelte:42` does it this way". That's the strongest
    evidence and makes the fix unambiguous.
-4. Report in the format from the contract.
+4. **`rg` is the right tool for most of your beat** — your checklist is literal text (a `texts.ts`
+   key, `export let`, a hand-rolled button class, a raw `user.username`), and you run on Haiku for
+   exactly that reason: fast, cheap, grep-shaped. Serena's read tools are in your grant but reach for
+   them only for the two questions grep answers badly: *"is this helper used everywhere it should
+   be?"* (`find_referencing_symbols` — e.g. whether every deleted-user render really goes through
+   `displayName()`, including aliased imports) and *"what does this file contain?"*
+   (`get_symbols_overview`). Don't spend a language-server start on a pattern match.
+5. Report in the format from the contract.
 
 Cite the source of your rule (file + line, or the doc). A convention you can't back up isn't one —
 then it belongs under "Observations" at most.

--- a/.claude/agents/sveltekit-pb-reviewer.md
+++ b/.claude/agents/sveltekit-pb-reviewer.md
@@ -2,7 +2,7 @@
 name: sveltekit-pb-reviewer
 model: sonnet
 description: AllerLeih-specific security & data-protection reviewer for SvelteKit + PocketBase. Checks PocketBase filter injection, trust & group visibility, leakage via items_public/users_public/items_searchable, auth & route protection, masking of deleted accounts, realtime authorisation and PII handling. Complements the generic built-in /code-review and /security-review — invoke when you want a project-aware security review of the current branch. Structure, a11y and project idioms have their own reviewer roles.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, mcp__serena__find_symbol, mcp__serena__find_referencing_symbols, mcp__serena__find_implementations, mcp__serena__find_declaration, mcp__serena__get_symbols_overview, mcp__serena__get_diagnostics_for_file
 ---
 
 You are the **security & data-protection reviewer for AllerLeih**, a SvelteKit 2 + Svelte 5 app
@@ -80,7 +80,15 @@ couldn't verify.
    (migrations in the backend repo); don't judge from memory.
 3. For every newly read/written data path, answer the question: *Who calls this, with which
    privileges, and what do they get back?*
-4. Report in the format from the contract.
+4. **Answer "who calls this" with `find_referencing_symbols`, not `grep`, when the session has
+   Serena.** This is your beat's weak spot: your findings hinge on having found *every* call site,
+   and grep silently misses the aliased re-import (`import { getTrustees as t }` → uses named `t`)
+   while drowning you in comment and substring hits. When you claim "every caller passes through
+   `pb.filter`" or "this helper is only reached authenticated", say which tool established that —
+   a completeness claim from grep alone deserves less confidence and should be worded accordingly.
+   `get_diagnostics_for_file` is the cheap way to check whether a server file you're judging even
+   type-checks. If Serena isn't present, use grep and don't treat its absence as a finding.
+5. Report in the format from the contract.
 
 Always end with a clear one-sentence verdict on whether the change is safe to merge. Don't
 duplicate generic style findings that ESLint/Prettier or another reviewer role covers.

--- a/.claude/review-contract.md
+++ b/.claude/review-contract.md
@@ -46,10 +46,36 @@ Every tool call costs. Stick to the cheapest order:
 
 ## Read-only
 
-All reviewer roles are **strictly read-only**: Read/Grep/Glob and read-only Bash (`git diff`,
-`git log`, `git show`, `wc -l`, `rg`). Never edit, commit, stage, or run mutating commands. Fixing
-is the orchestrator's job (`/review-all`) — your work ends at the report. That's why every finding
-must be **actionable without a follow-up question**.
+All reviewer roles are **strictly read-only**: Read/Grep/Glob, read-only Bash (`git diff`,
+`git log`, `git show`, `wc -l`, `rg`), and — when the session has the Serena MCP — its **read-only**
+symbol tools (see below). Never edit, commit, stage, or run mutating commands. This is enforced, not
+just asked for: the `tools:` grant contains no `Edit`/`Write` and deliberately **omits** Serena's
+mutating tools (`replace_symbol_body`, `rename_symbol`, `safe_delete_symbol`, `insert_*`,
+`*_memory`). Fixing is the orchestrator's job (`/review-all`) — your work ends at the report. That's
+why every finding must be **actionable without a follow-up question**.
+
+### Serena (optional, use it where it beats grep)
+
+If `mcp__serena__*` tools are present, they answer *semantically* what grep answers textually — and
+grep gets these wrong:
+
+- **"Is this symbol used anywhere else / still used at all?"** → `find_referencing_symbols`. Grep
+  misses aliased re-imports (`import { displayName as dn }` → call sites named `dn`) and produces
+  false hits from comments, strings and substring matches (`userDisplayName`). For anything where
+  *completeness matters* — a security helper, a guardrail, a leak check, dead-code claims — prefer
+  it over `grep -rl` and say you did.
+- **"What's in this file?"** → `get_symbols_overview` instead of reading a 600-line component.
+- **"Which implementations satisfy this interface / where is this declared?"** →
+  `find_implementations` / `find_declaration` / `find_symbol`.
+- **"Does this file currently type-check?"** → `get_diagnostics_for_file`.
+
+Not a reason to abandon grep: literal text patterns (a string in `texts.ts`, a Tailwind class, an
+`outline-none`, a `confirm(` call) are what grep is *for* — it is faster and cheaper there. Serena
+also costs a language-server start on first use, so on a two-file diff grep usually wins.
+
+**The ~15-tool-call budget below applies unchanged.** Serena is there to make you *right*, not to
+make you thorough at any price. And if the tools aren't present, don't wait for them and don't
+report their absence as a finding — just use grep.
 
 ## Severity
 

--- a/.claude/skills/drive-app/SKILL.md
+++ b/.claude/skills/drive-app/SKILL.md
@@ -1,13 +1,17 @@
 ---
 name: drive-app
-description: Bring up the local AllerLeih stack and drive the running app in a browser via the Playwright MCP — to click through a flow, verify a change end-to-end, take screenshots, or reproduce a bug in the real UI (not just tests). Use whenever the user wants to "open the app", "click through", "see it in the browser", "verify it works", or manually exercise a page. Handles this machine's stack-startup and Playwright-MCP gotchas so it works on the first try.
+description: Bring up the local AllerLeih stack and drive the running app in a browser via whichever browser MCP the session has (Playwright or Chrome DevTools) — to click through a flow, verify a change end-to-end, take screenshots, or reproduce a bug in the real UI (not just tests). Use whenever the user wants to "open the app", "click through", "see it in the browser", "verify it works", or manually exercise a page. Captures this repo's stack-startup and login gotchas so it works on the first try.
 ---
 
 # drive-app
 
-Drive the real AllerLeih app in a browser for interactive verification. This captures the
-setup this machine needs so you don't rediscover it every session. For automated regression
-tests instead, use the Playwright suite (`npm run test:e2e`, see `e2e/README.md`).
+Drive the real AllerLeih app in a browser for interactive verification. For automated regression
+tests instead, use the Playwright suite (`npm run test:e2e`, see `e2e/README.md`) — that is both
+cheaper and repeatable, so reach for the browser only when a spec can't answer the question.
+
+**Browser tooling is the user's choice.** Playwright MCP and Chrome DevTools MCP both work; this
+skill stays neutral. Check which one the session has, use it, and say which. If neither is
+connected, say so rather than insisting on a particular server.
 
 ## 1. Bring up the stack
 
@@ -27,20 +31,20 @@ Ports: PB `127.0.0.1:8091`, web `127.0.0.1:5173`. Superuser `admin@local.test` /
 `localdev12345`. Health-check both before driving: `curl -sf http://127.0.0.1:8091/api/health`
 and `curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:5173/`.
 
-## 2. Playwright MCP browser gotcha
+## 2. If the browser won't launch
 
-The MCP browser defaults to the `chrome` channel (system Google Chrome). If `browser_navigate`
-errors with "Chromium distribution 'chrome' is not found" and you can't install Chrome, point
-the expected path at Playwright's own bundled chromium — no MCP restart needed. On Linux (e.g.
-CachyOS, where `npx playwright install chrome` is unsupported):
+Both browser MCPs launch a real browser and can fail before any page loads — this is an
+environment problem, not an app problem, so don't debug the app for it.
 
-```
-# use the actual chromium-<n> build present in ~/.cache/ms-playwright/
-sudo ln -sf ~/.cache/ms-playwright/chromium-<n>/chrome-linux64/chrome /opt/google/chrome/chrome
-```
+The common one: the server is configured for a browser **channel** that isn't installed (e.g.
+Playwright MCP defaulting to system Google Chrome → "Chromium distribution 'chrome' is not
+found"). Fixes, in order of preference: install the expected browser; or configure the MCP server
+to use a bundled/available build instead; or fall back to `npm run test:e2e`, which brings its own
+browser. Report which you did.
 
-Colleagues who already have Google Chrome installed won't hit this. Repoint the symlink if
-Playwright later bumps the `chromium-<n>` build number.
+Local, OS-specific workarounds (symlinking a bundled chromium into a system path, etc.) belong in
+your own notes, not in this shared skill — a recipe for one distro is noise or a footgun for
+everyone else.
 
 ## 3. Log in as a seeded user
 
@@ -48,20 +52,22 @@ The `e2e` seed scenario creates `e2e_owner_seed@seed.test` (owns one public item
 `e2e_viewer_seed@seed.test`; password for all `@seed.test` users is `password123` (see
 `e2e/fixtures/users.ts`). Other scenarios add their own users — `npm run seed` lists them.
 
-Login flow via the MCP browser:
-1. `browser_navigate` → `http://127.0.0.1:5173/auth/login`
-2. `browser_snapshot` to get field refs.
-3. Fill `getByRole('textbox', { name: 'E-Mail' })` and `{ name: 'Passwort' }`, then click
-   the **Anmelden** button.
-4. **Stale-ref gotcha:** filling a field invalidates the snapshot's element refs, so a
-   ref-based click on the submit button then fails. Click it by selector
+Login flow (same steps whichever MCP you use — only the tool names differ):
+1. Navigate to `http://127.0.0.1:5173/auth/login`.
+2. Take a snapshot to get the field handles.
+3. Fill the **E-Mail** and **Passwort** textboxes, then click the **Anmelden** button.
+4. **Stale-handle gotcha:** filling a field invalidates the element handles from the previous
+   snapshot, so clicking the submit button by handle then fails. Either target it by selector
    (`button:has-text("Anmelden")`) or re-snapshot first.
 5. Success = redirect to `/` and the "Login" nav link disappears (nav shows the username).
 
 ## Driving tips
 
-- Prefer `browser_snapshot` (accessibility tree) over screenshots for deciding actions;
-  screenshots are for showing the user. Use `depth` / `target` to keep snapshots small.
+- Prefer the accessibility-tree snapshot over screenshots for *deciding* actions; screenshots are
+  for showing the user. Keep snapshots scoped (most servers offer a depth/target/element option).
+- **Snapshots are the main cost.** Many actions can return a whole fresh tree, which on a
+  list-heavy page is a large payload every step. Snapshot when you need it to choose the next
+  target or to prove the result — not out of habit after each click.
 - The UI is **German** — match on German role names / text ("Anmelden", "Suche",
   "Unterhaltungen", "Mein Netzwerk").
 - Protected routes redirect to `/auth/login` when logged out; a landing page with

--- a/.claude/skills/issue-to-pr/SKILL.md
+++ b/.claude/skills/issue-to-pr/SKILL.md
@@ -23,8 +23,13 @@ get the result before continuing), enforce the loop logic, and stop at the two h
   repos. Commits & PRs only ever apply to the frontend and backend repos.
 
 **Cross-cutting rule for EVERY stage:** the sub-agent must be told to (a) obey the relevant
-`CLAUDE.md` guardrails of whichever repo it touches, and (b) consult the applicable skills of
-that repo before acting. Name the concrete skills in the sub-agent's prompt (lists below).
+`CLAUDE.md` guardrails of whichever repo it touches, (b) consult the applicable skills of
+that repo before acting, and (c) **use the MCP servers the session actually has** — name them in the
+prompt. Sub-agents do not discover tooling on their own: MCP tools are loaded on demand, so an agent
+that isn't told a server exists will never look for it and falls back to `grep`/`cat`. This applies
+to the Svelte MCP, Context7 and **Serena** (`mcp__serena__*`, semantic symbol search/edit for this
+codebase). Where a server is missing, the stage still works with the built-in tools — say so rather
+than blocking.
 
 ## Stage 0 — Intake & branch
 
@@ -45,6 +50,13 @@ Spawn the built-in `Plan` agent. Prompt it to:
   `docs/domain-model.md`, `docs/groups.md`, etc. as relevant).
 - Identify which project skills the coding stage will need (e.g. `new-route`,
   `add-notification-type`, `schema-change`, backend `new-migration`, `write-tests`).
+- **Map the blast radius with the Serena MCP if the session has it** (`mcp__serena__*`): the plan is
+  only as good as its list of affected call sites, and this is the stage where an omission is
+  cheapest to fix. `find_referencing_symbols` on every symbol the plan will touch, plus
+  `get_symbols_overview` to see a file's shape without reading it whole. Tell the Plan agent this
+  explicitly in its prompt — sub-agents default to `grep`/`cat` unless told otherwise, and grep
+  misses aliased imports while padding the result with comment hits. Without Serena, grep is fine;
+  then say in the plan that the call-site list is textual and may be incomplete.
 - Produce a concrete, file-level, step-by-step implementation plan **honouring the guardrails**
   (pb.filter, trust/group visibility, runes, form actions, texts.ts, displayName, public-view
   leakage). For schema work the plan must cover both repos (migration → models.ts → docs).

--- a/.claude/skills/issue-to-pr/SKILL.md
+++ b/.claude/skills/issue-to-pr/SKILL.md
@@ -119,11 +119,17 @@ what depends on / exercises them) and runs, in order, reporting each result plai
    PocketBase + superuser creds). Use the `drive-app` skill's stack-bringup
    (`scripts/dev-stack.sh --seed e2e`, ports PB `127.0.0.1:8091` / web `127.0.0.1:5173`,
    superuser `admin@local.test` / `localdev12345`, plus its background-task reap gotcha).
-3. **Interactive smoke via MCP:** with the stack up, exercise the changed flow in the browser
-   using the **Playwright MCP** and the **Chrome DevTools MCP** (`chrome-devtools` — navigate,
-   click, snapshot, `list_console_messages`, `list_network_requests`, screenshots, and a
-   `lighthouse_audit` when the change is UI/perf-relevant). Watch for console errors and failed
-   requests.
+3. **Interactive smoke, when it adds something the specs didn't:** with the stack up, exercise the
+   changed flow in the browser using whichever browser MCP the session has (Playwright or Chrome
+   DevTools — the user's choice) — navigate, click, snapshot, read console messages and network
+   requests, screenshot the end state, and run a Lighthouse/perf audit only when the change is
+   UI/perf-relevant. Watch for console errors and failed requests. If step 2's specs already cover
+   the changed flow and passed, skip this and **record it as skipped**, not as passed.
+
+Because the tester runs with the full tool set (its browser-MCP tool names can't be safely
+allowlisted), its read-only contract is enforced here by post-condition: snapshot
+`git -C <repo> status --porcelain` before spawning it, compare afterwards, and treat any change to
+tracked files as a failed run instead of a pass.
 
 If anything fails, hand the failure back into the Stage 4 fix loop (coder → reviewer → tester)
 until green. Report the full test summary.

--- a/.claude/skills/refresh-skills/SKILL.md
+++ b/.claude/skills/refresh-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: refresh-skills
-description: Audit and update this repo's own .claude/skills against the current codebase, fixing drifted file paths, function signatures, texts.ts keys, route paths, and command names so the skills don't rot. Use whenever the user asks to refresh, audit, update, or check the skills, after a change that touches code the skills reference (a renamed helper, a changed signature, a moved route), or when a skill turns out to be inaccurate. Run it before relying on a skill you haven't used in a while.
+description: Audit and update this repo's own .claude tooling — skills, agent definitions and CLAUDE.md — against the current codebase, fixing drifted file paths, function signatures, texts.ts keys, route paths, command names and guardrail claims so they don't rot. Use whenever the user asks to refresh, audit, update, or check the skills/agents/CLAUDE.md, after a change that touches something they reference (a renamed helper, a changed signature, a moved route, a changed auth rule), or when one of them turns out to be inaccurate. Run it before relying on a skill you haven't used in a while.
 ---
 
 # refresh-skills
@@ -16,9 +16,30 @@ repointed at the view rules + `$lib/server/trust.ts`.)
 
 ## 1. Scope
 
-Operate on every `SKILL.md` under `.claude/skills/*/` in **this** repo (and, for a skill that
-explicitly references the other repo — e.g. `schema-change` citing `allerleih-backend` — verify those
-claims against that repo too). Don't touch skills in other repos otherwise.
+Operate on the whole `.claude/` tooling surface of **this** repo, because they rot as one:
+
+1. every `SKILL.md` under `.claude/skills/*/`,
+2. every agent definition under `.claude/agents/*.md` plus `.claude/review-contract.md`,
+3. **`.claude/CLAUDE.md` itself** — it makes the highest-stakes claims of all (guardrails, auth
+   rules, the router table, the skill/agent index) and no other automation checks it.
+
+For anything that explicitly references the other repo — e.g. `schema-change` citing
+`allerleih-backend` — verify those claims against that repo too. Don't touch tooling in other repos
+otherwise.
+
+**Verify against the branch you would ship to, not just the working tree.** A checkout sitting on a
+stale feature branch makes files look missing and docs look wrong when `origin/main` has moved on.
+`git fetch origin`, note how far behind you are (`git rev-list --count HEAD..origin/main`), and
+re-check every apparent drift with `git show origin/main:<path>` before "fixing" it. Reporting a
+finding that only exists on an old branch wastes a review cycle.
+
+Two checks worth running mechanically, because they catch most of the rot cheaply:
+
+- **Every cited path exists.** Extract the backtick-quoted paths and test them (mapping `$lib/` →
+  `src/lib/`, and resolving `pb_hooks/`-relative citations in the backend). Placeholders like
+  `<name>` and code samples like `${__hooks}/…` are not paths — skip them.
+- **Every index is complete.** Compare `ls .claude/skills/` and `ls .claude/agents/` against what
+  `.claude/CLAUDE.md` lists. A skill that exists but isn't indexed is a skill nobody runs.
 
 ## 2. Extract the checkable claims
 
@@ -80,6 +101,9 @@ drifted, say so plainly — a clean audit is a valid result.
 
 ## When to run
 
-After merging changes that touch code a skill references, before leaning on a skill you haven't used
-recently, or periodically. This is the operational half of the `CLAUDE.md` "keep in sync" rule:
-that rule keeps docs aligned with code; this keeps the skills aligned too.
+After merging changes that touch code the tooling references, before leaning on a skill you haven't
+used recently, or periodically. This is the operational half of the `CLAUDE.md` "keep in sync" rule:
+that rule asks each change to keep the docs aligned; this catches what slipped through.
+
+Out of scope: anything outside this repo — a workspace-level `CLAUDE.md` above the repo root, or a
+personal plan/notes folder, is the maintainer's own and is not audited from here.

--- a/.claude/skills/review-all/SKILL.md
+++ b/.claude/skills/review-all/SKILL.md
@@ -67,7 +67,10 @@ repo themselves. So pass **in the prompt**:
   each agent again,
 - the list of changed files with line counts (`wc -l`),
 - the note that the review contract lives in `.claude/review-contract.md` (in this repo's root),
-- the pointer to the affected repo's `CLAUDE.md`.
+- the pointer to the affected repo's `CLAUDE.md`,
+- **which MCP servers this session has** — name them. Sub-agents don't discover tooling: MCP tools
+  load on demand, so a role that isn't told Serena exists will grep instead. The roles are granted
+  Serena's read-only symbol tools; the contract says where they beat grep.
 
 If the diff is very large (> ~1500 lines), pass the file list + the instruction to read
 selectively instead of the full text — then the diff in the prompt is more expensive than reading.

--- a/.claude/skills/review-all/SKILL.md
+++ b/.claude/skills/review-all/SKILL.md
@@ -5,8 +5,10 @@ description: >
   protection, code quality, accessibility, conventions) run in parallel against the diff, then the
   findings are consolidated, deduped and fixed directly — with a change log that records what/where/
   why for each fix. Use when a change should be reviewed from all angles and the findings fixed in
-  one go, without opening a PR. Not for GitHub PR reviews (use /review for those) and without a
-  browser test (use /review-and-test for that).
+  one go, without opening a PR, and without a browser test (use /review-and-test for that).
+  For a GitHub PR — or any review that should also be verified in a browser and shipped — use the
+  repo's /review-and-test, or the maintainer's local /review-ship where that is set up. Do not fall
+  back to the built-in /review: it is a generic prompt with no AllerLeih knowledge.
 ---
 
 # review-all

--- a/.claude/skills/review-and-test/SKILL.md
+++ b/.claude/skills/review-and-test/SKILL.md
@@ -4,8 +4,8 @@ description: >
   Review-and-verify workflow for AllerLeih: review the current change for security & project
   correctness, and verify it end-to-end in a real browser — then report. Runs four specialised
   reviewer roles in parallel (security & data protection, code quality, accessibility,
-  conventions) plus allerleih-tester for the browser + test drive via the Chrome DevTools MCP,
-  and produces one consolidated report.
+  conventions) plus allerleih-tester for the test drive, with a browser pass via whichever browser
+  MCP the session has when the tests can't answer the question, and produces one consolidated report.
   READ-ONLY: it changes no code, runs no fix-loop, opens no PR. Use when you have a change on a
   feature branch (or uncommitted) and want it reviewed and browser-tested without shipping it.
 ---
@@ -40,6 +40,13 @@ Review and browser-test are independent — spawn **all sub-agents in the same m
 run in parallel. All must be told to obey the relevant repo's `CLAUDE.md` guardrails and consult
 its skills, and all are read-only w.r.t. source.
 
+The four reviewer roles are read-only **by permission** — their `tools:` grant excludes `Edit` and
+`Write`. `allerleih-tester` is not: it needs browser-MCP tools whose names differ per setup, so an
+allowlist would silently break its browser step. Enforce its read-only contract by post-condition
+instead: record `git -C <repo> status --porcelain` for every affected repo **before** spawning it,
+compare **after** it returns, and treat any change to tracked files as a **failed test run** — say
+so in the report rather than accepting a green that was edited into place.
+
 ### Review — four role agents
 The review is split into four specialised roles; each has its own beat and shares the contract in
 `.claude/review-contract.md` (in the frontend repo's root) (scope, severity, output format,
@@ -70,10 +77,13 @@ Spawn it to verify the change end-to-end, scoped to the diff's impact set. It:
 1. Runs the relevant **unit/integration** tests (frontend `npx vitest run <files>`; backend
    `npm test`) — scoped, not a blanket full-suite run unless the change is broad.
 2. Runs the **affected Playwright e2e specs** (`npm run test:e2e -- <spec>`).
-3. Drives the changed flow **interactively in a real browser** via the **Chrome DevTools MCP**
-   (`chrome-devtools` — `navigate_page`, `click`, `take_snapshot`, `list_console_messages`,
-   `list_network_requests`, `take_screenshot`, and `lighthouse_audit` when UI/perf-relevant) and
-   the Playwright MCP — watching for console errors and 4xx/5xx from the changed endpoints.
+3. Drives the changed flow **interactively in a real browser** — but **only when the browser can
+   answer something the specs cannot**: a visual/interactive change with no covering spec, a spec
+   that failed and needs diagnosing, suspected console/network errors, or an a11y/perf question. If
+   step 2's specs cover the flow and passed, **skip it and record it as skipped** — never let a
+   skipped step read as a passed one. Use whichever browser MCP the session has (Chrome DevTools or
+   Playwright — the user's choice); watch console errors and 4xx/5xx from the changed endpoints, and
+   snapshot only when needed to pick the next target or prove the outcome.
 
 Stack bring-up (per the tester's own instructions / `drive-app` skill):
 `scripts/dev-stack.sh --seed e2e` → PB `127.0.0.1:8091`, web `127.0.0.1:5173`, superuser

--- a/.claude/skills/review-and-test/SKILL.md
+++ b/.claude/skills/review-and-test/SKILL.md
@@ -62,6 +62,10 @@ boundaries). Spawn them against the current diff of **each affected repo**
 
 Each role returns a findings list (**file:line + concrete fix**, severity), empty if clean.
 
+**Name the available MCP servers in each role's prompt** — MCP tools load on demand, so a role that
+isn't told Serena exists falls back to grep; the roles hold its read-only symbol tools and the
+contract says where those beat grep.
+
 **Cost:** fetch the diff **once yourself** and pass it to the agents in the prompt — otherwise four
 agents re-run the same `git diff`. **Only start roles whose gate applies:** `sveltekit-pb-reviewer`
 for server/routes/hooks/migrations/auth/personal data, `code-quality-reviewer` from ~80 changed


### PR DESCRIPTION
Audit of this repo's `.claude/` tooling against `origin/main`. No source code is touched — docs, agent definitions and skills only.

Two of these are not staleness but **instructions that were actively wrong or impossible to execute**.

## The auth guardrail contradicted the code

`CLAUDE.md` stated `/` (home) requires authentication. It does not:

- `authorization` exempts it explicitly — `if (!unprotectedPrefix.some(...) && pathname !== '/')` (`src/hooks.server.ts:83`)
- `src/routes/+page.server.ts` has no guard and loads `getPublicStats()`

Anything written against that guardrail could assume `locals.user` is set on `/` — while the same bullet correctly says `locals.user` is `null` when unauthenticated. The file contradicted itself, and `skills/drive-app` already documented the truth ("a landing page … renders at `/` for logged-out visitors").

Also corrected in the same bullet: `sequence(...)` lists three handlers, not two (`instanceHead` was missing), and the legal-consent gate (#399) is now documented — it redirects on nearly every logged-in request and appeared nowhere.

## `a11y-reviewer` was told to do things its tool grant forbids

Its `tools:` is `Read, Grep, Glob, Bash` — an allowlist with **no MCP tools**. It was nonetheless instructed to run `lighthouse_audit` (Chrome DevTools MCP) and to consult Context7 (also MCP). Neither could ever run. It now judges from code, reads `node_modules/flowbite-svelte/dist/` for component a11y guarantees, and recommends a measured pass be delegated to `allerleih-tester`.

## `allerleih-tester`'s read-only was prose only

The four reviewer roles are read-only *by permission*. The tester was described as read-only while running with the full tool set, `Edit`/`Write` included — the one agent where "make the tests green" is the tempting shortcut.

An allowlist is not a workable fix here: its browser-MCP tool names depend on how the server is registered (`mcp__plugin_playwright_playwright__…` via plugin vs `mcp__playwright__…` directly), so a hardcoded list would silently disable the browser step for anyone with a different setup. Enforced by **post-condition** instead: `review-and-test` and `issue-to-pr` snapshot `git status --porcelain` before spawning the tester, compare afterwards, and treat any change to tracked files as a failed run.

## Browser tooling is no longer prescribed

Playwright MCP and Chrome DevTools MCP were named inconsistently across four documents. Neither is "the" tool — the choice belongs to whoever runs the session, so the docs now say to use what the session has and to report which. The browser pass is additionally **gated**: skip it when the affected e2e specs already cover the flow, and record a skipped step as skipped rather than letting it read as passed.

## Smaller corrections

- `review-all` sent GitHub PR reviews to the built-in `/review`, which the project rules forbid; it now points at this repo's own pipelines.
- `drive-app` carried a CachyOS-specific `sudo ln -sf` into `/opt` and "this machine's gotchas" — a one-distro recipe is a footgun in a shared skill. Replaced with the general resolution order.
- `drive-app` was missing from the skill index that calls itself "the human index of what exists".
- `refresh-skills` audited only `SKILL.md` files — which is precisely where nothing had rotted. Widened to agents + `CLAUDE.md`, with mechanical path/index checks and the rule to verify against `origin/main`: this audit initially produced a false finding because the checkout sat 9 commits behind main, making a file that exists on main look deleted.

## Verification

- All 238 backtick-quoted path citations across the tooling resolve; the remaining non-resolving strings are code samples (`${__hooks}/…`), brace shorthand (`{mail,unsubscribe}.js`) and two files that are genuinely still only planned.
- Skill index matches `ls .claude/skills/` exactly; all six agent symlinks match their documented pattern.
- Every claim re-checked against `origin/main` rather than the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)