### PR TITLE
fix(social): drop ui-avatars.com, render local avatars (#651)

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -134,7 +134,9 @@ no markup or component changes:
 
 1. Add a `[data-theme='<operator>']` block in `src/app.css` next to the `@theme` block,
    overriding the `--color-*` tokens the operator wants changed (at minimum the shades
-   the design system uses: base + `200`/`400`/`600` of `primary`, plus `accent` if used).
+   the design system uses: base + `200`/`400`/`600` of `primary`, plus `accent` if used,
+   plus `700`/`800` of `primary`/`accent` — `InitialsAvatar.svelte` pairs those shades for
+   contrast, so leaving them un-overridden can drop a pair below the 4.5:1 AA floor).
 2. Set `data-theme="<operator>"` on `<html>` in `src/app.html` (or dynamically on a
    wrapper element).
 

--- a/src/app.css
+++ b/src/app.css
@@ -66,7 +66,8 @@
    tokens here. Tailwind v4 utilities like bg-primary-200 read var(--color-primary-200)
    at runtime, so a [data-theme] block on a DOM ancestor re-skins the whole app —
    including $lib/components/ui/Button.svelte — with no markup changes. Override at
-   least the shades the design system uses (base + 200/400/600 for buttons/links).
+   least the shades the design system uses (base + 200/400/600 for buttons/links, plus
+   700/800 of primary/accent — InitialsAvatar.svelte pairs those for contrast).
    See docs/design-system.md → "White-Labeling". */
 [data-theme='example'] {
 	--color-primary: #4da2ff;

--- a/src/lib/components/InitialsAvatar.svelte
+++ b/src/lib/components/InitialsAvatar.svelte
@@ -1,8 +1,37 @@
+<script module lang="ts">
+	// Fixed bg/text token-class pairs, each >= 4.5:1 (WCAG AA) in light and dark mode.
+	// Full class strings, not `bg-${colour}-200` — Tailwind can't see concatenated names
+	// and would purge them. A `[data-theme]` override should re-check the contrast.
+	const COLOR_PALETTE = [
+		'bg-tinte-200 dark:bg-tinte-700 text-tinte-600 dark:text-tinte-300',
+		'bg-primary-200 dark:bg-primary-700 text-primary-800 dark:text-primary-200',
+		'bg-secondary-200 dark:bg-secondary-800 text-secondary-800 dark:text-secondary-200',
+		'bg-accent-200 dark:bg-accent-700 text-accent-800 dark:text-accent-200',
+	];
+
+	// Pure string hash — no Math.random/Date, so SSR and CSR agree. The final mixing step
+	// matters: `% 4` reads only the low bits, and 31 ≡ -1 (mod 4) would pile short
+	// lowercase usernames onto one or two colours without it.
+	function hashString(value: string): number {
+		let hash = 0;
+		for (let i = 0; i < value.length; i++) {
+			hash = (Math.imul(hash, 31) + value.charCodeAt(i)) | 0;
+		}
+		hash ^= hash >>> 16;
+		hash = Math.imul(hash, 0x7feb352d);
+		hash ^= hash >>> 15;
+		return hash >>> 0;
+	}
+</script>
+
 <script lang="ts">
 	/**
 	 * Local, privacy-preserving fallback avatar for users without a `profileImage` —
 	 * renders their initials instead of calling a third-party avatar service (which
-	 * would otherwise leak the username to that service).
+	 * would otherwise leak the username to that service). The background/text colour
+	 * pair is picked deterministically from `name` (a small pure string hash into a
+	 * fixed palette of theme-token classes), so a given user always gets the same
+	 * colour instead of a new random one on every page load.
 	 */
 	let { name, class: cls = '' }: { name: string; class?: string } = $props();
 
@@ -14,10 +43,12 @@
 			.map((part) => part[0]?.toUpperCase() ?? '')
 			.join('') || '?'
 	);
+
+	const colorClasses = $derived(COLOR_PALETTE[hashString(name) % COLOR_PALETTE.length]);
 </script>
 
 <div
-	class="flex items-center justify-center bg-tinte-200 dark:bg-tinte-700 text-tinte-600 dark:text-tinte-300 font-semibold select-none {cls}"
+	class="flex items-center justify-center font-semibold select-none {colorClasses} {cls}"
 	role="img"
 	aria-label={name}
 >

--- a/src/lib/components/InitialsAvatar.test.ts
+++ b/src/lib/components/InitialsAvatar.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'svelte/server';
+import InitialsAvatar from './InitialsAvatar.svelte';
+
+function renderAvatar(props: { name: string } & Record<string, unknown>) {
+	return render(InitialsAvatar, { props }).body;
+}
+
+describe('InitialsAvatar', () => {
+	it('renders up to two uppercased initials from the name', () => {
+		expect(renderAvatar({ name: 'Alice Example' })).toContain('>AE<');
+		expect(renderAvatar({ name: 'bob' })).toContain('>B<');
+	});
+
+	it('exposes an accessible label and role', () => {
+		const html = renderAvatar({ name: 'Alice Example' });
+		expect(html).toContain('role="img"');
+		expect(html).toContain('aria-label="Alice Example"');
+	});
+
+	it('forwards the class prop alongside the palette classes', () => {
+		const html = renderAvatar({ name: 'Erin', class: 'h-9 w-9 rounded-full' });
+		expect(html).toContain('h-9 w-9 rounded-full');
+	});
+
+	it('gives a name a stable colour, and spreads names across the palette', () => {
+		expect(renderAvatar({ name: 'Carol' })).toBe(renderAvatar({ name: 'Carol' }));
+
+		// Guards the hash's distribution, not just its stability: `% 4` reads only the low
+		// bits, so an unmixed hash would pile these onto one or two colours.
+		const names = ['anna', 'max', 'lena', 'paul', 'mia', 'finn', 'emma', 'noah', 'lea', 'ben'];
+		const backgrounds = new Set(names.map((name) => renderAvatar({ name }).match(/\bbg-\S+/)?.[0]));
+		expect(backgrounds.size).toBeGreaterThanOrEqual(3);
+	});
+});

--- a/src/routes/social/+page.server.ts
+++ b/src/routes/social/+page.server.ts
@@ -24,7 +24,10 @@ export async function load({ locals, url }) {
 	// Build the bidirectional trust network from the join: edges where I am the
 	// truster ("I trust them") and edges where I am the trustee ("they trust me").
 	// Deleted (anonymized) counterparts are skipped so they never surface here.
-	const network = new Map<string, { username: string; iTrustThem: boolean; theyTrustMe: boolean }>();
+	const network = new Map<
+		string,
+		{ username: string; profileImage: string | null; iTrustThem: boolean; theyTrustMe: boolean }
+	>();
 	try {
 		const [trustees, trusters] = await Promise.all([
 			getTrustees(locals.pb, locals.user.id),
@@ -33,14 +36,25 @@ export async function load({ locals, url }) {
 		for (const t of trustees) {
 			const u = t.expand?.trustee;
 			if (!u || u.deleted) continue;
-			network.set(u.id, { username: u.username, iTrustThem: true, theyTrustMe: false });
+			network.set(u.id, {
+				username: u.username,
+				profileImage: u.profileImage ?? null,
+				iTrustThem: true,
+				theyTrustMe: false,
+			});
 		}
 		for (const t of trusters) {
 			const u = t.expand?.truster;
 			if (!u || u.deleted) continue;
 			const existing = network.get(u.id);
 			if (existing) existing.theyTrustMe = true;
-			else network.set(u.id, { username: u.username, iTrustThem: false, theyTrustMe: true });
+			else
+				network.set(u.id, {
+					username: u.username,
+					profileImage: u.profileImage ?? null,
+					iTrustThem: false,
+					theyTrustMe: true,
+				});
 		}
 	} catch (error: Error | any) {
 		console.error(error.message ? error.message : error);
@@ -49,7 +63,7 @@ export async function load({ locals, url }) {
 	const trustNetwork = [...network].map(([id, v]) => ({
 		id,
 		username: v.username,
-		profilePic: `https://ui-avatars.com/api/?name=${v.username}&background=random`,
+		profileImage: v.profileImage,
 		iTrustThem: v.iTrustThem,
 		theyTrustMe: v.theyTrustMe,
 	}));

--- a/src/routes/social/TrustNetworkTable.svelte
+++ b/src/routes/social/TrustNetworkTable.svelte
@@ -9,9 +9,11 @@
 		TableBodyCell
 	} from 'flowbite-svelte';
 	import Button from '$lib/components/ui/Button.svelte';
+	import InitialsAvatar from '$lib/components/InitialsAvatar.svelte';
 	import { ArrowUpDownOutline, ArrowUpOutline, ArrowDownOutline, CheckCircleOutline } from 'flowbite-svelte-icons';
 	import { resolve } from '$app/paths';
 	import { texts } from '$lib/texts.js';
+	import { PUBLIC_PB_URL } from '$env/static/public';
 
 	/**
 	 * The sortable, paginated trust-network table of /social (rows post to the page's
@@ -22,7 +24,7 @@
 		trustNetwork: {
 			id: string;
 			username: string;
-			profilePic: string;
+			profileImage: string | null;
 			iTrustThem: boolean;
 			theyTrustMe: boolean;
 		}[];
@@ -122,11 +124,17 @@
 							href={resolve('/users/[id]', { id: entry.id })}
 							class="flex flex-row items-center font-medium text-tinte-900 dark:text-white hover:underline"
 						>
-							<img
-								src={entry.profilePic}
-								alt="@{entry.username}"
-								class="h-9 w-9 mr-4 shrink-0 rounded-full object-cover hidden sm:block"
-							/>
+							<span class="hidden sm:block mr-4 shrink-0" aria-hidden="true">
+								{#if entry.profileImage}
+									<img
+										src="{PUBLIC_PB_URL}api/files/users/{entry.id}/{entry.profileImage}"
+										alt="@{entry.username}"
+										class="h-9 w-9 rounded-full object-cover"
+									/>
+								{:else}
+									<InitialsAvatar name={entry.username} class="h-9 w-9 rounded-full text-sm" />
+								{/if}
+							</span>
 							{entry.username}
 						</a>
 					</TableBodyCell>

--- a/src/routes/social/page.server.test.ts
+++ b/src/routes/social/page.server.test.ts
@@ -54,8 +54,8 @@ function callLoad(pb: unknown) {
 describe('social load — bidirectional trust network', () => {
 	it('merges mutual + one-directional edges and excludes deleted counterparts', async () => {
 		const trustees = [
-			{ trustee: 'A', expand: { trustee: { id: 'A', username: 'Alice', deleted: false } } }, // mutual (below)
-			{ trustee: 'B', expand: { trustee: { id: 'B', username: 'Bob' } } }, // I trust B only
+			{ trustee: 'A', expand: { trustee: { id: 'A', username: 'Alice', deleted: false, profileImage: 'alice.png' } } }, // mutual (below)
+			{ trustee: 'B', expand: { trustee: { id: 'B', username: 'Bob' } } }, // I trust B only, no profileImage
 			{ trustee: 'D', expand: { trustee: { id: 'D', username: 'deleted-D', deleted: true } } }, // deleted → skip
 		];
 		const trusters = [
@@ -66,11 +66,27 @@ describe('social load — bidirectional trust network', () => {
 		const data = await callLoad(makePb(trustees, trusters));
 		const byId = Object.fromEntries(data.trustNetwork.map((n) => [n.id, n]));
 
-		expect(byId['A']).toMatchObject({ username: 'Alice', iTrustThem: true, theyTrustMe: true });
-		expect(byId['B']).toMatchObject({ iTrustThem: true, theyTrustMe: false });
-		expect(byId['C']).toMatchObject({ iTrustThem: false, theyTrustMe: true });
+		expect(byId['A']).toMatchObject({
+			username: 'Alice',
+			profileImage: 'alice.png',
+			iTrustThem: true,
+			theyTrustMe: true,
+		});
+		expect(byId['B']).toMatchObject({ iTrustThem: true, theyTrustMe: false, profileImage: null });
+		expect(byId['C']).toMatchObject({ iTrustThem: false, theyTrustMe: true, profileImage: null });
 		expect(byId['D']).toBeUndefined(); // anonymized counterpart must not surface
 		expect(data.trustNetwork).toHaveLength(3);
+	});
+
+	it('builds no avatar URL server-side — only the raw profileImage filename', async () => {
+		const trustees = [
+			{ trustee: 'A', expand: { trustee: { id: 'A', username: 'Alice', profileImage: 'alice.png' } } },
+		];
+		const data = await callLoad(makePb(trustees, []));
+
+		expect(data.trustNetwork).toHaveLength(1);
+		expect(data.trustNetwork[0]).not.toHaveProperty('profilePic');
+		expect(JSON.stringify(data.trustNetwork)).not.toContain('http');
 	});
 
 	it('returns an empty network when there are no edges', async () => {


### PR DESCRIPTION
Closes #651

## What & why

`/social` was the **last** route calling the third-party avatar service `ui-avatars.com`. The URL was built server-side and rendered into the page, so every visitor's browser requested it directly — handing `ui-avatars.com` the visitor's IP, timestamp and user agent **plus another user's username** in the `name` query param. On this route those usernames are the members of the visitor's trust network, so the third party could observe a social graph.

The privacy statement (§15a) only ever described IP, timestamp and browser identifier being transmitted, and framed the purpose as "default image for users without their own profile picture" — neither matched what actually happened, since the URL was built unconditionally.

Fixing the code was the cleaner path than amending the statement: `InitialsAvatar.svelte` already existed (added in #585, which listed this route under "Out of scope — same privacy pattern, different route") and has no external dependency.

## Changes

- **`src/routes/social/+page.server.ts`** — no avatar URL is constructed server-side any more. The load passes the raw `profileImage` filename through; the component decides what to render. The explicit projection is preserved, so no additional base-`users` field reaches the client (the #438 hardening still holds).
- **`src/routes/social/TrustNetworkTable.svelte`** — renders the user's uploaded image from our own PocketBase origin, or `InitialsAvatar` as fallback. Matches the conversations route. The responsive/spacing classes moved to a wrapper `<span>` so they don't collide with `InitialsAvatar`'s own `flex` base class.
- **`src/lib/components/InitialsAvatar.svelte`** — deterministic background colour derived from the name, replacing `background=random` (which gave a user a *different* colour on every page load). Palette and hash hoisted into `<script module>`.
- **a11y** — `aria-hidden` on the avatar wrapper: the link already renders the username as text, so the `img alt` / `aria-label` were a duplicate accessible name (WCAG H2).
- **`src/app.css` + `docs/design-system.md`** — white-label themes must now also override `700`/`800` of `primary`/`accent`, which the palette pairs for contrast.

### On the colour hash

The mixing step before the modulo is load-bearing, not decoration: `% 4` reads only the low two bits, and `31 ≡ -1 (mod 4)`, which collapses the bucket to an alternating sum of character codes. Measured over 30 realistic lowercase usernames the four palette entries got **14 / 3 / 4 / 9** — one colour on ~47% of users. With the finalizer: **7 / 7 / 9 / 7** (24.4 / 23.6 / 25.8 / 26.2 % over a 450-name set). A test guards the spread, not just determinism.

## Test notes

Preflight all green: `npm run lint`, `npm run check` (0 errors, 8 pre-existing warnings), `npx vitest run` (79 files / 854 tests), `npm run build`. `grep -r "ui-avatars" src/` returns no matches.

Reviewed by the four project reviewer roles — security/data-protection and conventions came back clean; the a11y and code-quality findings (duplicate accessible name, theme-override contrast, hash distribution) are fixed in this branch.

**Please verify in the browser:** open `/social` with the network tab on a cold reload and confirm there is **no request to any host other than the app's own origin**. That is the actual point of the issue and the one thing the unit tests can't assert. Worth also toggling dark mode (initials stay legible on all four colours) and checking a user *with* an uploaded profile picture.

## Follow-up — not covered by this PR

§15a and the UI Avatars row in the recipients table (§16) of the Datenschutzerklärung can be deleted once this merges. The statement lives in the `legal_documents` PocketBase collection and **does not update with a deploy** — it needs a separate edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
