### PR TITLE
Split instance-specific FAQ prose out of texts.ts

### DIFF
--- a/docs/text-management.md
+++ b/docs/text-management.md
@@ -69,9 +69,41 @@ return fail(400, {
 
 ## Adding New Text
 
+0. First decide **where** the string belongs — generic UI copy vs. instance-specific content —
+   per the rule in "Instance-specific content vs. generic UI strings" below. Most strings are
+   generic UI copy and go straight into `texts.ts`; only genuinely instance-specific prose goes
+   into `instance-content.ts`.
 1. Add your text to the appropriate category in `src/lib/texts.ts`
 2. Use it in your component or server file via the import above
 3. Keep texts organized by functional area; use function signatures for dynamic values
+
+## Instance-specific content vs. generic UI strings
+
+Two modules feed instance-related copy into `texts.ts`, and they're not interchangeable:
+
+- **`src/lib/instance.ts`** — instance-*derived* scalars/URLs (city, origin, contact/feedback
+  email, social links, analytics config). These are values a template interpolates; the wording
+  around them stays identical across instances.
+- **`src/lib/instance-content.ts`** — instance-*specific* prose. Content whose actual wording
+  (not just a variable inside it) would need to change if AllerLeih relaunched in a different
+  city with a different team.
+
+**Boundary rule:** would this string's wording need to change (not just a variable substituted
+into it) if AllerLeih relaunched in a different city with a different team?
+- Yes → `instance-content.ts`.
+- No, it only needs `CITY`/`APP_NAME`/an email substituted into an otherwise-identical template →
+  stays in `texts.ts`, parameterized from `$lib/instance.ts` as today.
+
+**Concrete example:** the FAQ founder-bio answer (`texts.pages.guide.faqItems[0].a`, "Wer seid
+ihr?") is biographical — it names the founders and says they studied in Lüneburg. That's true
+regardless of which city currently runs the instance, so it's *not* `CITY`-interpolated; it lives
+verbatim in `instanceContent.faq.whoWeAre` (`src/lib/instance-content.ts`) and `texts.ts` just
+references it.
+
+**Guardrail:** like `$lib/instance`, never import `$lib/instance-content` from
+`src/service-worker.ts`.
+
+See `instance-content.ts`'s own top-of-file doc comment for the full rationale.
 
 ## Categories
 
@@ -89,7 +121,7 @@ return fail(400, {
 | `buttons` | Button labels |
 | `ui` | General UI elements; many entries are functions `(value: T) => string` for dynamic values |
 | `itemStatus` | Item availability status display labels |
-| `pages` | Large per-page text objects, keyed by route name |
+| `pages` | Large per-page text objects, keyed by route name. Exception: `pages.guide.faqItems[0].a` ("Wer seid ihr?") is sourced from `instanceContent.faq.whoWeAre` in `src/lib/instance-content.ts` — see "Instance-specific content vs. generic UI strings" below |
 | `bulkUpload` | AI bulk photo upload workflow texts (institution import flow) |
 | `onboarding` | 10-step post-registration onboarding wizard texts |
 | `notifications` | Notification inbox text; also contains the push notification title |

--- a/src/lib/instance-content.test.ts
+++ b/src/lib/instance-content.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Hermetic default env, same rationale as instance.test.ts: `instance-content.ts` has no
+// `$env/dynamic/public` import today, but mocking it anyway pins the "no env-driven content"
+// claim below without depending on that staying true only by accident.
+vi.mock('$env/dynamic/public', () => ({ env: {} }));
+
+import { instanceContent } from './instance-content';
+
+describe('instanceContent — defaults (static, not env-driven)', () => {
+	it('has a non-empty FAQ founder-bio answer', () => {
+		expect(typeof instanceContent.faq.whoWeAre).toBe('string');
+		expect(instanceContent.faq.whoWeAre.length).toBeGreaterThan(0);
+	});
+
+	it('pins the current default founder-bio content (Lüneburg, deliberately not CITY-interpolated)', () => {
+		expect(instanceContent.faq.whoWeAre).toContain('Lüneburg');
+	});
+
+	it('does not change based on env vars — this is static content, not a template', async () => {
+		vi.resetModules();
+		vi.doMock('$env/dynamic/public', () => ({
+			env: { PUBLIC_INSTANCE_CITY: 'Marburg', PUBLIC_APP_NAME: 'AndersLeih' },
+		}));
+		const { instanceContent: overridden } = await import('./instance-content');
+		expect(overridden.faq.whoWeAre).toBe(instanceContent.faq.whoWeAre);
+		expect(overridden.faq.whoWeAre).toContain('Lüneburg');
+		vi.doUnmock('$env/dynamic/public');
+	});
+});

--- a/src/lib/instance-content.ts
+++ b/src/lib/instance-content.ts
@@ -1,0 +1,26 @@
+/**
+ * Instanzspezifischer Erzähl-Content (Issue #474): Gegenstück zu `$lib/instance.ts`, aber für
+ * *Prosa* statt für ableitbare Konfigurationswerte (Stadt, Origin, E-Mail, …). `instance.ts`
+ * hält Werte, die in ein ansonsten identisches deutsches Textbaustein-Template interpoliert
+ * werden (siehe `texts.ts`); dieses Modul hält Strings, deren WORTLAUT selbst instanzspezifisch
+ * ist und sich mit keiner Variable ersetzen lässt.
+ *
+ * Abgrenzungsregel: Müsste sich dieser Text (nicht nur eine Variable darin) ändern, wenn
+ * AllerLeih in einer anderen Stadt mit einem anderen Team neu gestartet würde? Wenn ja → hierher.
+ * Wenn nur CITY/APP_NAME/eine E-Mail-Adresse in ein ansonsten identisches Template eingesetzt
+ * werden muss → bleibt in `texts.ts`, parametrisiert aus `$lib/instance.ts`.
+ *
+ * Wie bei `$lib/instance`: NIE aus `src/service-worker.ts` importieren (auch wenn dieses Modul
+ * aktuell keinen `$env/dynamic/public`-Import hat — die Grenze gilt für den ganzen
+ * Instanzkonfigurations-/Content-Bereich, damit sie nicht bei der nächsten Erweiterung reißt).
+ */
+
+export const instanceContent = {
+	faq: {
+		// Gründer-Biografie: Betreiber-Inhalt, bewusst NICHT instanzabhängig — die beiden
+		// Gründer haben tatsächlich in Lüneburg studiert; das bliebe wahr für jede Instanz,
+		// eine Interpolation von CITY würde den Satz für eine andere Stadt verfälschen.
+		whoWeAre:
+			'Derzeit sind wir ein Duo: Timo und Matteo! Wir haben beide in Lüneburg studiert und wollen mit AllerLeih einen Beitrag zum Gemeinwohl leisten. Wir sind der Auffassung, dass das Teilen und Leihen in vielerlei Hinsicht eine bessere Alternative zum Kaufen ist. Und wir wollen, dass die Infrastruktur dafür nicht nur einfach und zugänglich ist, sondern auch nachhaltig für alle funktioniert. Deswegen entwickeln wir AllerLeih als gemeinnützige Organisation und Open-Source-Software. So verhindern wir die Kommerzialisierung und manipulative Algorithmen.',
+	},
+};

--- a/src/lib/texts.ts
+++ b/src/lib/texts.ts
@@ -1,5 +1,6 @@
 import { USERNAME_MIN_LENGTH, USERNAME_MAX_LENGTH } from '$lib/utils/username';
 import { instance } from '$lib/instance';
+import { instanceContent } from '$lib/instance-content';
 
 /** App name — referenced in interpolated strings below (object literals can't self-reference via `this`). */
 const APP_NAME = instance.appName;
@@ -8,6 +9,10 @@ const APP_NAME = instance.appName;
 // constant here (mainContactMail, feedbackMail) so the "user-facing strings live in texts.ts"
 // rule holds even though the value originates in `$lib/instance.ts`; a `mailto:` href (not
 // itself visible text) may still read straight from `instance` at the call site, like URLs do.
+// `instanceContent` (from `$lib/instance-content`) is the counterpart for instance-specific
+// PROSE whose wording itself (not just a variable) would change for a different instance — see
+// that module's doc comment for the full boundary rule. Used directly at the value site below
+// (e.g. `faqItems[0].a`), not hoisted to a const like the scalars above.
 const CITY = instance.city;
 const CONTACT_MAIL = instance.contactEmail;
 const FEEDBACK_MAIL = instance.feedbackEmail;
@@ -538,10 +543,9 @@ export const texts = {
 			faqItems: [
 				{
 					q: 'Wer seid ihr?',
-					// Gründer-Biografie: Betreiber-Inhalt, bewusst NICHT instanzabhängig — die beiden
-					// Gründer haben tatsächlich in Lüneburg studiert; das bliebe wahr für jede Instanz,
-					// eine Interpolation von CITY würde den Satz für eine andere Stadt verfälschen.
-					a: 'Derzeit sind wir ein Duo: Timo und Matteo! Wir haben beide in Lüneburg studiert und wollen mit AllerLeih einen Beitrag zum Gemeinwohl leisten. Wir sind der Auffassung, dass das Teilen und Leihen in vielerlei Hinsicht eine bessere Alternative zum Kaufen ist. Und wir wollen, dass die Infrastruktur dafür nicht nur einfach und zugänglich ist, sondern auch nachhaltig für alle funktioniert. Deswegen entwickeln wir AllerLeih als gemeinnützige Organisation und Open-Source-Software. So verhindern wir die Kommerzialisierung und manipulative Algorithmen.',
+					// Text + Begründung, warum er nicht CITY-interpoliert wird, lebt in
+					// `instance-content.ts` (`instanceContent.faq.whoWeAre`).
+					a: instanceContent.faq.whoWeAre,
 				},
 				{
 					q: 'Was passiert, wenn etwas kaputt geht?',


### PR DESCRIPTION
## What

Adds `src/lib/instance-content.ts` as the home for instance-*specific narrative content* — as opposed to `src/lib/instance.ts`, which holds instance-*derived config values* (city, origin, contact email, social links). Moves the FAQ founder-bio answer ("Wer seid ihr?") there, since its wording (not just a variable) is inherently about this instance's team and would need to change on a relaunch in another city — it's deliberately not `CITY`-interpolated.

`docs/text-management.md` gets a new section documenting the boundary rule between the two modules, plus a pointer at the top of "Adding New Text" so a contributor picks the right module before writing a new string.

## Why

Closes #474. Investigation before implementing showed most of the issue's originally-described problem was already solved by prior work on #473 (`instance.ts` now centralizes `mainContactMail`, `pages.city`, etc.) and other changes since the issue was filed (`NavBarComponent.svelte`'s beta banner and `misc/imprint/+page.svelte`'s address already source entirely from `texts.ts`, no inline strings). The one remaining real gap — genuine instance-specific prose still hardcoded inside the otherwise-generic `texts.ts` — was the FAQ founder bio, which this PR isolates.

Deliberately out of scope (per the issue's own open questions): DB-backed legal/imprint content, further decomposition of `texts.ts` into multiple per-domain files, and deduplication of `texts.ts`.

## Test notes

- `npm run lint` — clean
- `npm run check` — 0 errors, 8 pre-existing warnings in unrelated files
- `npx vitest run` — 852/852 passing (including new `src/lib/instance-content.test.ts`, which pins the default content and confirms it's static — not env/city-templated)
- `npm run build` — succeeds
- Manual check: `/misc/guide` FAQ "Wer seid ihr?" renders the unchanged founder-bio text

🤖 Generated with [Claude Code](https://claude.com/claude-code)