### PR TITLE
Read all app config at runtime via $env/dynamic/* so one build artifact serves any instance

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -54,22 +54,30 @@ PB_SUPERUSER_EMAIL=you@example.com PB_SUPERUSER_PASSWORD=secret npm run seed -- 
 
 ## Environment variables
 
-Required in `.env` (see `docs/architecture.md` for what each does; template: `.env.example`):
-`PUBLIC_PB_URL`, `PUBLIC_VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`, `ORS_API_KEY`,
-`MISTRAL_API_KEY` (prod only), `PB_SUPERUSER_EMAIL`, `PB_SUPERUSER_PASSWORD`. The superuser
-credentials are read at runtime by `$lib/server/superuser.ts` (`getSuperuserClient`), which backs
-the superuser-only `metrics_daily` reads in `$lib/server/metrics.ts`; local tooling (seed scripts,
-Playwright e2e) reads the same two vars via `process.env`. `SYNC_SECRET` is **gone** as of #487
-Phase 3 — the integrations run entirely in the backend, so the frontend holds no sync secret and
-no `/api/sync`/`/api/refresh` endpoints.
+**All app env is read at runtime via `$env/dynamic/*`** (issue #627) — `$env/static/*` is banned
+repo-wide (ESLint), so one build artefact serves any instance and nothing is baked in. The
+**required** set lives in `$lib/server/env.ts` (`REQUIRED_PUBLIC_ENV` + `REQUIRED_PRIVATE_ENV`)
+and is validated by the `init` hook in `src/hooks.server.ts`: a missing **or empty** value makes
+the server refuse to start, naming every offender. Required (template: `.env.example`; see
+`docs/architecture.md` for what each does): `PUBLIC_PB_URL`, `PUBLIC_VAPID_PUBLIC_KEY`,
+`VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`, `ORS_API_KEY`, `PB_SUPERUSER_EMAIL`,
+`PB_SUPERUSER_PASSWORD`. `MISTRAL_API_KEY` is the **only optional** var (unset ⇒
+`/api/analyze-item` answers 503). `SYNC_SECRET` is **gone** as of #487 Phase 3 — the integrations
+run entirely in the backend, so the frontend holds no sync secret and no `/api/sync`/`/api/refresh`
+endpoints.
+The two public plumbing vars are read only through `$lib/publicEnv.ts` (`pbUrl()` /
+`vapidPublicKey()`) — functions, never module-scope constants, so nothing is snapshotted at import
+time. The superuser credentials are read at runtime by `$lib/server/superuser.ts`
+(`getSuperuserClient`), which backs `isAdmin()` + the `metrics_daily` reads in
+`$lib/server/metrics.ts` — that makes them a **per-request app dependency**, not just tooling;
+local tooling (seed scripts, Playwright e2e) reads the same two vars via `process.env`.
 Instance configuration (multi-city, all optional — see `docs/architecture.md` → "Instance
 configuration"): `PUBLIC_SITE_ORIGIN`, `PUBLIC_INSTANCE_CITY`, `PUBLIC_APP_NAME`,
-`PUBLIC_CONTACT_EMAIL`, `PUBLIC_ANALYTICS_ORIGIN`, `PUBLIC_ANALYTICS_WEBSITE_ID`. These are the
-only vars read via `$lib/instance.ts` (the sole `$env/dynamic/public` user in the repo — every
-other env access is `$env/static/*`). Unlike `$env/static/public`, `$env/dynamic/public`
-serialises the **whole** `PUBLIC_*` env into every rendered page, not just the vars a module
-references — treat any new `PUBLIC_*` var as fully public the moment it's set, whether or not
-`$lib/instance.ts` reads it (see `docs/architecture.md` → "Instance configuration").
+`PUBLIC_CONTACT_EMAIL`, `PUBLIC_ANALYTICS_ORIGIN`, `PUBLIC_ANALYTICS_WEBSITE_ID` — read via
+`$lib/instance.ts`. `$env/dynamic/public` serialises the **whole** `PUBLIC_*` env into every
+rendered page, not just the vars a module references — treat any `PUBLIC_*` var as fully public
+the moment it's set, whether or not any module reads it (see `docs/architecture.md` → "Instance
+configuration").
 For personal local overrides (local ports, sandbox creds) that shouldn't be shared with the team,
 use a gitignored `CLAUDE.local.md` at the repo root — it loads alongside this file.
 
@@ -81,6 +89,15 @@ These prevent the most common bugs/security issues here — follow them without 
   `let x = data.x` detaches `use:enhance` reactivity — and a *user-editable* field seeded from
   `data.x`/a prop needs a seed-once `$state` + `bind:value`, never one-way `value=`, or hydration
   clobbers it (issue #558). → `docs/best-practices.md`
+- **Never `$env/static/*`** — env is read at **runtime** so one build artefact serves any
+  instance (issue #627); a static import bakes an instance's value into the bundle. ESLint bans
+  both static modules. Public vars go through `$lib/publicEnv.ts` (`pbUrl()`/`vapidPublicKey()`)
+  or `$lib/instance.ts`; private vars `import { env } from '$env/dynamic/private'` at module scope
+  as usual — what must never happen is **reading** `env.X` at module scope, i.e. into a
+  module-level `const` or by passing it to something at import time (as the old
+  `webpush.setVapidDetails` call did). `vite build` imports every server module with an empty env,
+  so an import-time read sees `undefined`; read inside the function that needs the value. New
+  required vars go into `$lib/server/env.ts`, which the `init` hook validates at startup.
 - **Always build PocketBase filters with `pb.filter(raw, {params})`** — never template-literal
   interpolation. Applies to *every* value, including IDs from `locals.user.id` / route params
   (filter injection). Use `locals.pb.filter(...)` in routes, `pb.filter(...)` in `$lib/server/*`.

--- a/.claude/skills/new-route/SKILL.md
+++ b/.claude/skills/new-route/SKILL.md
@@ -29,14 +29,14 @@ unrelated route subtrees → `src/lib/components` (design-system primitives go i
 
 ```ts
 import type { PageServerLoad } from './$types';
-import { PUBLIC_PB_URL } from '$env/static/public';
+import { pbUrl } from '$lib/publicEnv';
 
 export const load: PageServerLoad = async ({ locals }) => {
   const items = await locals.pb.collection('items').getFullList({
     filter: locals.pb.filter('owner = {:ownerId}', { ownerId: locals.user.id }),
     sort: '-updated',
   });
-  return { items, PB_URL: PUBLIC_PB_URL };
+  return { items, PB_URL: pbUrl() };
 };
 ```
 
@@ -52,7 +52,9 @@ Guardrails (these prevent the bugs we actually hit):
   *relationship* itself (e.g. "does the owner trust the viewer"), use `$lib/server/trust.ts`
   (`isTrusting` / `getTrustees` / `getTrusters`) — never re-implement trust filtering client-side.
 - `locals.pb` is the server client; `locals.user` is the auth record (null if unauthenticated).
-- Pass `PUBLIC_PB_URL` (from `$env/static/public`) down as `PB_URL` so the client can build file URLs.
+- Pass `pbUrl()` (from `$lib/publicEnv`) down as `PB_URL` so the client can build file URLs. Never
+  import `$env/static/*` — env is read at runtime so one artefact serves any instance (#627), and
+  ESLint rejects the static modules.
 
 ## 2. `actions` — mutations
 

--- a/.env.example
+++ b/.env.example
@@ -1,25 +1,48 @@
-# AllerLeih environment template — copy to .env and fill in real values.
+# AllerLeih environment template — copy to .env; the placeholders below are enough to boot.
 # See docs/architecture.md (overview).
+#
+# EVERY var here is read at RUNTIME via `$env/dynamic/*` (issue #627) — nothing is baked into
+# the build, so one `npm run build` artefact serves any instance and only this file differs.
+# The app REFUSES TO START if one of the seven required vars below is missing OR EMPTY: the
+# `init` server hook calls `assertRequiredEnv()` (see src/lib/server/env.ts), which prints
+# every missing name with its purpose and exits non-zero. An empty value is NOT "unset but
+# fine" — it is a startup failure. `MISTRAL_API_KEY` is the only optional var.
+# The check is presence-only: it proves a non-empty line exists, NOT that the value works. A
+# placeholder like the ORS_API_KEY below satisfies it and still leaves that feature broken.
+#
+# Heads-up on `PUBLIC_*`: SvelteKit serialises the WHOLE `PUBLIC_*` environment into every
+# rendered page (not just the vars a module reads), so treat any `PUBLIC_*` value you set here
+# as fully public — never put a secret behind that prefix.
 
-# PocketBase instance the app talks to (see allerleih-backend repo)
-PUBLIC_PB_URL=http://localhost:8090
+# PocketBase instance the app talks to (see allerleih-backend repo).
+# A trailing slash is added if you omit it — file URLs are built as `${pbUrl()}api/files/…`.
+PUBLIC_PB_URL=http://localhost:8090/
 
-# Web Push (VAPID) — generate a key pair with: npx web-push generate-vapid-keys
-PUBLIC_VAPID_PUBLIC_KEY=
-VAPID_PRIVATE_KEY=
+# Web Push (VAPID) — generate your own key pair with: npx web-push generate-vapid-keys
+# The pair below is the throwaway CI keypair (already public in .github/workflows/e2e.yaml):
+# well-formed, so the app starts, but never use it for a real deployment.
+PUBLIC_VAPID_PUBLIC_KEY=BOFZzlLgQ1kjzoCIyyPuVu-BKj4UYV1kpx6Rkl827Kqg5V27QOLsJnJqbNjdGCb1g4QvOEnb8Bi7oV12HiEMdWQ
+VAPID_PRIVATE_KEY=Fz1mNiBa1Nk3mpy8KjzIjqKf8R0ff9ZHqw525Vy_d-4
 VAPID_SUBJECT=mailto:you@example.com
 
 # OpenRouteService — geocoding + travel times (https://openrouteservice.org)
-ORS_API_KEY=
+# Required (the app won't start without it), but a wrong value only degrades /api/geocode to
+# empty suggestions. Travel times additionally need the BACKEND's own ORS_API_KEY.
+ORS_API_KEY=replace-me-or-geocoding-stays-empty
 
-# Mistral AI — item photo analysis (prod only; optional in dev)
+# Mistral AI — item photo analysis (/api/analyze-item). The ONLY optional var:
+# unset ⇒ that endpoint answers 503 and nothing else changes.
 MISTRAL_API_KEY=
 
-# PocketBase superuser — used ONLY by local tooling (seed scripts + Playwright e2e, read via
-# process.env; see scripts/seed/ and e2e/README.md). The app runtime no longer uses these:
-# as of #487 Phase 3 the integration sync/refresh + the CSV-import write path run in the backend.
-PB_SUPERUSER_EMAIL=
-PB_SUPERUSER_PASSWORD=
+# PocketBase superuser — read by the APP AT RUNTIME (`$lib/server/superuser.ts` →
+# `$lib/server/metrics.ts` → the root `+layout.server.ts`'s `isAdmin()` call on every
+# authenticated request, plus the public stats on `/` and `/misc/stats`) AND by local tooling
+# via process.env (seed scripts + Playwright e2e; see scripts/seed/ and e2e/README.md).
+# The values below match the superuser `scripts/dev-stack.sh` upserts on the local backend.
+# LOOPBACK ONLY — this pair grants full database access; change it before exposing this
+# PocketBase on any non-localhost address.
+PB_SUPERUSER_EMAIL=admin@local.test
+PB_SUPERUSER_PASSWORD=localdev12345
 
 # Optional dev-server settings (see vite.config.ts)
 # DEV_ALLOWED_HOST=

--- a/.github/workflows/deploy-to-uberspace.yaml
+++ b/.github/workflows/deploy-to-uberspace.yaml
@@ -16,21 +16,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # No `env:` here on purpose — since #627 every app var is read at runtime via
+      # `$env/dynamic/*`, so a build-step value would silently do nothing (it would not even
+      # reach the artefact). Runtime vars go into the `.env` written in the SSH step below.
       - name: Build Svelte app
         run: npm run build
-        env:
-          PUBLIC_PB_URL: ${{ secrets.PUBLIC_PB_URL }}
-          ORS_API_KEY: ${{ secrets.ORS_API_KEY }}
-          PUBLIC_VAPID_PUBLIC_KEY: ${{ secrets.PUBLIC_VAPID_PUBLIC_KEY }}
-          VAPID_PRIVATE_KEY: ${{ secrets.VAPID_PRIVATE_KEY }}
-          VAPID_SUBJECT: ${{ secrets.VAPID_SUBJECT }}
-          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
-          # PB_SUPERUSER_*: still required at build time — `$lib/server/superuser.ts` reads them
-          # via `$env/static/private` for the superuser-only `metrics_daily` reads in
-          # `$lib/server/metrics.ts`. No SYNC_SECRET: #487 Phase 3 moved the integrations into
-          # the backend, so the frontend shares no sync secret anymore.
-          PB_SUPERUSER_EMAIL: ${{ secrets.PB_SUPERUSER_EMAIL }}
-          PB_SUPERUSER_PASSWORD: ${{ secrets.PB_SUPERUSER_PASSWORD }}
       - name: Deploy build folder
         uses: burnett01/rsync-deployments@8.0.2
         with:
@@ -46,29 +36,96 @@ jobs:
         # interpolated into `script:` as `${{ … }}`. Textual interpolation would break on a
         # value containing a quote or `;` and is a shell-injection shape even when the input
         # is repo-admin-controlled.
+        #
+        # Each forwarded variable is named EXACTLY like its `.env` target, so there is no
+        # translation layer to get out of step: adding one means one `env:` line, one `envs:`
+        # entry and one `echo` line in the `{ … } > .env` block below. A forgotten `envs:` entry
+        # is visible by diffing the two lists; a forgotten `echo` line is the dangerous one — the
+        # var stays forwarded but is never written, and `assertRequiredEnv()` then refuses to boot.
+        # `envs:` is a comma-separated list, kept flat and space-free — see the note on it below.
         env:
-          ANALYTICS_ORIGIN: ${{ vars.PUBLIC_ANALYTICS_ORIGIN }}
-          ANALYTICS_WEBSITE_ID: ${{ vars.PUBLIC_ANALYTICS_WEBSITE_ID }}
+          PUBLIC_PB_URL: ${{ secrets.PUBLIC_PB_URL }}
+          PUBLIC_VAPID_PUBLIC_KEY: ${{ secrets.PUBLIC_VAPID_PUBLIC_KEY }}
+          VAPID_PRIVATE_KEY: ${{ secrets.VAPID_PRIVATE_KEY }}
+          VAPID_SUBJECT: ${{ secrets.VAPID_SUBJECT }}
+          ORS_API_KEY: ${{ secrets.ORS_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          PB_SUPERUSER_EMAIL: ${{ secrets.PB_SUPERUSER_EMAIL }}
+          PB_SUPERUSER_PASSWORD: ${{ secrets.PB_SUPERUSER_PASSWORD }}
+          PUBLIC_ANALYTICS_ORIGIN: ${{ vars.PUBLIC_ANALYTICS_ORIGIN }}
+          PUBLIC_ANALYTICS_WEBSITE_ID: ${{ vars.PUBLIC_ANALYTICS_WEBSITE_ID }}
+          PUBLIC_SITE_ORIGIN: ${{ vars.PUBLIC_SITE_ORIGIN }}
+          PUBLIC_INSTANCE_CITY: ${{ vars.PUBLIC_INSTANCE_CITY }}
         with:
           host: ${{ vars.SSH_HOST }}
           username: ${{ vars.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          envs: ANALYTICS_ORIGIN,ANALYTICS_WEBSITE_ID
+          # Deliberately one line, no spaces: `origin/main` has always used the space-free form, so
+          # per-element trimming by the action is unproven in this pipeline. If it did not trim, 11 of
+          # 12 names would be looked up with a leading space, silently resolve to empty, and
+          # `assertRequiredEnv()` would refuse to boot the freshly deployed site. Keep it flat.
+          envs: PUBLIC_PB_URL,PUBLIC_VAPID_PUBLIC_KEY,VAPID_PRIVATE_KEY,VAPID_SUBJECT,ORS_API_KEY,MISTRAL_API_KEY,PB_SUPERUSER_EMAIL,PB_SUPERUSER_PASSWORD,PUBLIC_ANALYTICS_ORIGIN,PUBLIC_ANALYTICS_WEBSITE_ID,PUBLIC_SITE_ORIGIN,PUBLIC_INSTANCE_CITY
           script: |
+            # `set -e` so a failing `npm ci` fails the deploy instead of reporting success with a
+            # half-updated server; `set -u` to catch a typo'd variable name. Because of `set -u`,
+            # EVERY forwarded var is referenced as `${VAR:-}`: appleboy/ssh-action may not export
+            # a variable whose repo Secret/Variable does not exist, and an unset reference would
+            # abort the whole deploy.
+            set -eu
+            # `.env` carries the PocketBase superuser password, the VAPID private key and two API
+            # keys, and Uberspace is shared hosting: with the login's default umask (0644) every
+            # other account on the host could read full-database credentials. Set before anything
+            # is written, so it also covers the conditional appends below. `rsync … --delete` has
+            # already removed the server-side `.env`, so the file is always created fresh here and
+            # really does get the umask (a `>` onto an existing file would keep its old mode).
+            umask 077
             cd share-mvp
-            npm ci
             # Runtime environment for the `svelte` service. `~/etc/services.d/share-mvp.ini`
             # starts it as `node -r dotenv/config build`, so this file — and only this file —
-            # is what reaches `process.env`. The service has no `environment=` line, and the
-            # `>` truncates, so every runtime var must be listed here: anything added to
-            # `.env` by hand on the server is discarded on the next deploy.
+            # is what reaches `process.env`. The service has no `environment=` line, the `>`
+            # below truncates, and the preceding `rsync … --delete` removes a server-side `.env`
+            # that isn't in the CI workspace: nothing hand-added on the server survives a deploy.
             #
-            # Build-time vars (`$env/static/*`) belong in the build step above instead; they
-            # are baked into the artefact. These are the `$env/dynamic/public` ones read by
-            # `src/lib/instance.ts` at server start, so the build step cannot supply them.
+            # Written BEFORE `npm ci` on purpose. `rsync --delete` has already deleted the old
+            # `.env`, so with the write after `npm ci` a failing install would abort via `set -e`
+            # and leave the server with NO `.env` at all: the running process survives (dotenv
+            # loaded it at start), but the next restart or reboot hits `assertRequiredEnv()` and
+            # the site is hard-down with no file left to recover from.
+            #
+            # Since #627 EVERY app var is runtime (`$env/dynamic/*`) — there is no such thing as
+            # a build-time var any more, so anything omitted here is simply absent at runtime.
+            # The app now REFUSES TO START when one of the seven required vars is missing or
+            # empty, so a forgotten line shows up as a FATAL `svelte` service in the supervisord
+            # log (with the missing names printed), not as a half-working site. The exception is
+            # `BODY_SIZE_LIMIT`: an adapter-node var the app validator cannot see, so only this
+            # comment and review protect it.
+            #
+            # Secrets are single-quoted because `dotenv` strips an inline ` # comment` from an
+            # UNQUOTED value — a password containing ` #` would be silently truncated. Quoting is
+            # what dotenv reads as "take it literally". Consequence: a secret value must contain
+            # NO single quote and NO newline. The two `PUBLIC_ANALYTICS_*` values are known-safe
+            # and stay unquoted, as before.
             {
               echo "BODY_SIZE_LIMIT=10485760"
-              echo "PUBLIC_ANALYTICS_ORIGIN=${ANALYTICS_ORIGIN}"
-              echo "PUBLIC_ANALYTICS_WEBSITE_ID=${ANALYTICS_WEBSITE_ID}"
+              echo "PUBLIC_PB_URL='${PUBLIC_PB_URL:-}'"
+              echo "PUBLIC_VAPID_PUBLIC_KEY='${PUBLIC_VAPID_PUBLIC_KEY:-}'"
+              echo "VAPID_PRIVATE_KEY='${VAPID_PRIVATE_KEY:-}'"
+              echo "VAPID_SUBJECT='${VAPID_SUBJECT:-}'"
+              echo "ORS_API_KEY='${ORS_API_KEY:-}'"
+              echo "MISTRAL_API_KEY='${MISTRAL_API_KEY:-}'"
+              echo "PB_SUPERUSER_EMAIL='${PB_SUPERUSER_EMAIL:-}'"
+              echo "PB_SUPERUSER_PASSWORD='${PB_SUPERUSER_PASSWORD:-}'"
+              echo "PUBLIC_ANALYTICS_ORIGIN=${PUBLIC_ANALYTICS_ORIGIN:-}"
+              echo "PUBLIC_ANALYTICS_WEBSITE_ID=${PUBLIC_ANALYTICS_WEBSITE_ID:-}"
             } > .env
+            # Appended only when non-empty: an explicit empty line would OVERRIDE the code
+            # defaults in `src/lib/instance.ts` with "", whereas an absent line lets them apply.
+            # This is what makes the two repo Variables optional rather than mandatory.
+            if [ -n "${PUBLIC_SITE_ORIGIN:-}" ]; then
+              echo "PUBLIC_SITE_ORIGIN='${PUBLIC_SITE_ORIGIN}'" >> .env
+            fi
+            if [ -n "${PUBLIC_INSTANCE_CITY:-}" ]; then
+              echo "PUBLIC_INSTANCE_CITY='${PUBLIC_INSTANCE_CITY}'" >> .env
+            fi
+            npm ci
             supervisorctl restart svelte

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -106,9 +106,12 @@ jobs:
           PB_SUPERUSER_EMAIL: ci@example.com
           PB_SUPERUSER_PASSWORD: ci-e2e-password-only
           # playwright.config.ts's webServer only sets PUBLIC_PB_URL/DEV_DISABLE_MKCERT itself —
-          # everything else the dev server reads via $env/static/* (e.g. web-push's VAPID setup
-          # in $lib/server/notifications.ts) must already be in this step's env, since Playwright
-          # spawns the dev server inheriting process.env. vitest.yaml carries its own copy of
+          # everything else the dev server reads via `$env/dynamic/*` must already be in this
+          # step's env, since Playwright spawns the dev server inheriting process.env. Since
+          # #627 these are required at DEV-SERVER START, not at build time: the `init` hook runs
+          # `assertRequiredEnv()` in `vite dev` too, so a missing var makes every request 500 —
+          # Playwright's `webServer` readiness probe then times out and the whole run fails
+          # loudly, rather than specs failing one by one. vitest.yaml carries its own copy of
           # these dummy values; the two are independent and nothing keeps them in sync, so treat
           # a change here as a prompt to check that file too rather than assuming it matches.
           PUBLIC_VAPID_PUBLIC_KEY: BOFZzlLgQ1kjzoCIyyPuVu-BKj4UYV1kpx6Rkl827Kqg5V27QOLsJnJqbNjdGCb1g4QvOEnb8Bi7oV12HiEMdWQ

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,20 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     # Skip on fork PRs (mirrors the Vitest workflow); still runs on manual dispatch.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    # `svelte-kit sync` generates the `$env/static/*` type declarations from the environment,
-    # so `npm run check` fails on missing members without these. Dummy values are fine — only
-    # the presence of the members matters for type-checking, not the values.
-    env:
-      PUBLIC_PB_URL: http://127.0.0.1:8090
-      PUBLIC_VAPID_PUBLIC_KEY: dummy
-      VAPID_PRIVATE_KEY: dummy
-      VAPID_SUBJECT: mailto:ci@example.com
-      ORS_API_KEY: dummy
-      MISTRAL_API_KEY: dummy
-      # Read by `$lib/server/superuser.ts` for the superuser-only `metrics_daily` reads.
-      # (SYNC_SECRET is gone with #487 Phase 3 — the integrations moved into the backend.)
-      PB_SUPERUSER_EMAIL: ci@example.com
-      PB_SUPERUSER_PASSWORD: dummy
+    # No `env:` block on purpose (issue #627): every app var is read at runtime via
+    # `$env/dynamic/*`, so `svelte-kit sync` generates index-signature types
+    # (`string | undefined`) instead of per-var members. `npm run check` therefore passes with a
+    # COMPLETELY EMPTY env only if the code is genuinely undefined-safe — that is the point of
+    # the check. Re-adding dummy values here would make CI type-check the *looser* variant while
+    # a contributor with a filled `.env` type-checks the stricter one, i.e. CI weaker than local.
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/vitest.yaml
+++ b/.github/workflows/vitest.yaml
@@ -1,25 +1,14 @@
 name: Vitest on PR
 env:
   node_version: '25.2.1'
-  # Shared by the build and test jobs below (step-level `env` inherits from here and may
-  # override). Every var read via $env/static/* must exist at build time or the build fails
-  # with "Missing export", even if nothing calls the code path that uses it. Tests aren't
-  # bundled, but code under test still reads these via $env/static/*, and Vite normally
-  # resolves them from a local .env (absent in CI) — so both jobs need them. SYNC_SECRET is
-  # gone with #487 Phase 3 (the integrations moved into the backend); the rest below (VAPID
-  # push, ORS geocoding, Mistral item-photo analysis, PB_SUPERUSER_* for metrics_daily) are
-  # never exercised for real here, so dummy values are fine — see .env.example for the
-  # canonical list of required vars. VAPID keys must still be well-formed (web-push validates
-  # key length on import), so this is a throwaway keypair, not an arbitrary string.
-  # PUBLIC_PB_URL is deliberately NOT here: it differs per job, and keeping it at step level
-  # avoids needing the `secrets` context at workflow level.
-  PB_SUPERUSER_EMAIL: ci@example.com
-  PB_SUPERUSER_PASSWORD: dummy
-  PUBLIC_VAPID_PUBLIC_KEY: BOFZzlLgQ1kjzoCIyyPuVu-BKj4UYV1kpx6Rkl827Kqg5V27QOLsJnJqbNjdGCb1g4QvOEnb8Bi7oV12HiEMdWQ
-  VAPID_PRIVATE_KEY: Fz1mNiBa1Nk3mpy8KjzIjqKf8R0ff9ZHqw525Vy_d-4
-  VAPID_SUBJECT: mailto:ci@example.com
-  ORS_API_KEY: dummy
-  MISTRAL_API_KEY: dummy
+  # Deliberately no app env vars here (issue #627). Every var is read at RUNTIME via
+  # `$env/dynamic/*`, so `npm run build` must succeed with a COMPLETELY EMPTY env — that is
+  # exactly what the Build job below now verifies. Tests mock `$env/dynamic/*` per file
+  # (`vi.mock('$env/dynamic/public', () => ({ env: { … } }))`), which is the only mechanism that
+  # works under Vitest anyway: Vite bakes the dynamic-env module at transform time, so neither
+  # `process.env` nor `vi.stubEnv` reaches it. Nothing here to keep in sync with `.env.example`
+  # any more; `e2e.yaml` still needs its own block because it boots a real dev server, where
+  # the `init` hook's `assertRequiredEnv()` refuses to start on a missing var.
 on:
   pull_request:
     branches:
@@ -43,13 +32,11 @@ jobs:
           cache-dependency-path: package-lock.json
       - name: Install dependencies
         run: npm ci
+      # No `env:` here on purpose — this step IS the acceptance test for issue #627: the build
+      # must produce a generic, instance-agnostic artefact from a completely empty environment.
+      # Adding any var back would silently retire that guarantee.
       - name: Build
         run: npm run build
-        env:
-          # Pre-existing and left as-is: `npm run build` inlines $env/static/public into the
-          # bundle, so this job takes the real origin from a repo secret. Everything else this
-          # step needs comes from the workflow-level `env` block above.
-          PUBLIC_PB_URL: ${{ secrets.PUBLIC_PB_URL }}
   test:
     # This matrix tests both the main and pull request branches
     name: Test ${{ matrix.artifact }}
@@ -78,14 +65,10 @@ jobs:
         run: npm ci
       # Run tests with coverage with summary in json format
       - name: Run tests with coverage
+        # No `env:` here either: since #627 every test that needs `PUBLIC_PB_URL` mocks
+        # `$env/dynamic/public` itself (the only mechanism Vitest honours), including
+        # src/routes/user/groups/[id]/page.server.test.ts, which used to read this injected value.
         run: npx vitest run --coverage.enabled --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=lcov
-        env:
-          # A literal loopback URL, not the production secret: the only test that reads this
-          # unmocked (src/routes/user/groups/[id]/page.server.test.ts) just asserts the value is
-          # truthy, a secret would be masked in the logs anyway, and the production origin has no
-          # business in a unit-test run. Matches lint.yaml. Everything else comes from the
-          # workflow-level `env` block above.
-          PUBLIC_PB_URL: http://127.0.0.1:8090
       - name: Copy thresholds config (if exists)
         run: |
           if [ -f vitest.thresholds.js ]; then

--- a/README.md
+++ b/README.md
@@ -62,19 +62,27 @@ npm ci
 cp .env.example .env
 ```
 
-**Every variable in `.env.example` must exist in your `.env`, even if the value is empty.** The app imports them via SvelteKit's `$env/static/private` and `$env/static/public`, which fail the build with `Missing export "X"` when a member is absent — an empty value is fine, a missing line is not. (CI does the same thing with dummy values; see `.github/workflows/lint.yaml`.)
+**Copy `.env.example` and keep its placeholders — the file is filled in so a fresh clone boots.**
+Every variable is read at **runtime** via SvelteKit's `$env/dynamic/*`, not baked into the build,
+so one build artefact serves any instance. The flip side: the server **refuses to start** when a
+required variable is missing **or empty** — it prints every offending name with what it is for and
+exits non-zero (`assertRequiredEnv()` in `src/lib/server/env.ts`, called from the `init` hook). An
+empty value is *not* "unset but fine". The old `Missing export "X"` build failure no longer exists.
+`MISTRAL_API_KEY` is the only variable you may leave empty. The check is presence-only, though: it
+guarantees a non-empty line exists, **not** that the value is valid — `ORS_API_KEY=replace-me-…`
+satisfies it and still yields empty address suggestions.
 
 | Variable                                                     | Needed for                                                               | How to get it                                                                                                                           |
 | ------------------------------------------------------------ | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `PUBLIC_PB_URL`                                              | Everything — the PocketBase instance the app talks to                    | Your local backend, e.g. `http://127.0.0.1:8090/`. **Keep the trailing slash** — image URLs are built as `${PUBLIC_PB_URL}api/files/…`. |
+| `PUBLIC_PB_URL`                                              | Everything — the PocketBase instance the app talks to                    | Your local backend, e.g. `http://127.0.0.1:8090/`. A trailing slash is added if you omit it — image URLs are built as `${pbUrl()}api/files/…`. |
 | `PUBLIC_VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY`              | Web push notifications                                                   | Ask kontakt@allerleih.org for the shared dev pair, or generate a throwaway one with `npx web-push generate-vapid-keys`.                 |
 | `VAPID_SUBJECT`                                              | Web push                                                                 | A `mailto:` URI, e.g. `mailto:you@example.com`.                                                                                         |
 | `ORS_API_KEY`                                                | Address autocomplete (`/api/geocode`)                                    | Request from kontakt@allerleih.org. Travel times additionally need the **backend's** own `ORS_API_KEY`.                                 |
-| `MISTRAL_API_KEY`                                            | AI item-photo analysis (`/api/analyze-item`)                             | Request from kontakt@allerleih.org. Safe to leave empty in dev — only that one feature stops working.                                   |
-| `SYNC_SECRET`, `PB_SUPERUSER_EMAIL`, `PB_SUPERUSER_PASSWORD` | Partner-catalogue sync (`/api/sync`, `/api/refresh`) and the seed runner | The superuser is one you create on your own local backend (step 4). `SYNC_SECRET` must match the backend's; any string works locally.   |
+| `MISTRAL_API_KEY`                                            | AI item-photo analysis (`/api/analyze-item`)                              | Request from kontakt@allerleih.org. **The only optional variable** — unset ⇒ that endpoint answers 503 and nothing else changes.        |
+| `PB_SUPERUSER_EMAIL`, `PB_SUPERUSER_PASSWORD`                | The app at runtime (the `/admin` gate via `isAdmin()`, the public stats on `/` and `/misc/stats`, `metrics_daily`) **and** the seed runner + Playwright e2e | A superuser you create on your own local backend (step 4). `scripts/dev-stack.sh` upserts the pair from `.env.example`. (`SYNC_SECRET` is gone — #487 Phase 3 moved the integrations into the backend.) |
 | `DEV_ALLOWED_HOST`, `DEV_DISABLE_MKCERT`                     | Optional dev-server tweaks (see `vite.config.ts`)                        | Set `DEV_DISABLE_MKCERT=true` when mkcert can't install its CA (no sudo) or TLS is terminated upstream.                                 |
 
-Credentials for the real external services are **not** in the repo. Ask kontakt@allerleih.org for shared development credentials; until you have them, leave the values empty — the dependent feature won't work, but the rest of the app runs fine.
+Credentials for the real external services are **not** in the repo. Ask kontakt@allerleih.org for shared development credentials; until you have them, keep the `.env.example` placeholders for the required variables — the dependent feature won't work, but the app starts and the rest runs fine. Do **not** blank a required variable out: an empty value stops the server from starting at all.
 
 ### 4. Start the stack
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,22 +135,29 @@ client recomputes a right-looking value after hydration (issue #473, caught only
 reading the raw SSR response — see `e2e/tests/seo-canonical.spec.ts`). `instanceUrl()` logs a
 DEV-only console error if given a non-root-absolute path, to make a repeat loud instead of silent.
 
-**This is the only place in the frontend that uses `$env/dynamic/public`** — every other env
-access in the repo goes through `$env/static/*` (build-time replaced). The exception is
-deliberate: one build artefact must serve N city instances, and `adapter-node` reads environment
-variables from `process.env` at **server start** (runtime), not at build time — `$env/static/public`
-would bake a single instance's values into the build, requiring one build per city.
-`$lib/instance.ts` (and therefore `$lib/texts.ts`) must never be imported from
-`src/service-worker.ts` — `$env/dynamic/public` is a hard error there (no request context).
+**`$env/dynamic/*` is the repo-wide convention** (issue #627): every env access — public and
+private — is read at **runtime**, and `$env/static/*` is banned by ESLint. The reason is the one
+this file already gave for `instance.ts`: one build artefact must serve N city instances, and
+`adapter-node` reads environment variables from `process.env` at **server start**, not at build
+time; `$env/static/*` would bake a single instance's values into the bundle, requiring one build
+per city. What differs is only the *scope* of each module: `$lib/instance.ts` is the source for
+**instance/branding** values (city, origin, contact, analytics), `$lib/publicEnv.ts` for the two
+public **plumbing** vars (`pbUrl()` → `PUBLIC_PB_URL`, `vapidPublicKey()` →
+`PUBLIC_VAPID_PUBLIC_KEY`), and each private var is read with `{ env } from
+'$env/dynamic/private'` in the single module that needs it. Which vars must exist at startup is
+declared in `$lib/server/env.ts` and enforced by the `init` server hook (see "Runtime env vars"
+below). `$lib/instance.ts`, `$lib/publicEnv.ts` — and therefore `$lib/texts.ts` — must never be
+imported from `src/service-worker.ts`: `$env/dynamic/public` is a hard error there (no request
+context), which `eslint.config.js` now enforces for that file.
 
-**Consequence for every future `PUBLIC_*` var:** `$env/static/public` only ships the `PUBLIC_*`
-constants a module actually references (build-time, tree-shaken), but `$env/dynamic/public`
-serialises the **entire** `PUBLIC_*` env into every rendered page (SvelteKit ships the whole
-dynamic-public object to the client so it can hydrate) — and since `$lib/instance.ts` is
-transitively imported by `$lib/texts.ts`, which reaches the client bundle, that whole-object
-broadcast now applies repo-wide, not just to the six vars above. Harmless today because only
-already-public vars exist, but treat any new `PUBLIC_*` var as fully public from the moment it is
-set in the server env — it is shipped to every visitor whether or not any module reads it.
+**Consequence for every `PUBLIC_*` var:** `$env/dynamic/public` serialises the **entire**
+`PUBLIC_*` env into every rendered page (SvelteKit ships the whole dynamic-public object to the
+client so it can hydrate) — unlike the tree-shaken `$env/static/public` this repo no longer uses.
+Since `$lib/instance.ts` and `$lib/publicEnv.ts` are both transitively reachable from the client
+bundle, that whole-object broadcast applies repo-wide. Harmless today because only already-public
+vars exist, but treat any new `PUBLIC_*` var as fully public from the moment it is set in the
+server env — it is shipped to every visitor whether or not any module reads it. Never put a secret
+behind the `PUBLIC_` prefix.
 
 **Branding is only partially instance-configurable.** `PUBLIC_APP_NAME` overrides `texts.names.app`
 (used in `<title>`s, meta tags, a handful of UI strings), but it does **not** rewrite the ~89
@@ -168,27 +175,51 @@ separate, unrelated mechanisms:
 stops Umami tracking rather than falling back to a default. Production therefore has to supply
 `PUBLIC_ANALYTICS_ORIGIN=https://analytics.allerleih.org` and
 `PUBLIC_ANALYTICS_WEBSITE_ID=6cfb6acd-259e-4771-baa7-c677387ea292` in its **runtime** environment —
-see "Current Deployment Pipeline" below for where that has to live and which two traps to avoid.
+see "Current Deployment Pipeline" below for where that has to live and which three traps to avoid.
 
 ## Current Deployment Pipeline for "AllerLeih" (proof-of-concept instance)
 
 - **Platform:** Uberspace shared hosting (Linux, Node.js, supervisord)
 - **Deploy trigger:** push to `main` → GitHub Actions (`.github/workflows/deploy-to-uberspace.yaml`) → `npm ci && npm run build` → `rsync` to Uberspace
 - **Process restart:** `supervisorctl restart svelte`
-- **Build-time secrets injected:** `PUBLIC_PB_URL`, `ORS_API_KEY`, `MISTRAL_API_KEY`, VAPID keys (`PUBLIC_VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`); a tracked `.env.example` lists all required vars. (Integration sync/refresh + the CSV write path run entirely in the backend as of #487 Phase 3 — no frontend sync secret. `PB_SUPERUSER_*` are used only by local seed/e2e tooling, not the app runtime.)
+- **Build-time secrets injected: none.** As of issue #627 the build takes **no** environment at
+  all — `npm run build` produces a generic, instance-agnostic artefact, and a value passed to the
+  build step would silently do nothing. All seven required vars are **runtime** vars, written by
+  the deploy's SSH step into a `.env` next to `build/`: `PUBLIC_PB_URL`,
+  `PUBLIC_VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`, `ORS_API_KEY`,
+  `PB_SUPERUSER_EMAIL`, `PB_SUPERUSER_PASSWORD` (plus the optional `MISTRAL_API_KEY`, the
+  optional `PUBLIC_*` instance vars, and the adapter's `BODY_SIZE_LIMIT`). That `.env` is written
+  with a truncating `>`, so **every** runtime var must be listed in the workflow — anything
+  hand-added on the server is discarded on the next deploy. The contract is enforced in-app: the
+  `init` hook in `src/hooks.server.ts` calls `assertRequiredEnv()` (`$lib/server/env.ts`) before
+  the server listens, so a missing or empty required var makes the process exit non-zero with
+  every offender named, instead of leaving a half-working site up. The check is presence-only — it
+  proves a non-empty line exists, not that the value is usable (a placeholder `ORS_API_KEY`
+  satisfies it). `logOptionalEnvGaps()` then prints one `console.info` line naming the vars from
+  `OPTIONAL_ENV` this instance runs without and what that disables (names only, never values), so a
+  quietly-off feature shows up in the startup log instead of surfacing later as a 503.
+  (Integration sync/refresh + the CSV write path run entirely in the backend as of #487 Phase 3 —
+  no frontend sync secret.
+  `PB_SUPERUSER_*` are **not** tooling-only: `$lib/server/superuser.ts` → `$lib/server/metrics.ts`
+  → the root `+layout.server.ts`'s `isAdmin()` call reads them on every authenticated request, and
+  they also back the public stats on `/` and `/misc/stats`.)
 - **Body size limit:** 10 MB, set via `BODY_SIZE_LIMIT` env var on the server after each deploy
-- **PocketBase:** runs as a separate process on Uberspace (repo `allerleih-backend`; schema + JS hooks version-controlled, migrations auto-applied on start); SQLite data and file uploads live on the server filesystem — not managed by the SvelteKit CI/CD pipeline. ⚠️ The backend now requires **`ORS_API_KEY`** in **its own** environment (used by the `/api/travel-times` hook) — not only in the SvelteKit build.
-- **Instance config vars** (`PUBLIC_SITE_ORIGIN`, `PUBLIC_INSTANCE_CITY`, `PUBLIC_APP_NAME`,
-  `PUBLIC_CONTACT_EMAIL`, `PUBLIC_ANALYTICS_ORIGIN`, `PUBLIC_ANALYTICS_WEBSITE_ID`) are read via
-  `$env/dynamic/public` at **runtime** from `process.env` (adapter-node), not baked into the build
-  like the other `PUBLIC_*` vars above — so one build artefact serves every city instance and only
-  each instance's runtime environment differs. Two traps when adding one: (1) putting it in the
-  workflow's `npm run build` step has **no** effect, that only reaches `$env/static/*`; (2) the
-  deploy's SSH step runs `echo "BODY_SIZE_LIMIT=…" > .env` — with `>`, so anything hand-added to that
-  file on the server is discarded on the next deploy. Add runtime vars to that line in
-  `deploy-to-uberspace.yaml` (these six are public values, so GitHub Actions *variables*, not
-  secrets), or to the `svelte` supervisord service's own environment. See "Instance configuration"
-  above.
+- **PocketBase:** runs as a separate process on Uberspace (repo `allerleih-backend`; schema + JS hooks version-controlled, migrations auto-applied on start); SQLite data and file uploads live on the server filesystem — not managed by the SvelteKit CI/CD pipeline. ⚠️ The backend requires **`ORS_API_KEY`** in **its own** environment (used by the `/api/travel-times` hook) — a separate value from the frontend's, which lives in the SvelteKit runtime `.env`.
+- **Runtime env vars** — since #627 that is *all* of them (the seven required ones,
+  `MISTRAL_API_KEY`, and the optional instance vars `PUBLIC_SITE_ORIGIN`, `PUBLIC_INSTANCE_CITY`,
+  `PUBLIC_APP_NAME`, `PUBLIC_CONTACT_EMAIL`, `PUBLIC_ANALYTICS_ORIGIN`,
+  `PUBLIC_ANALYTICS_WEBSITE_ID`). They are read via `$env/dynamic/*` from `process.env`
+  (adapter-node) at server start, never baked into the build — so one build artefact serves every
+  city instance and only each instance's runtime environment differs. Three traps when adding one:
+  (1) putting it in the workflow's `npm run build` step has **no** effect — that is now true for
+  *every* var, not just the instance ones, and it is the single most likely mistake; (2) the
+  deploy's SSH step writes the whole `.env` with a truncating `>`, so anything hand-added to that
+  file on the server is discarded on the next deploy — add the var to that block in
+  `deploy-to-uberspace.yaml` (public instance values are GitHub Actions *variables*, secrets are
+  *secrets*); (3) the `svelte` supervisord service has no `environment=` line, so `.env` +
+  `node -r dotenv/config build` is the **only** bridge into `process.env` — which means `dotenv`
+  must stay in `dependencies` (`dotenv@^17.2.3`, `package.json`), never move it to
+  `devDependencies`. See "Instance configuration" above.
 
 **CI on pull requests:** Vitest runs with coverage (json + lcov) on every PR to `main` via `.github/workflows/vitest.yaml`. Coverage is posted as a PR comment via `davelosert/vitest-coverage-report-action`. The build step also catches TypeScript and Svelte compilation errors before merging.
 

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -101,8 +101,12 @@ keep it in sync with `computeDailyMetrics()` in `jobs/metrics.js` when the catal
 - Both read through `src/lib/server/metrics.ts` (`isAdmin`, `getLiveCoreMetrics`,
   `getMetricsHistory`, `getPublicStats`), which uses `getSuperuserClient()` from
   `src/lib/server/superuser.ts`. That helper lived in the frontend integration core until #487
-  Phase 3 tore it down; it reads `PB_SUPERUSER_*` from `$env/static/private`, so those two vars
-  must be present at **build** time (they are set in the lint/vitest/deploy workflows).
+  Phase 3 tore it down; it reads `PB_SUPERUSER_*` from `$env/dynamic/private`, so those two vars
+  must be present at **runtime** (issue #627 — nothing is baked into the build any more). They are
+  in `REQUIRED_PRIVATE_ENV` (`src/lib/server/env.ts`) and validated at server start by the `init`
+  hook, so a missing value makes the process refuse to start rather than silently closing the
+  `/admin` gate. In production they come from the `.env` the deploy's SSH step writes
+  (`.github/workflows/deploy-to-uberspace.yaml`); the lint/vitest workflows no longer set them.
 
 ## Adding a new metric
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,7 +23,8 @@ export default defineConfig(
 			// typescript-eslint strongly recommend that you do not use the no-undef lint rule on TypeScript projects.
 			// see: https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
 			'no-undef': 'off',
-			// Buttons go through the design system, not Flowbite (docs/design-system.md).
+			// Buttons go through the design system, not Flowbite (docs/design-system.md);
+			// env is read at runtime, never baked into the build (issue #627).
 			'no-restricted-imports': [
 				'error',
 				{
@@ -33,6 +34,52 @@ export default defineConfig(
 							importNames: ['Button'],
 							message:
 								'Use $lib/components/ui/Button.svelte instead (see docs/design-system.md).',
+						},
+						{
+							name: '$env/static/public',
+							message:
+								'Use $lib/publicEnv (or `$env/dynamic/public`) — static env is baked into the build, breaking one-artefact-N-instances (#627).',
+						},
+						{
+							name: '$env/static/private',
+							message:
+								'Use `$env/dynamic/private` — static env is baked into the build and would ship secrets in the artefact (#627).',
+						},
+					],
+				},
+			],
+		},
+	},
+	{
+		// A service worker has no page globals, so `$env/dynamic/public` resolves to `undefined`
+		// there and the first property read throws (issue #627). That makes every module built on
+		// it — $lib/publicEnv, $lib/instance and therefore $lib/texts — unusable in the SW. This
+		// turns the documented caveat into a lint error instead of a runtime TypeError.
+		files: ['src/service-worker.ts'],
+		rules: {
+			'no-restricted-imports': [
+				'error',
+				{
+					paths: [
+						{
+							name: '$env/dynamic/public',
+							message:
+								'A service worker has no request context — `$env/dynamic/public` is undefined there (#627).',
+						},
+						{
+							name: '$lib/publicEnv',
+							message:
+								'$lib/publicEnv reads `$env/dynamic/public`, which is undefined in a service worker (#627).',
+						},
+						{
+							name: '$lib/instance',
+							message:
+								'$lib/instance reads `$env/dynamic/public`, which is undefined in a service worker (#473/#627).',
+						},
+						{
+							name: '$lib/texts',
+							message:
+								'$lib/texts transitively imports $lib/instance → `$env/dynamic/public`, undefined in a service worker (#473/#627).',
 						},
 					],
 				},

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,13 +1,34 @@
 import PocketBase from 'pocketbase';
-import { PUBLIC_PB_URL } from '$env/static/public';
-import type { Handle } from '@sveltejs/kit';
+import { building } from '$app/environment';
+import type { Handle, ServerInit } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
 import { redirect } from '@sveltejs/kit';
 import { getOutstandingLegalDocs, isLegalLocked, type LegalUser } from '$lib/server/legal';
 import { getActiveLegalVersions } from '$lib/server/legalDocs';
 import { analyticsHeadSnippet } from '$lib/instance';
+import { pbUrl } from '$lib/publicEnv';
+import { assertRequiredEnv, logOptionalEnvGaps } from '$lib/server/env';
 
-export { PUBLIC_PB_URL };
+/**
+ * Fail fast, once, before the first request (issue #627). Since env moved from
+ * `$env/static/*` to `$env/dynamic/*`, `vite build` no longer catches a missing variable —
+ * so a misconfigured instance would otherwise 500 (or silently degrade: no admin gate, no
+ * public stats, no push) on first use. `assertRequiredEnv()` names every missing variable at
+ * once; adapter-node awaits this before `listen()`, so the throw kills the process with the
+ * full list in the supervisord log instead of leaving a half-working server up.
+ *
+ * Skipped while `building`: `vite build` analyses/prerenders with a possibly empty env, and
+ * building a generic artefact must never require an instance's configuration.
+ *
+ * `logOptionalEnvGaps()` then prints one line naming the optional vars this instance runs
+ * without (and what that disables), so a self-hoster sees a quietly-off feature in the startup
+ * log rather than discovering it as a 503. Names only — never values.
+ */
+export const init: ServerInit = () => {
+	if (building) return;
+	assertRequiredEnv();
+	logOptionalEnvGaps();
+};
 
 const unprotectedPrefix = [
 	'/auth/login',
@@ -34,7 +55,7 @@ const unprotectedPrefix = [
 const legalGateExempt = ['/legal', '/auth', '/misc', '/api/diagnostics', '/api/redirect'];
 
 export const authentication: Handle = async ({ event, resolve }) => {
-	event.locals.pb = new PocketBase(PUBLIC_PB_URL);
+	event.locals.pb = new PocketBase(pbUrl());
 
 	event.locals.pb.authStore.loadFromCookie(
 		event.request.headers.get('cookie') || ''

--- a/src/lib/client-pb.ts
+++ b/src/lib/client-pb.ts
@@ -1,5 +1,5 @@
 import PocketBase from 'pocketbase';
-import { PUBLIC_PB_URL } from '$env/static/public';
+import { pbUrl } from '$lib/publicEnv';
 
 // The resilient realtime layer (subscribeRealtime + retry/watchdog machinery,
 // issue #435) lives in $lib/realtime.ts — this module is only the shared client
@@ -28,7 +28,7 @@ let instance: PocketBase | null = null;
  */
 export function getClientPB(): PocketBase {
 	if (!instance) {
-		instance = new PocketBase(PUBLIC_PB_URL);
+		instance = new PocketBase(pbUrl());
 
 		let lastUserId: string | null = instance.authStore.record?.id ?? null;
 		instance.authStore.onChange((_token, record) => {

--- a/src/lib/instance.ts
+++ b/src/lib/instance.ts
@@ -4,12 +4,13 @@
  * Literale ("allerleih.org", "Lüneburg") in Routen und Komponenten. `texts.ts` interpoliert
  * daraus die deutschen Copy-Strings (siehe dort); Code liest URLs/E-Mails direkt von hier.
  *
- * Bewusste Ausnahme von der `$env/static/*`-Konvention des Repos: Diese Datei nutzt
- * `$env/dynamic/public`, weil ein einziges Build-Artefakt N Stadt-Instanzen bedienen soll —
- * `adapter-node` liest Umgebungsvariablen zur Laufzeit aus `process.env`, nicht zur Build-Zeit.
- * `$env/static/public` würde die Werte fest in den Build backen (ein Artefakt pro Instanz).
- * Alle anderen 12 `$env/static/*`-Imports im Repo bleiben unverändert – dies ist die einzige
- * Stelle mit `$env/dynamic/public`.
+ * `$env/dynamic/*` ist seit #627 die **repo-weite** Konvention, nicht mehr die Ausnahme dieser
+ * Datei: `$env/static/*` ist verboten (ESLint `no-restricted-imports`), weil ein einziges
+ * Build-Artefakt N Stadt-Instanzen bedienen soll — `adapter-node` liest Umgebungsvariablen zur
+ * Laufzeit aus `process.env`, nicht zur Build-Zeit. Diese Datei ist die Quelle für
+ * **Instanz-/Branding**-Werte; die zwei öffentlichen Infrastruktur-Variablen
+ * (`PUBLIC_PB_URL`, `PUBLIC_VAPID_PUBLIC_KEY`) kommen aus `$lib/publicEnv.ts`. Welche Variablen
+ * beim Start vorhanden sein MÜSSEN, steht in `$lib/server/env.ts`.
  *
  * Sicherheitshinweise für Wartende:
  * (a) Die Top-Level-Auswertung unten (Modul wird einmal beim ersten Import ausgewertet) ist
@@ -18,7 +19,8 @@
  *     dieses Modul zum ersten Mal importiert wird. Bei einem Adapter-Wechsel (weg von
  *     adapter-node) diese Annahme erneut prüfen.
  * (b) `$lib/instance` (und damit `$lib/texts`) darf NIE aus `src/service-worker.ts` importiert
- *     werden — `$env/dynamic/public` ist dort ein Hard-Error (kein Request-Kontext).
+ *     werden — `$env/dynamic/public` ist dort ein Hard-Error (kein Request-Kontext). Gilt
+ *     genauso für `$lib/publicEnv.ts`; `eslint.config.js` erzwingt das für diese Datei.
  *
  * Nie direkt `throw`en: ein Fehler hier würde die komplette App mit 500 lahmlegen. Ungültige
  * Werte fallen still auf sichere Defaults zurück (siehe `resolveOrigin`/`resolveAnalytics`).

--- a/src/lib/publicEnv.test.ts
+++ b/src/lib/publicEnv.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// Hermetic default env: mocked so a local `.env` (which may set real PUBLIC_* vars for dev)
+// can never skew what "no env vars set" means here. Same pattern as instance.test.ts.
+vi.mock('$env/dynamic/public', () => ({ env: {} }));
+
+import { pbUrl, vapidPublicKey } from './publicEnv';
+
+describe('publicEnv — unset env', () => {
+	it('falls back to an empty string instead of throwing (a throw here would 500 the app)', () => {
+		expect(pbUrl()).toBe('');
+		expect(vapidPublicKey()).toBe('');
+	});
+});
+
+describe('publicEnv — env var wiring (integration)', () => {
+	afterEach(() => {
+		vi.doUnmock('$env/dynamic/public');
+		vi.resetModules();
+	});
+
+	/**
+	 * A fresh copy of the module under `env`. Fresh per call because the module registry caches
+	 * the `$env/dynamic/public` mock, not because the getters snapshot anything.
+	 */
+	async function withPublicEnv(env: Record<string, string | undefined>) {
+		vi.resetModules();
+		vi.doMock('$env/dynamic/public', () => ({ env }));
+		return import('./publicEnv');
+	}
+
+	it('wires both PUBLIC_* vars through and adds the missing trailing slash to pbUrl()', async () => {
+		const { pbUrl: url, vapidPublicKey: key } = await withPublicEnv({
+			PUBLIC_PB_URL: 'https://pb.marburg.example.org',
+			PUBLIC_VAPID_PUBLIC_KEY: 'BOFZzlLgQ1kjzoCIyyPuVu',
+		});
+		// Consumers build file URLs as `${pbUrl()}api/files/…`, so the slash cannot be optional.
+		expect(url()).toBe('https://pb.marburg.example.org/');
+		expect(key()).toBe('BOFZzlLgQ1kjzoCIyyPuVu');
+	});
+
+	it('leaves an already-slashed PUBLIC_PB_URL untouched', async () => {
+		const { pbUrl: url } = await withPublicEnv({
+			PUBLIC_PB_URL: 'https://pb.marburg.example.org/',
+		});
+		expect(url()).toBe('https://pb.marburg.example.org/');
+	});
+
+	it('keeps an unset PUBLIC_PB_URL empty rather than normalising it to "/"', async () => {
+		const { pbUrl: url } = await withPublicEnv({});
+		expect(url()).toBe('');
+	});
+
+	it('reads at call time, so a later env change is picked up without a re-import', async () => {
+		const env: Record<string, string | undefined> = {
+			PUBLIC_PB_URL: 'http://first/',
+		};
+		const { pbUrl: url } = await withPublicEnv(env);
+		expect(url()).toBe('http://first/');
+		env.PUBLIC_PB_URL = 'http://second';
+		expect(url()).toBe('http://second/');
+	});
+});

--- a/src/lib/publicEnv.ts
+++ b/src/lib/publicEnv.ts
@@ -1,0 +1,37 @@
+/**
+ * Public runtime configuration (issue #627). Read at **call time** from
+ * `$env/dynamic/public`, so one build artefact serves any instance. SvelteKit populates the
+ * dynamic env before hooks run and before any route module is imported, so a call-time read
+ * always sees the value the running instance was started with.
+ *
+ * Client-safe: SvelteKit serialises the whole `PUBLIC_*` env into every rendered page and
+ * exposes it to the browser bundle as `globalThis.__sveltekit_<hash>.env`. Treat *every*
+ * `PUBLIC_*` var an operator sets as fully public, whether or not this module reads it.
+ *
+ * MUST NEVER be imported from `src/service-worker.ts` — same constraint as `$lib/instance.ts`
+ * and `$lib/texts.ts`: a service worker has no page globals, so `$env/dynamic/public`
+ * resolves to `undefined` there and the first property read throws. `eslint.config.js`
+ * enforces this with a `no-restricted-imports` block scoped to that file.
+ *
+ * Both getters fall back to `''` rather than throwing: an error here would 500 the whole app.
+ * `assertRequiredEnv()` in `$lib/server/env.ts` (called from the `init` server hook) is what
+ * makes an empty value impossible in a real deployment.
+ */
+import { env } from '$env/dynamic/public';
+
+/**
+ * PocketBase base URL, **normalised to a trailing slash** — the single home for that invariant.
+ * Every consumer concatenates (`` `${pbUrl()}api/files/…` ``), so a slash-less value would build
+ * `http://host:8090api/files/…` and break every image on the site; the startup validator only
+ * checks that the var is non-empty. Unset/empty stays `''` (never `'/'`).
+ */
+export function pbUrl(): string {
+	const raw = env.PUBLIC_PB_URL;
+	if (!raw) return '';
+	return raw.endsWith('/') ? raw : `${raw}/`;
+}
+
+/** Web-Push VAPID public key (URL-safe base64, 65 bytes decoded). */
+export function vapidPublicKey(): string {
+	return env.PUBLIC_VAPID_PUBLIC_KEY ?? '';
+}

--- a/src/lib/realtime.test.ts
+++ b/src/lib/realtime.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-// client-pb.ts (imported by realtime.ts) reads PUBLIC_PB_URL from here at import time.
-vi.mock('$env/static/public', () => ({ PUBLIC_PB_URL: 'http://localhost:8090' }));
+// client-pb.ts (imported by realtime.ts) reads PUBLIC_PB_URL from here via $lib/publicEnv's
+// pbUrl(), at call time. Vitest bakes $env/dynamic/* at transform time, so vi.mock is the only
+// way to control it (process.env / vi.stubEnv do not reach the module).
+vi.mock('$env/dynamic/public', () => ({ env: { PUBLIC_PB_URL: 'http://localhost:8090' } }));
 
 // A hoisted holder collects every PocketBase instance the module constructs, so
 // a test can reach the singleton created lazily by getClientPB().

--- a/src/lib/server/env.test.ts
+++ b/src/lib/server/env.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import {
+	ENV_PURPOSE,
+	OPTIONAL_ENV,
+	REQUIRED_PRIVATE_ENV,
+	REQUIRED_PUBLIC_ENV,
+	formatMissingEnvError,
+	formatOptionalEnvGaps,
+	missingRequiredEnv,
+} from './env';
+
+// No `$env` mocking anywhere in this file on purpose: both functions under test take the
+// environment reader as a parameter, so the whole startup contract (issue #627) is verifiable
+// without touching the module registry.
+
+const ALL_REQUIRED = [...REQUIRED_PUBLIC_ENV, ...REQUIRED_PRIVATE_ENV] as const;
+
+/**
+ * A reader over one plain object. Passed as *both* arguments at the call sites below, i.e. what
+ * `process.env` looks like to the validator when both stores are populated from the same `.env`.
+ */
+function readerFor(values: Record<string, string | undefined>) {
+	return (name: string) => values[name];
+}
+
+function allPresent(): Record<string, string> {
+	return Object.fromEntries(
+		ALL_REQUIRED.map((name) => [name, `value-for-${name}`])
+	);
+}
+
+describe('missingRequiredEnv', () => {
+	it('reports nothing when all seven required vars are set', () => {
+		const read = readerFor(allPresent());
+		expect(missingRequiredEnv(read, read)).toEqual([]);
+	});
+
+	it('reports every required var, in registry order, when the env is empty', () => {
+		const read = readerFor({});
+		expect(missingRequiredEnv(read, read)).toEqual([
+			'PUBLIC_PB_URL',
+			'PUBLIC_VAPID_PUBLIC_KEY',
+			'VAPID_PRIVATE_KEY',
+			'VAPID_SUBJECT',
+			'ORS_API_KEY',
+			'PB_SUPERUSER_EMAIL',
+			'PB_SUPERUSER_PASSWORD',
+		]);
+	});
+
+	it('counts an empty string as missing (strict — a set-but-blank line is a startup failure)', () => {
+		const values = { ...allPresent(), ORS_API_KEY: '' };
+		const read = readerFor(values);
+		expect(missingRequiredEnv(read, read)).toEqual(['ORS_API_KEY']);
+	});
+
+	it('counts a whitespace-only value as missing', () => {
+		const values = { ...allPresent(), VAPID_SUBJECT: '   \t ' };
+		const read = readerFor(values);
+		expect(missingRequiredEnv(read, read)).toEqual(['VAPID_SUBJECT']);
+	});
+
+	it('never reports MISTRAL_API_KEY — the one optional var', () => {
+		const values = allPresent();
+		delete values.MISTRAL_API_KEY;
+		expect(OPTIONAL_ENV).toContain('MISTRAL_API_KEY');
+		const read = readerFor(values);
+		expect(missingRequiredEnv(read, read)).toEqual([]);
+		expect(ALL_REQUIRED).not.toContain('MISTRAL_API_KEY');
+	});
+});
+
+describe('formatMissingEnvError', () => {
+	it('names every missing var together with its purpose', () => {
+		const message = formatMissingEnvError([
+			'PUBLIC_PB_URL',
+			'PB_SUPERUSER_PASSWORD',
+		]);
+		expect(message).toContain('PUBLIC_PB_URL');
+		expect(message).toContain(ENV_PURPOSE.PUBLIC_PB_URL);
+		expect(message).toContain('PB_SUPERUSER_PASSWORD');
+		expect(message).toContain(ENV_PURPOSE.PB_SUPERUSER_PASSWORD);
+	});
+
+	it('states how many vars are missing and points at .env.example', () => {
+		const message = formatMissingEnvError(ALL_REQUIRED);
+		expect(message).toContain(
+			`${ALL_REQUIRED.length} required environment variable(s)`
+		);
+		expect(message).toContain('.env.example');
+		expect(message).toContain('process.env');
+	});
+
+	it('does not name a var that is set', () => {
+		const message = formatMissingEnvError(['ORS_API_KEY']);
+		expect(message).not.toContain('PUBLIC_PB_URL');
+		expect(message).not.toContain('VAPID_SUBJECT');
+	});
+
+	// The empty list is unreachable from `assertRequiredEnv` (it only formats when something is
+	// missing), but the `Math.max(0, …)` seed is what keeps the column width from being -Infinity.
+	it('survives an empty list without an -Infinity column width', () => {
+		expect(formatMissingEnvError([])).toContain(
+			'0 required environment variable(s)'
+		);
+	});
+});
+
+describe('the registry itself', () => {
+	// A purpose line for every required var is a compile-time guarantee: `ENV_PURPOSE` is keyed
+	// by `RequiredEnvName`, so a var added to either tuple without one does not type-check.
+
+	it('reads each registry from its own store, never from the name prefix', () => {
+		const publicValues = Object.fromEntries(
+			REQUIRED_PUBLIC_ENV.map((n) => [n, 'set'])
+		);
+		const privateValues = Object.fromEntries(
+			REQUIRED_PRIVATE_ENV.map((n) => [n, 'set'])
+		);
+		const read = (values: Record<string, string>) => (name: string) =>
+			values[name];
+
+		expect(missingRequiredEnv(read(publicValues), read(privateValues))).toEqual(
+			[]
+		);
+		// Swapping the two stores makes every var look missing — which is exactly the failure
+		// mode a var listed in the wrong tuple would produce.
+		expect(missingRequiredEnv(read(privateValues), read(publicValues))).toEqual(
+			ALL_REQUIRED
+		);
+	});
+});
+
+describe('formatOptionalEnvGaps', () => {
+	it('names the unset optional var and what it disables, without printing a value', () => {
+		const line = formatOptionalEnvGaps(() => undefined);
+		expect(line).toContain('MISTRAL_API_KEY');
+		expect(line).toContain('/api/analyze-item');
+	});
+
+	it('stays silent when every optional var is set', () => {
+		expect(formatOptionalEnvGaps(() => 'a-key')).toBe('');
+		expect(formatOptionalEnvGaps(() => '   ')).not.toBe('');
+	});
+});

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -1,0 +1,140 @@
+import { env as privateEnv } from '$env/dynamic/private';
+import { env as publicEnv } from '$env/dynamic/public';
+
+/**
+ * The runtime environment contract (issue #627). Nothing is verified at `vite build` time
+ * any more — one artefact serves any instance — so this list is the only thing that still
+ * guarantees a booting server is completely configured.
+ *
+ * Keep in sync with `.env.example`, README's env table, `docs/architecture.md`
+ * ("Current Deployment Pipeline") and the `.env` block in
+ * `.github/workflows/deploy-to-uberspace.yaml`.
+ */
+export const REQUIRED_PUBLIC_ENV = [
+	'PUBLIC_PB_URL',
+	'PUBLIC_VAPID_PUBLIC_KEY',
+] as const;
+
+export const REQUIRED_PRIVATE_ENV = [
+	'VAPID_PRIVATE_KEY',
+	'VAPID_SUBJECT',
+	'ORS_API_KEY',
+	'PB_SUPERUSER_EMAIL',
+	'PB_SUPERUSER_PASSWORD',
+] as const;
+
+type PublicEnvName = (typeof REQUIRED_PUBLIC_ENV)[number];
+type PrivateEnvName = (typeof REQUIRED_PRIVATE_ENV)[number];
+
+/** Every name the startup validator knows about — the two registries above, nothing else. */
+export type RequiredEnvName = PublicEnvName | PrivateEnvName;
+
+/**
+ * What breaks without it — printed next to the name in the startup error. Keyed by
+ * `RequiredEnvName`, so adding a var to either registry without a purpose line is a compile
+ * error, not a startup message with a bare name and no explanation.
+ */
+export const ENV_PURPOSE: Record<RequiredEnvName, string> = {
+	PUBLIC_PB_URL: 'PocketBase base URL every request talks to',
+	PUBLIC_VAPID_PUBLIC_KEY:
+		'Web-Push VAPID public key (npx web-push generate-vapid-keys)',
+	VAPID_PRIVATE_KEY: 'Web-Push VAPID private key',
+	VAPID_SUBJECT: 'Web-Push VAPID subject — a mailto: or https: URL',
+	ORS_API_KEY: 'OpenRouteService key for address autocomplete (/api/geocode)',
+	PB_SUPERUSER_EMAIL:
+		'PocketBase superuser — /admin gate, public stats, metrics_daily',
+	PB_SUPERUSER_PASSWORD:
+		'PocketBase superuser — /admin gate, public stats, metrics_daily',
+};
+
+/**
+ * Optional: a missing value disables exactly one feature and must not stop the server.
+ * `MISTRAL_API_KEY` unset ⇒ `/api/analyze-item` answers 503; nothing else changes.
+ *
+ * Turning any of the seven required vars into an optional, feature-toggling one (run without
+ * push, without the admin dashboard) is a deliberate follow-up, not something to smuggle in here.
+ *
+ * **Private-only by construction.** `logOptionalEnvGaps()` reads this whole list from
+ * `$env/dynamic/private`, which never holds `PUBLIC_*` vars — so an optional `PUBLIC_*` var
+ * cannot just be appended here: it would be reported "running without" even when set. Give this
+ * list the split-registry, one-reader-per-store shape of `missingRequiredEnv()` first.
+ */
+export const OPTIONAL_ENV = ['MISTRAL_API_KEY'] as const;
+
+type OptionalEnvName = (typeof OPTIONAL_ENV)[number];
+
+/** What an unset optional var switches off — reported at startup by `logOptionalEnvGaps()`. */
+const OPTIONAL_ENV_DISABLES: Record<OptionalEnvName, string> = {
+	MISTRAL_API_KEY: 'AI item analysis, /api/analyze-item answers 503',
+};
+
+/**
+ * Pure — an empty string counts as missing. Unit-tested directly. Each registry is read through
+ * its own store: which of the two a var lives in is declared by the tuple it is listed in, never
+ * re-derived from its name (a var in the wrong list would be read from the wrong store and
+ * reported "missing" although it is set). Returns registry order: public first, then private.
+ */
+export function missingRequiredEnv(
+	readPublic: (name: PublicEnvName) => string | undefined,
+	readPrivate: (name: PrivateEnvName) => string | undefined
+): RequiredEnvName[] {
+	return [
+		...REQUIRED_PUBLIC_ENV.filter((name) => !readPublic(name)?.trim()),
+		...REQUIRED_PRIVATE_ENV.filter((name) => !readPrivate(name)?.trim()),
+	];
+}
+
+/**
+ * Pure — the operator-facing message. English on purpose: `texts.ts` is scoped to the German
+ * UI copy rendered to end users, while this line is read by a self-hoster in a supervisord /
+ * Docker log. Matches the existing precedent in `scripts/seed/lib.js` and `e2e/global-setup.ts`.
+ */
+export function formatMissingEnvError(
+	missing: readonly RequiredEnvName[]
+): string {
+	const width = Math.max(0, ...missing.map((n) => n.length));
+	const lines = missing.map((n) =>
+		`  ${n.padEnd(width)}  ${ENV_PURPOSE[n]}`.trimEnd()
+	);
+	return [
+		`AllerLeih cannot start: ${missing.length} required environment variable(s) are missing or empty.`,
+		'',
+		...lines,
+		'',
+		'These are read at runtime from process.env, not baked into the build. The production',
+		'service is started as `node -r dotenv/config build`, so one KEY=value line per variable',
+		'in a `.env` next to `build/` is what reaches process.env.',
+		'See .env.example for the full, annotated list.',
+	].join('\n');
+}
+
+/** Throws with the full list. Called from the `init` server hook in `src/hooks.server.ts`. */
+export function assertRequiredEnv(): void {
+	const missing = missingRequiredEnv(
+		(name) => publicEnv[name],
+		(name) => privateEnv[name]
+	);
+	if (missing.length > 0) throw new Error(formatMissingEnvError(missing));
+}
+
+/**
+ * Pure — one line naming the optional vars this instance runs without and what that switches off
+ * (`''` when everything is set). Values are never printed. The self-hosting audience otherwise
+ * has to diff `.env.example` to find out which feature is quietly off.
+ */
+export function formatOptionalEnvGaps(
+	read: (name: OptionalEnvName) => string | undefined
+): string {
+	const unset = OPTIONAL_ENV.filter((name) => !read(name)?.trim());
+	if (unset.length === 0) return '';
+	const disabled = unset
+		.map((n) => `${n} (${OPTIONAL_ENV_DISABLES[n]})`)
+		.join(', ');
+	return `AllerLeih: running without ${disabled}.`;
+}
+
+/** Logs the above once, at startup. Called from the `init` server hook, after the assertion. */
+export function logOptionalEnvGaps(): void {
+	const line = formatOptionalEnvGaps((name) => privateEnv[name]);
+	if (line) console.info(line);
+}

--- a/src/lib/server/notifications.test.ts
+++ b/src/lib/server/notifications.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { makeMockPb } from '$lib/test-utils/pocketbase';
+
+// The regression guard for issue #627: notifications.ts used to call
+// `webpush.setVapidDetails()` at module scope, which throws on an empty subject/key — so
+// `vite build`'s analyse pass (which imports every server node with an empty
+// `$env/dynamic/private`) could not build an env-less artefact. The VAPID setup is now lazy
+// and memoized inside `sendPushToUser`; these tests pin both halves of that.
+const { setVapidDetails, sendNotification } = vi.hoisted(() => ({
+	setVapidDetails: vi.fn(),
+	sendNotification: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('web-push', () => ({ default: { setVapidDetails, sendNotification } }));
+
+const SUBSCRIPTION = {
+	id: 's1',
+	endpoint: 'https://push.example/x',
+	p256dh: 'p',
+	auth: 'a',
+};
+
+function makePb() {
+	const getFullList = vi.fn().mockResolvedValue([SUBSCRIPTION]);
+	const deleteRecord = vi.fn().mockResolvedValue(undefined);
+	const pb = makeMockPb({
+		push_subscriptions: { getFullList, delete: deleteRecord },
+	});
+	return { pb, getFullList, deleteRecord };
+}
+
+/**
+ * Loads a fresh copy of notifications.ts under the given env. A fresh module is required per
+ * case because the "configured" and "warned once" flags are module state.
+ */
+async function loadNotifications(env: {
+	VAPID_SUBJECT?: string;
+	VAPID_PRIVATE_KEY?: string;
+	PUBLIC_VAPID_PUBLIC_KEY?: string;
+}) {
+	vi.resetModules();
+	vi.doMock('$env/dynamic/private', () => ({
+		env: {
+			VAPID_SUBJECT: env.VAPID_SUBJECT,
+			VAPID_PRIVATE_KEY: env.VAPID_PRIVATE_KEY,
+		},
+	}));
+	vi.doMock('$env/dynamic/public', () => ({
+		env: { PUBLIC_VAPID_PUBLIC_KEY: env.PUBLIC_VAPID_PUBLIC_KEY },
+	}));
+	return import('./notifications');
+}
+
+const FULL_VAPID = {
+	VAPID_SUBJECT: 'mailto:ci@example.com',
+	VAPID_PRIVATE_KEY: 'Fz1mNiBa1Nk3mpy8KjzIjqKf8R0ff9ZHqw525Vy_d-4',
+	PUBLIC_VAPID_PUBLIC_KEY: 'BOFZzlLgQ1kjzoCIyyPuVu',
+};
+
+let consoleError: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+	consoleError.mockRestore();
+	// `setVapidDetails` has no default implementation, so a test that makes it throw must not
+	// leak that into the next one (`clearAllMocks` clears calls, not implementations).
+	setVapidDetails.mockReset();
+	vi.doUnmock('$env/dynamic/private');
+	vi.doUnmock('$env/dynamic/public');
+	vi.resetModules();
+});
+
+describe('sendPushToUser — VAPID not configured', () => {
+	it('returns before touching push_subscriptions and never calls web-push', async () => {
+		const { sendPushToUser } = await loadNotifications({});
+		const { pb } = makePb();
+
+		await sendPushToUser(pb, 'u1', 'Titel', 'Body', '/conversations/c1');
+
+		expect(pb.collection).not.toHaveBeenCalled();
+		expect(setVapidDetails).not.toHaveBeenCalled();
+		expect(sendNotification).not.toHaveBeenCalled();
+	});
+
+	it('logs the misconfiguration exactly once, not per call', async () => {
+		const { sendPushToUser } = await loadNotifications({});
+		const { pb } = makePb();
+
+		await sendPushToUser(pb, 'u1', 'Titel', 'Body', '/conversations/c1');
+		await sendPushToUser(pb, 'u2', 'Titel', 'Body', '/conversations/c2');
+
+		expect(consoleError).toHaveBeenCalledTimes(1);
+		expect(String(consoleError.mock.calls[0][0])).toContain(
+			'Web Push disabled'
+		);
+	});
+
+	it('also bails out when only the public half is missing', async () => {
+		const { sendPushToUser } = await loadNotifications({
+			VAPID_SUBJECT: FULL_VAPID.VAPID_SUBJECT,
+			VAPID_PRIVATE_KEY: FULL_VAPID.VAPID_PRIVATE_KEY,
+		});
+		const { pb } = makePb();
+
+		await sendPushToUser(pb, 'u1', 'Titel', 'Body', '/conversations/c1');
+
+		expect(pb.collection).not.toHaveBeenCalled();
+		expect(setVapidDetails).not.toHaveBeenCalled();
+	});
+});
+
+// A non-empty but malformed value (VAPID_SUBJECT without a mailto:/https: scheme, a key of the
+// wrong decoded length) passes `assertRequiredEnv()`, which only checks non-emptiness — so
+// `web-push` is the first thing to reject it. Before #627 the same typo crashed the process at
+// boot; now it must degrade to "no push" instead of 500-ing a completed registration.
+// Its own block: unlike the "not configured" cases above, this one *requires* `setVapidDetails`
+// to be called (and to throw), so that block's shared premise does not hold here.
+describe('sendPushToUser — VAPID rejected by web-push', () => {
+	it('degrades instead of throwing when web-push rejects the VAPID config', async () => {
+		setVapidDetails.mockImplementation(() => {
+			throw new Error('Vapid subject is not a url or mailto url');
+		});
+		const { sendPushToUser } = await loadNotifications({
+			...FULL_VAPID,
+			VAPID_SUBJECT: 'ci@example.com',
+		});
+		const { pb } = makePb();
+
+		await expect(
+			sendPushToUser(pb, 'u1', 'Titel', 'Body', '/conversations/c1')
+		).resolves.toBeUndefined();
+		await sendPushToUser(pb, 'u2', 'Titel', 'Body', '/conversations/c2');
+
+		expect(pb.collection).not.toHaveBeenCalled();
+		expect(sendNotification).not.toHaveBeenCalled();
+		expect(consoleError).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('sendPushToUser — VAPID configured', () => {
+	it('configures web-push once across two calls and sends a notification per subscription', async () => {
+		const { sendPushToUser } = await loadNotifications(FULL_VAPID);
+		const { pb, getFullList } = makePb();
+
+		await sendPushToUser(pb, 'u1', 'Titel', 'Body', '/conversations/c1');
+		await sendPushToUser(pb, 'u1', 'Titel', 'Body', '/conversations/c1');
+
+		// Memoized: the details land in web-push's module state on the first call only.
+		expect(setVapidDetails).toHaveBeenCalledTimes(1);
+		expect(setVapidDetails).toHaveBeenCalledWith(
+			FULL_VAPID.VAPID_SUBJECT,
+			FULL_VAPID.PUBLIC_VAPID_PUBLIC_KEY,
+			FULL_VAPID.VAPID_PRIVATE_KEY
+		);
+		expect(getFullList).toHaveBeenCalledTimes(2);
+		expect(sendNotification).toHaveBeenCalledTimes(2);
+		expect(sendNotification).toHaveBeenLastCalledWith(
+			{ endpoint: SUBSCRIPTION.endpoint, keys: { p256dh: 'p', auth: 'a' } },
+			JSON.stringify({ title: 'Titel', body: 'Body', url: '/conversations/c1' })
+		);
+		expect(consoleError).not.toHaveBeenCalled();
+	});
+
+	it('drops a subscription the push service reports as gone (410)', async () => {
+		const { sendPushToUser } = await loadNotifications(FULL_VAPID);
+		const { pb, deleteRecord } = makePb();
+		sendNotification.mockRejectedValueOnce({ statusCode: 410 });
+
+		await sendPushToUser(pb, 'u1', 'Titel', 'Body', '/conversations/c1');
+
+		expect(deleteRecord).toHaveBeenCalledWith(SUBSCRIPTION.id);
+		expect(consoleError).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/server/notifications.ts
+++ b/src/lib/server/notifications.ts
@@ -1,11 +1,53 @@
 import webpush from 'web-push';
-import { VAPID_PRIVATE_KEY, VAPID_SUBJECT } from '$env/static/private';
-import { PUBLIC_VAPID_PUBLIC_KEY } from '$env/static/public';
+import { env } from '$env/dynamic/private';
+import { vapidPublicKey } from '$lib/publicEnv';
 import type { NotificationType } from '$lib/types/models.js';
 import { texts } from '$lib/texts';
 import type PocketBase from 'pocketbase';
 
-webpush.setVapidDetails(VAPID_SUBJECT, PUBLIC_VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY);
+let vapidConfigured = false;
+let vapidWarned = false;
+
+/**
+ * web-push stores the VAPID details in module state, so they only need setting once — but NOT
+ * at import time. `vite build`'s analyse pass imports every server node with an empty
+ * `$env/dynamic/private`, and `setVapidDetails` throws on an empty subject/key (issue #627).
+ * Called from `sendPushToUser` instead — by then SvelteKit has populated the dynamic env, so the
+ * read sees the value the running instance was started with.
+ * Returns false (logging once) instead of throwing — for a missing value AND for a non-empty but
+ * malformed one, which `assertRequiredEnv()` waves through because it only checks non-emptiness.
+ * A misconfiguration must not turn a lending-status change, or an invite-code registration whose
+ * user record already exists, into a 500.
+ */
+function ensureVapidConfigured(): boolean {
+	if (vapidConfigured) return true;
+	const subject = env.VAPID_SUBJECT;
+	const privateKey = env.VAPID_PRIVATE_KEY;
+	const publicKey = vapidPublicKey();
+	if (!subject || !privateKey || !publicKey) {
+		if (!vapidWarned) {
+			vapidWarned = true;
+			console.error(
+				'Web Push disabled: VAPID_SUBJECT, VAPID_PRIVATE_KEY and PUBLIC_VAPID_PUBLIC_KEY must all be set.'
+			);
+		}
+		return false;
+	}
+	try {
+		webpush.setVapidDetails(subject, publicKey, privateKey);
+	} catch (err) {
+		// Rejected by web-push: a VAPID_SUBJECT without a mailto:/https: scheme, or a key whose
+		// decoded length is wrong. Set-but-invalid passes the startup validator, so this is the
+		// only place that can catch it.
+		if (!vapidWarned) {
+			vapidWarned = true;
+			console.error('Web Push disabled: web-push rejected the VAPID configuration.', err);
+		}
+		return false;
+	}
+	vapidConfigured = true;
+	return true;
+}
 
 /** Minimum gap between new_message notifications for the same conversation (ms). */
 export const MESSAGE_NOTIFICATION_COOLDOWN_MS = 60_000; // 1 minute — adjust to taste
@@ -96,6 +138,8 @@ export async function sendPushToUser(
 	body: string,
 	url: string
 ): Promise<void> {
+	if (!ensureVapidConfigured()) return;
+
 	let subscriptions;
 	try {
 		subscriptions = await pb

--- a/src/lib/server/registration.test.ts
+++ b/src/lib/server/registration.test.ts
@@ -1,18 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import type PocketBase from 'pocketbase';
 
-// Hermetic env: registration.ts pulls in notifications.ts, whose import-time
-// `setVapidDetails` call crashes when a checkout has no .env (e.g. CI). web-push
-// validates key shapes, so the dummies must decode to 32 (private) / 65 (public) bytes.
-vi.mock('$env/static/private', () => ({
-	VAPID_PRIVATE_KEY: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-	VAPID_SUBJECT: 'mailto:test@example.com',
-}));
-vi.mock('$env/static/public', () => ({
-	PUBLIC_PB_URL: 'http://localhost:8090',
-	PUBLIC_VAPID_PUBLIC_KEY:
-		'BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-}));
+// No env mock needed since #627: notifications.ts configures web-push lazily inside
+// sendPushToUser (`ensureVapidConfigured`), so importing it no longer validates VAPID keys.
 // The inviter-relationship path fires a notification + push; stub them so the test
 // exercises only the trust-edge creation.
 vi.mock('$lib/server/notifications', () => ({

--- a/src/lib/server/superuser.ts
+++ b/src/lib/server/superuser.ts
@@ -1,6 +1,6 @@
 import PocketBase from 'pocketbase';
-import { PUBLIC_PB_URL } from '$env/static/public';
-import { PB_SUPERUSER_EMAIL, PB_SUPERUSER_PASSWORD } from '$env/static/private';
+import { pbUrl } from '$lib/publicEnv';
+import { env } from '$env/dynamic/private';
 
 let cachedSuperuserClient: PocketBase | null = null;
 
@@ -12,8 +12,13 @@ let cachedSuperuserClient: PocketBase | null = null;
  * layer down; it is a general-purpose helper, not integration-specific, and `$lib/server/metrics.ts`
  * still needs it to read the superuser-only `metrics_daily` collection.
  *
- * Server-only: it reads `PB_SUPERUSER_*` from `$env/static/private`. Never import it from a
- * `.svelte` component or any module reachable by the client bundle.
+ * Server-only: it reads `PB_SUPERUSER_*` from `$env/dynamic/private` (at call time, since #627).
+ * Never import it from a `.svelte` component or any module reachable by the client bundle.
+ *
+ * This is a **per-request runtime dependency**, not just tooling: the root `+layout.server.ts`
+ * calls `isAdmin()` (via `$lib/server/metrics.ts`) on every authenticated request, so without
+ * the two vars the `/admin` gate closes and the public stats disappear. Both are therefore in
+ * `REQUIRED_PRIVATE_ENV` (`$lib/server/env.ts`) and validated at server start.
  *
  * @returns An authenticated `PocketBase` instance valid for superuser operations.
  */
@@ -22,10 +27,18 @@ export async function getSuperuserClient(): Promise<PocketBase> {
 		return cachedSuperuserClient;
 	}
 
-	const newSuperuserClient = new PocketBase(PUBLIC_PB_URL);
-	await newSuperuserClient
-		.collection('_superusers')
-		.authWithPassword(PB_SUPERUSER_EMAIL, PB_SUPERUSER_PASSWORD);
+	const email = env.PB_SUPERUSER_EMAIL;
+	const password = env.PB_SUPERUSER_PASSWORD;
+	// Same shape as scripts/seed/lib.js. Every caller already treats a rejection as "no
+	// superuser access" (metrics.ts logs and degrades), so rejecting is the honest signal.
+	if (!email || !password) {
+		throw new Error(
+			'PB_SUPERUSER_EMAIL and PB_SUPERUSER_PASSWORD must be set to use the PocketBase superuser client.'
+		);
+	}
+
+	const newSuperuserClient = new PocketBase(pbUrl());
+	await newSuperuserClient.collection('_superusers').authWithPassword(email, password);
 	cachedSuperuserClient = newSuperuserClient;
 	return newSuperuserClient;
 }

--- a/src/lib/utils/pushSubscription.test.ts
+++ b/src/lib/utils/pushSubscription.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-// pushSubscription.ts reads the VAPID public key from here at import time.
-vi.mock('$env/static/public', () => ({ PUBLIC_VAPID_PUBLIC_KEY: 'dGVzdA' }));
+// pushSubscription.ts reads the VAPID public key from here (via $lib/publicEnv's
+// vapidPublicKey()) at call time.
+vi.mock('$env/dynamic/public', () => ({ env: { PUBLIC_VAPID_PUBLIC_KEY: 'dGVzdA' } }));
 
 import { teardownPushSubscription, nextPushRegistration } from './pushSubscription';
 

--- a/src/lib/utils/pushSubscription.ts
+++ b/src/lib/utils/pushSubscription.ts
@@ -1,4 +1,4 @@
-import { PUBLIC_VAPID_PUBLIC_KEY } from '$env/static/public';
+import { vapidPublicKey } from '$lib/publicEnv';
 
 /** Convert a base64url VAPID public key to a Uint8Array for the Web Push API. */
 function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
@@ -77,7 +77,7 @@ export async function setupPushSubscription(): Promise<void> {
 			existing ??
 			(await registration.pushManager.subscribe({
 				userVisibleOnly: true,
-				applicationServerKey: urlBase64ToUint8Array(PUBLIC_VAPID_PUBLIC_KEY),
+				applicationServerKey: urlBase64ToUint8Array(vapidPublicKey()),
 			}));
 
 		const { endpoint, keys } = subscription.toJSON() as {

--- a/src/routes/api/analyze-item/+server.ts
+++ b/src/routes/api/analyze-item/+server.ts
@@ -1,9 +1,15 @@
 import { json, error } from '@sveltejs/kit';
-import { MISTRAL_API_KEY } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 import { Mistral } from '@mistralai/mistralai';
 import { ITEM_CATEGORIES } from '$lib/categories';
 
-const client = new Mistral({ apiKey: MISTRAL_API_KEY });
+let client: Mistral | null = null;
+/** Lazy: `$env/dynamic/private` is empty while `vite build` analyses this endpoint module. */
+function getClient(): Mistral | null {
+	if (!env.MISTRAL_API_KEY) return null;
+	return (client ??= new Mistral({ apiKey: env.MISTRAL_API_KEY }));
+}
+
 const imageRecognitionPrompt = `Du bist ein Assistent für eine offene Verleih-Plattform. Analysiere das Bild und erkenne den dargestellten Gegenstand. Antworte NUR mit einem JSON-Objekt ohne Markdown-Formatierung in der folgenden Form:
 	{
 	"name": "Kurzname auf Deutsch (max. 50 Zeichen)",
@@ -19,7 +25,7 @@ const WINDOW_MS = 60 * 60 * 1000; // 1 hour
 const rateLimits = new Map<string, { count: number; resetAt: number }>();
 
 export async function POST({ request, locals }) {
-	if (!locals.user) error(401, 'Unauthorized');
+	if (!locals.user) throw error(401, 'Unauthorized');
 	const userId = locals.user.id;
 	const now = Date.now();
 	const entry = rateLimits.get(userId);
@@ -32,11 +38,16 @@ export async function POST({ request, locals }) {
 		entry.count++;
 	}
 
+	const mistral = getClient();
+	// MISTRAL_API_KEY is the one optional var (see $lib/server/env.ts). Unset ⇒ the feature is
+	// off; say so with a 503 instead of letting an unauthenticated SDK call surface as a 500.
+	if (!mistral) throw error(503, 'AI item analysis is not configured on this instance.');
+
 	const { imageBase64, mimeType } = await request.json();
 	if (!imageBase64 || !mimeType) throw error(400, 'Missing image data');
 
 	const model = 'pixtral-12b-2409';
-	const response = await client.chat.complete({
+	const response = await mistral.chat.complete({
 		model: model,
 		messages: [
 			{

--- a/src/routes/api/analyze-item/server.test.ts
+++ b/src/routes/api/analyze-item/server.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// MISTRAL_API_KEY is the one optional var (see $lib/server/env.ts). Unset ⇒ the endpoint must
+// answer 503 instead of constructing an unauthenticated Mistral client (issue #627).
+vi.mock('$env/dynamic/private', () => ({ env: {} }));
+
+const { complete } = vi.hoisted(() => ({ complete: vi.fn() }));
+vi.mock('@mistralai/mistralai', () => ({
+	Mistral: class {
+		chat = { complete };
+	},
+}));
+
+import { POST } from './+server';
+
+type ThrownError = { status: number; body?: { message: string } };
+
+async function capture(fn: () => unknown): Promise<ThrownError> {
+	try {
+		await fn();
+	} catch (e) {
+		return e as ThrownError;
+	}
+	throw new Error('expected a thrown error, but none was thrown');
+}
+
+function makeEvent(userId: string | null) {
+	const json = vi
+		.fn()
+		.mockResolvedValue({ imageBase64: 'x', mimeType: 'image/png' });
+	return {
+		request: { json },
+		locals: { user: userId ? { id: userId } : null },
+		json,
+	};
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('POST /api/analyze-item', () => {
+	it('answers 503 when MISTRAL_API_KEY is unset', async () => {
+		const event = makeEvent('user-503');
+		const result = await capture(() => POST(event as never));
+
+		expect(result.status).toBe(503);
+		expect(result.body?.message).toContain('not configured');
+		expect(complete).not.toHaveBeenCalled();
+	});
+
+	it('refuses the feature before reading the request body', async () => {
+		const event = makeEvent('user-order');
+		await capture(() => POST(event as never));
+
+		expect(event.json).not.toHaveBeenCalled();
+	});
+
+	it('still rejects an unauthenticated caller with 401', async () => {
+		const event = makeEvent(null);
+		const result = await capture(() => POST(event as never));
+
+		expect(result.status).toBe(401);
+	});
+});

--- a/src/routes/api/geocode/+server.ts
+++ b/src/routes/api/geocode/+server.ts
@@ -1,5 +1,5 @@
 import { json } from '@sveltejs/kit';
-import { ORS_API_KEY } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 
 export async function GET({ url }) {
 	const q = url.searchParams.get('q') ?? '';
@@ -10,7 +10,7 @@ export async function GET({ url }) {
 
 	try {
 		const params = new URLSearchParams({
-			api_key: ORS_API_KEY ?? '',
+			api_key: env.ORS_API_KEY ?? '',
 			text: q,
 			lang: 'de',
 			size: '5',

--- a/src/routes/auth/register/+page.svelte
+++ b/src/routes/auth/register/+page.svelte
@@ -8,7 +8,7 @@
 	import CustomAlert from '$lib/components/CustomAlert.svelte';
 	import debounce from 'debounce';
 	import PocketBase from 'pocketbase';
-	import { PUBLIC_PB_URL } from '$env/static/public';
+	import { pbUrl } from '$lib/publicEnv';
 	import LegalDocModal from '$lib/components/LegalDocModal.svelte';
 	import SeoHead from '$lib/components/SeoHead.svelte';
 	import { USERNAME_MAX_LENGTH, normalizeUsername, validateUsername } from '$lib/utils/username';
@@ -21,7 +21,7 @@
 	let openTos = $state(false);
 	let openPrivacy = $state(false);
 
-	const pb = new PocketBase(PUBLIC_PB_URL);
+	const pb = new PocketBase(pbUrl());
 
 	let username = $state('');
 	let usernameStatus: 'idle' | 'checking' | 'available' | 'taken' | 'too_short' | 'too_long' | 'invalid' =

--- a/src/routes/conversations/+layout.server.ts
+++ b/src/routes/conversations/+layout.server.ts
@@ -1,6 +1,6 @@
 import type { Conversation } from '$lib/types/models.js';
 import { error } from '@sveltejs/kit';
-import { PUBLIC_PB_URL } from '$env/static/public';
+import { pbUrl } from '$lib/publicEnv';
 import { conversationFieldsWithSafePartners } from '$lib/server/conversations.js';
 
 export async function load({ locals }) {
@@ -32,6 +32,6 @@ export async function load({ locals }) {
 	// return data to the page
 	return {
 		conversations: allConversations,
-		PB_IMG_URL: PUBLIC_PB_URL,
+		PB_IMG_URL: pbUrl(),
 	};
 }

--- a/src/routes/conversations/[conversationId]/ConversationHeader.svelte
+++ b/src/routes/conversations/[conversationId]/ConversationHeader.svelte
@@ -2,7 +2,7 @@
 	import { texts } from '$lib/texts';
 	import { itemStatusBadgeClasses, itemStatusLabel } from '$lib/utils/itemStatus';
 	import { formatTimestamp, displayName, itemOwnFileUrls, buildItemRedirectHref } from '$lib/utils/utils';
-	import { PUBLIC_PB_URL } from '$env/static/public';
+	import { pbUrl } from '$lib/publicEnv';
 	import { TrashBinSolid, ChevronLeftOutline } from 'flowbite-svelte-icons';
 	import { Tooltip } from 'flowbite-svelte';
 	import { enhance } from '$app/forms';
@@ -43,10 +43,10 @@
 	const itemName = $derived(item?.name ?? texts.ui.itemUnavailable);
 	const itemRedirectItemId = $derived(item?.id ?? '');
 
-	const requestedItemCoverUrl = $derived(item ? (itemOwnFileUrls(PUBLIC_PB_URL, item)[0] ?? null) : null);
+	const requestedItemCoverUrl = $derived(item ? (itemOwnFileUrls(pbUrl(), item)[0] ?? null) : null);
 
 	const chatPartnerAvatarUrl = $derived(
-		chatPartner.profileImage ? `${PUBLIC_PB_URL}api/files/users/${chatPartner.id}/${chatPartner.profileImage}` : null
+		chatPartner.profileImage ? `${pbUrl()}api/files/users/${chatPartner.id}/${chatPartner.profileImage}` : null
 	);
 </script>
 

--- a/src/routes/conversations/[conversationId]/conversationRealtime.test.ts
+++ b/src/routes/conversations/[conversationId]/conversationRealtime.test.ts
@@ -4,7 +4,7 @@ import type { Conversation, Message } from '$lib/types/models';
 import { makeMockPb } from '$lib/test-utils/pocketbase';
 
 // Capture the options passed to subscribeRealtime so tests can fire synthetic
-// events at the registered handler. The real client-pb pulls in $env/static/public
+// events at the registered handler. The real client-pb pulls in $env/dynamic/public
 // and opens an EventSource — neither is wanted here, so the whole module is mocked.
 const { subscribeRealtime, unsubscribe } = vi.hoisted(() => ({
 	subscribeRealtime: vi.fn(),

--- a/src/routes/items/[id]/+page.server.ts
+++ b/src/routes/items/[id]/+page.server.ts
@@ -1,4 +1,4 @@
-import { PUBLIC_PB_URL } from '../../../hooks.server';
+import { pbUrl } from '$lib/publicEnv';
 import { error, fail, redirect } from '@sveltejs/kit';
 import type { ItemPublic, UnmetRequirement } from '$lib/types/models';
 import type { ClientResponseError } from 'pocketbase';
@@ -121,7 +121,7 @@ export async function load({ params, locals }) {
 
 	return {
 		item,
-		PB_IMG_URL: PUBLIC_PB_URL,
+		PB_IMG_URL: pbUrl(),
 		currentUserId,
 		isAuthenticated,
 		isTrustRestricted,

--- a/src/routes/items/[id]/page.server.test.ts
+++ b/src/routes/items/[id]/page.server.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// hooks.server.ts (re-exported by +page.server) reads PUBLIC_PB_URL from here.
-vi.mock('$env/static/public', () => ({
-	PUBLIC_PB_URL: 'http://localhost/',
-	PUBLIC_VAPID_PUBLIC_KEY: 'x',
+// +page.server's load returns PB_IMG_URL from $lib/publicEnv's pbUrl(), which reads here.
+vi.mock('$env/dynamic/public', () => ({
+	env: { PUBLIC_PB_URL: 'http://localhost/', PUBLIC_VAPID_PUBLIC_KEY: 'x' },
 }));
-// Avoid loading web-push + VAPID env at import time.
+// No env mock needed since #627: notifications.ts configures web-push lazily inside
+// sendPushToUser (`ensureVapidConfigured`), so importing it no longer validates VAPID keys.
+// Stubbed only to keep this test focused on the load/actions logic.
 vi.mock('$lib/server/notifications.js', () => ({
 	createNotification: vi.fn(),
 	sendPushToUser: vi.fn(),

--- a/src/routes/onboarding/+page.server.ts
+++ b/src/routes/onboarding/+page.server.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { fail } from '@sveltejs/kit';
 import { texts } from '$lib/texts';
-import { PUBLIC_PB_URL } from '../../hooks.server';
+import { pbUrl } from '$lib/publicEnv';
 import type { User } from '$lib/types/models';
 import { addTrustAndNotify, removeTrust, getTrustees } from '$lib/server/trust';
 import { generateInviteSlug } from '$lib/inviteSlug';
@@ -29,7 +29,7 @@ export async function load({ locals, url }) {
 	const trustIds = (await getTrustees(locals.pb, locals.user.id)).map((t) => t.trustee);
 
 	return {
-		PB_URL: PUBLIC_PB_URL,
+		PB_URL: pbUrl(),
 		inviteUrl: `${url.origin}/invite/${inviteCode}`,
 		username: locals.user.username as string,
 		users,

--- a/src/routes/search/+page.server.ts
+++ b/src/routes/search/+page.server.ts
@@ -1,4 +1,4 @@
-import { PUBLIC_PB_URL } from '../../hooks.server';
+import { pbUrl } from '$lib/publicEnv';
 import type { ItemPublic } from '$lib/types/models';
 import { parseSearchParameters, buildItemFilter, sortToPbSort, type SearchParameters } from './searchFilter';
 import type { ListResult } from 'pocketbase';
@@ -59,7 +59,7 @@ export async function load({ locals, url }) {
 
 	return {
 		items: result.items,
-		PB_IMG_URL: PUBLIC_PB_URL,
+		PB_IMG_URL: pbUrl(),
 		q: searchParameters.query,
 		selectedCategories: searchParameters.selectedCategories,
 		op: searchParameters.op,

--- a/src/routes/search/page.server.test.ts
+++ b/src/routes/search/page.server.test.ts
@@ -5,8 +5,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // without a real PocketBase.
 const { getAttachableGroupsMock } = vi.hoisted(() => ({ getAttachableGroupsMock: vi.fn() }));
 vi.mock('$lib/server/groups', () => ({ getAttachableGroups: getAttachableGroupsMock }));
-// +page.server re-exports PUBLIC_PB_URL from hooks.server, which reads it from $env at import.
-vi.mock('$env/static/public', () => ({ PUBLIC_PB_URL: 'http://localhost', PUBLIC_VAPID_PUBLIC_KEY: 'x' }));
+// +page.server's load returns PB_IMG_URL from $lib/publicEnv's pbUrl(), which reads here.
+vi.mock('$env/dynamic/public', () => ({
+	env: { PUBLIC_PB_URL: 'http://localhost', PUBLIC_VAPID_PUBLIC_KEY: 'x' },
+}));
 
 import { load } from './+page.server';
 

--- a/src/routes/social/page.server.test.ts
+++ b/src/routes/social/page.server.test.ts
@@ -1,16 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 
-// social/+page.server imports notifications.ts (web-push), which validates VAPID key
-// shapes at import time — provide decodable dummies.
-vi.mock('$env/static/private', () => ({
-	VAPID_PRIVATE_KEY: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-	VAPID_SUBJECT: 'mailto:test@example.com',
-}));
-vi.mock('$env/static/public', () => ({
-	PUBLIC_PB_URL: 'http://localhost:8090',
-	PUBLIC_VAPID_PUBLIC_KEY:
-		'BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-}));
+// No env mock needed since #627: social/+page.server still imports notifications.ts, but
+// web-push is configured lazily inside sendPushToUser, so the import validates nothing.
 
 import { load } from './+page.server';
 

--- a/src/routes/user/groups/[id]/+page.server.ts
+++ b/src/routes/user/groups/[id]/+page.server.ts
@@ -1,4 +1,4 @@
-import { PUBLIC_PB_URL } from '$env/static/public';
+import { pbUrl } from '$lib/publicEnv';
 import { requireGroupMembership } from '$lib/server/groups';
 import type { ItemPublic } from '$lib/types/models';
 
@@ -32,6 +32,6 @@ export async function load({ locals, params }) {
 		},
 		isOwner,
 		items,
-		PB_IMG_URL: PUBLIC_PB_URL,
+		PB_IMG_URL: pbUrl(),
 	};
 }

--- a/src/routes/user/groups/[id]/page.server.test.ts
+++ b/src/routes/user/groups/[id]/page.server.test.ts
@@ -1,4 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The load returns PB_IMG_URL from $lib/publicEnv's pbUrl(). Mocked so the assertion below
+// pins an exact value instead of depending on the runner's env (issue #627 removed the
+// PUBLIC_PB_URL injection that vitest.yaml used to do for exactly this test).
+vi.mock('$env/dynamic/public', () => ({ env: { PUBLIC_PB_URL: 'http://localhost/' } }));
+
 import { load } from './+page.server';
 import { ME, params, makeLocals } from './groupTestHelpers';
 
@@ -34,7 +40,7 @@ describe('group overview — load', () => {
 
 		expect(res.items).toEqual(groupItems);
 		expect(res.isOwner).toBe(true);
-		expect(res.PB_IMG_URL).toBeTruthy();
+		expect(res.PB_IMG_URL).toBe('http://localhost/');
 		// Filter is built with pb.filter (injection-safe), scoped to this group.
 		expect(locals.pb.filter).toHaveBeenCalledWith('groups ~ {:gid}', { gid: 'g1' });
 		// The query must not return the `groups` column (would leak an item's other groups).

--- a/src/routes/user/items/+page.server.ts
+++ b/src/routes/user/items/+page.server.ts
@@ -1,5 +1,5 @@
 import { fail } from '@sveltejs/kit';
-import { PUBLIC_PB_URL } from '../../../hooks.server';
+import { pbUrl } from '$lib/publicEnv';
 import { texts } from '$lib/texts';
 import { failFromPbError } from '$lib/server/pbErrors';
 import type { Item } from '$lib/types/models';
@@ -50,7 +50,7 @@ export async function load({ locals, url }) {
 		perPage,
 		search,
 		statusFilter,
-		PB_URL: PUBLIC_PB_URL,
+		PB_URL: pbUrl(),
 	};
 }
 

--- a/src/routes/user/items/page.server.test.ts
+++ b/src/routes/user/items/page.server.test.ts
@@ -17,8 +17,10 @@ vi.mock('$lib/server/items', () => ({
 }));
 // sanitizeGroups() calls getAttachableGroups; mock it so the group-filtering wiring is testable.
 vi.mock('$lib/server/groups', () => ({ getAttachableGroups: getAttachableGroupsMock }));
-// hooks.server.ts (re-exported by +page.server) reads PUBLIC_PB_URL from here.
-vi.mock('$env/static/public', () => ({ PUBLIC_PB_URL: 'http://localhost', PUBLIC_VAPID_PUBLIC_KEY: 'x' }));
+// +page.server's load returns PB_URL from $lib/publicEnv's pbUrl(), which reads here.
+vi.mock('$env/dynamic/public', () => ({
+	env: { PUBLIC_PB_URL: 'http://localhost', PUBLIC_VAPID_PUBLIC_KEY: 'x' },
+}));
 
 import { actions } from './+page.server';
 import { texts } from '$lib/texts';

--- a/src/routes/user/profile/+page.server.ts
+++ b/src/routes/user/profile/+page.server.ts
@@ -1,4 +1,4 @@
-import { PUBLIC_PB_URL } from '../../../hooks.server';
+import { pbUrl } from '$lib/publicEnv';
 import { texts } from '$lib/texts';
 import { generateInviteSlug } from '$lib/inviteSlug';
 import { upsertUserGeolocation } from '$lib/server/geolocation';
@@ -43,7 +43,7 @@ export async function load({ locals, url }) {
 	);
 
 	return {
-		PB_URL: PUBLIC_PB_URL,
+		PB_URL: pbUrl(),
 		inviteUrl,
 		currentUser,
 		currentUserPreferences,

--- a/src/routes/user/profile/page.server.test.ts
+++ b/src/routes/user/profile/page.server.test.ts
@@ -2,10 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { texts } from '$lib/texts';
 import { USERNAME_MAX_LENGTH } from '$lib/utils/username';
 
-// hooks.server.ts (reached via +page.server's import chain) reads these.
-vi.mock('$env/static/public', () => ({
-	PUBLIC_PB_URL: 'http://localhost/',
-	PUBLIC_VAPID_PUBLIC_KEY: 'x',
+// +page.server's load returns PB_URL from $lib/publicEnv's pbUrl(), which reads here.
+vi.mock('$env/dynamic/public', () => ({
+	env: { PUBLIC_PB_URL: 'http://localhost/', PUBLIC_VAPID_PUBLIC_KEY: 'x' },
 }));
 // Stub the server helpers saveProfile delegates to, so the tests exercise the
 // action's own logic (validation, field parsing, folded-in requirement save).

--- a/src/routes/users/[id]/+page.server.ts
+++ b/src/routes/users/[id]/+page.server.ts
@@ -1,5 +1,5 @@
 import { error, fail } from '@sveltejs/kit';
-import { PUBLIC_PB_URL } from '$env/static/public';
+import { pbUrl } from '$lib/publicEnv';
 import type { Item, User } from '$lib/types/models.js';
 import type { ClientResponseError } from 'pocketbase';
 import { texts } from '$lib/texts';
@@ -36,7 +36,7 @@ export async function load({ params, locals }) {
 			loggedIn: !!locals.user,
 			viewerTrustsProfile: false,
 			profileTrustsViewer: false,
-			PB_IMG_URL: PUBLIC_PB_URL,
+			PB_IMG_URL: pbUrl(),
 		};
 	}
 
@@ -123,7 +123,7 @@ export async function load({ params, locals }) {
 		loggedIn: !!currentUser,
 		viewerTrustsProfile,
 		profileTrustsViewer,
-		PB_IMG_URL: PUBLIC_PB_URL,
+		PB_IMG_URL: pbUrl(),
 	};
 }
 


### PR DESCRIPTION
Closes #627.

## What & why

Vite inlined eight variables into the build artifact at `vite build` time, so every instance needed its own build and whoever built an image baked *their* secrets (VAPID private key, ORS key, superuser credentials) into the distributed layers. Everything is now read at runtime from `process.env`, so **one artifact serves any instance** — the prerequisite for the frontend Docker image (#628).

`$lib/instance.ts` already worked this way (the deliberate exception from #473/#597). This generalises that decision and makes `$env/static/*` a lint error.

### New modules
- **`$lib/publicEnv.ts`** — `pbUrl()` / `vapidPublicKey()`, call-time reads from `$env/dynamic/public`. Functions rather than constants so nothing is snapshotted at import time. `pbUrl()` **normalises the trailing slash**: every file URL is built by concatenation (`${pbUrl()}api/files/…`), so a slash-less value would silently break every image on the site. This is not hypothetical — a local `.env` in the wild already had it without the slash.
- **`$lib/server/env.ts`** — the required-variable registry plus a validator called from the `init` server hook. A missing **or empty** value aborts the boot naming every offender and what it does. `adapter-node` awaits `server.init()` before `listen()`, so this exits non-zero rather than serving a half-working site. Previously a missing var either degraded silently (no admin gate, no public stats, no push) or 500'd on first use.

### Notable call-site changes
- `hooks.server.ts` no longer re-exports `PUBLIC_PB_URL`. That re-export was not in the issue's list and pulled in five more route files — a property read on the env object cannot be re-exported as a binding. 17 files changed for the env read, not 8.
- `notifications.ts` and `analyze-item/+server.ts` construct **lazily**. Both previously ran at module scope, and `vite build`'s analyse pass imports every server module with an empty env — `webpush.setVapidDetails` throws on an empty subject, which made an env-less build impossible. `setVapidDetails` failures now degrade with a single log line instead of throwing mid-request (a malformed `VAPID_SUBJECT` used to 500 an invite registration *after* the user record was created).
- `MISTRAL_API_KEY` stays the only optional var and answers **503** when unset; startup logs optional gaps once.

### Deploy workflow
Secrets leave the build step (where they only ever reached `$env/static/*`) and are written into the server-side `.env`, with two safety fixes found in review:
- **`umask 077`** — that file now holds the superuser password and the VAPID private key on a shared host; it previously held only `BODY_SIZE_LIMIT` and two public analytics values. Partially delivers the `.env` file-permission task in #634.
- **written before `npm ci`** — with `set -e` plus the preceding `rsync --delete`, a failed `npm ci` would otherwise leave the host with no `.env` at all, and the next restart would refuse to boot.

`BODY_SIZE_LIMIT` remains the one runtime-required var the validator cannot see (it is an adapter var, not an app var) — it is in the `.env` block and called out in the comment.

⚠️ **#649 will need this ported.** This PR reworks four GitHub Actions workflows, the deploy one substantially. Not a blocker, but the migration to Codeberg Woodpecker has to carry the runtime-`.env` mechanism over, not just the build step.

### Also in scope
ESLint bans both `$env/static/*` modules repo-wide and bans page-global imports (`$env/dynamic/public`, `$lib/publicEnv`, `$lib/instance`, `$lib/texts`) inside `src/service-worker.ts`. Docs, README, `.env.example` and the `new-route` skill follow — that skill taught the old pattern, so every new route would have reintroduced it.

**Doc bug fixed on the way:** `.env.example` and `docs/architecture.md` claimed `PB_SUPERUSER_*` were "used only by local seed/e2e tooling, not the app runtime". False — `src/routes/+layout.server.ts` calls `isAdmin()` → `getSuperuserClient()` on **every authenticated request**.

## Operator notes

- **New optional repo *Variables*:** `PUBLIC_SITE_ORIGIN`, `PUBLIC_INSTANCE_CITY`. Both are optional by construction — the deploy omits the line entirely when unset, so the `$lib/instance.ts` defaults still apply. Nothing has to be created. All nine Secrets already exist; their values only move from the build step to the SSH step.
- **The first deploy after merge lands on the new path.** If a secret is missing there, the service now **refuses to start** instead of degrading silently. That is the intent, but the first deploy deserves a look at the supervisord log.
- `.env.example` now ships non-empty placeholders, including the throwaway VAPID keypair that is already public in `.github/workflows/e2e.yaml`, so `cp .env.example .env && npm run dev` boots a fresh clone. The validator checks **presence, not validity** — a placeholder `ORS_API_KEY` satisfies it. This is stated in the README table and `.env.example`.

## Test notes

Preflight, all green: `npm run lint` · `npm run check` (0 errors, 8 pre-existing `state_referenced_locally` warnings in untouched files) · `npx vitest run` (**82 files / 875 tests**) · `npm run build`.

Playwright: **59 specs green**, no startup failure — the new `init` hook gets everything it needs under `vite dev` from `playwright.config.ts` + the workflow env.

Beyond the suites, verified in a real browser:
- **One artifact, two configs** — a single `build/` (identical checksum) run simultaneously as two cities on two ports. Title, canonical and `og:image` correct per instance, cross-leak 0× in both directions. The `.env` PocketBase URL, the `.env` VAPID key and the **values** of `ORS_API_KEY` / `MISTRAL_API_KEY` appear **0×** in `build/`, despite a populated `.env` at build time (checked with a positive control so the scanner cannot pass blindly).
- **Images survive both spellings** of `PUBLIC_PB_URL` — with and without the trailing slash, no `…8091api/files/…` and no `…8091//api/…`.
- **The public env reaches the client** — the username-availability check on `/auth/register` calls the *runtime* PocketBase URL, not the build-time one; the push toggle receives an `applicationServerKey` that decodes to the runtime VAPID key.
- **Fail-fast** in four variants, each exiting non-zero with no HTTP listener, including `KEY=` set-but-empty. No secret **value** appears in startup output.
- **`/misc/stats` renders** with real numbers and no `isAdmin check failed` in any instance log, i.e. the superuser client authenticates with the runtime credentials.

Not verified, environment limits rather than code doubts: the geocoding success path (no real ORS key locally — but a *non-empty* key demonstrably goes out, since ORS answers 401 on empty and 403 on invalid, and we got 403), a real push subscribe (no permission grant), and `/admin/metrics` with an admin session (no admin user in the local DB).

## Reviewer notes

Two review rounds by four roles; 0 blocking. 27 findings fixed, one rejected with evidence: the 503 message stays inline English rather than moving to `texts.ts` — the cited precedent (`error(500, 'export_failed')`) is not a `texts.ts` key, and the sole caller discards the response body, so the string is operator-facing only.

One reviewer suggestion was **reverted deliberately**: folding `envs:` into a multi-line block relies on the SSH action trimming each element. `origin/main` has always used the space-free single-line form, so that behaviour is unproven in this pipeline — and if it did not trim, 11 of 12 names would resolve to empty and the freshly deployed site would refuse to boot. It stays flat, with a comment saying why.

Note this branch also touches `.claude/CLAUDE.md`, which #650 and #621 also modify — expect a small conflict there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
